### PR TITLE
Improve handling of name collisions between parameters and top-level body fields

### DIFF
--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -614,13 +614,13 @@ impl Generator {
 
         let scalar = prop_type.has_impl(TypeSpaceImpl::FromStr);
 
-        if scalar {
+        let prop_name = name.to_kebab_case();
+        if scalar && !args.has_arg(&prop_name) {
             let volitionality = if required {
                 Volitionality::RequiredIfNoBody
             } else {
                 Volitionality::Optional
             };
-            let prop_name = name.to_kebab_case();
             let parser = clap_arg(
                 &prop_name,
                 volitionality,

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -1,0 +1,303 @@
+#[allow(unused_imports)]
+use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
+/// Types used as operation parameters and responses.
+#[allow(clippy::all)]
+pub mod types {
+    /// Error types.
+    pub mod error {
+        /// Error from a TryFrom or FromStr implementation.
+        pub struct ConversionError(::std::borrow::Cow<'static, str>);
+        impl ::std::error::Error for ConversionError {}
+        impl ::std::fmt::Display for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl ::std::fmt::Debug for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+
+        impl From<&'static str> for ConversionError {
+            fn from(value: &'static str) -> Self {
+                Self(value.into())
+            }
+        }
+
+        impl From<String> for ConversionError {
+            fn from(value: String) -> Self {
+                Self(value.into())
+            }
+        }
+    }
+
+    ///UnoBody
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "required"
+    ///  ],
+    ///  "properties": {
+    ///    "gateway": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    pub struct UnoBody {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub gateway: Option<String>,
+        pub required: ::serde_json::Value,
+    }
+
+    impl From<&UnoBody> for UnoBody {
+        fn from(value: &UnoBody) -> Self {
+            value.clone()
+        }
+    }
+
+    impl UnoBody {
+        pub fn builder() -> builder::UnoBody {
+            Default::default()
+        }
+    }
+
+    /// Types for composing complex structures.
+    pub mod builder {
+        #[derive(Clone, Debug)]
+        pub struct UnoBody {
+            gateway: Result<Option<String>, String>,
+            required: Result<::serde_json::Value, String>,
+        }
+
+        impl Default for UnoBody {
+            fn default() -> Self {
+                Self {
+                    gateway: Ok(Default::default()),
+                    required: Err("no value supplied for required".to_string()),
+                }
+            }
+        }
+
+        impl UnoBody {
+            pub fn gateway<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.gateway = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for gateway: {}", e));
+                self
+            }
+            pub fn required<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<::serde_json::Value>,
+                T::Error: std::fmt::Display,
+            {
+                self.required = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for required: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<UnoBody> for super::UnoBody {
+            type Error = super::error::ConversionError;
+            fn try_from(value: UnoBody) -> Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    gateway: value.gateway?,
+                    required: value.required?,
+                })
+            }
+        }
+
+        impl From<super::UnoBody> for UnoBody {
+            fn from(value: super::UnoBody) -> Self {
+                Self {
+                    gateway: Ok(value.gateway),
+                    required: Ok(value.required),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+///Client for CLI gen test
+///
+///Test case to exercise CLI generation
+///
+///Version: 9000
+pub struct Client {
+    pub(crate) baseurl: String,
+    pub(crate) client: reqwest::Client,
+}
+
+impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new(baseurl: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
+    }
+
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+
+    /// Get the base URL to which requests are made.
+    pub fn baseurl(&self) -> &String {
+        &self.baseurl
+    }
+
+    /// Get the internal `reqwest::Client` used to make requests.
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Get the version of this API.
+    ///
+    /// This string is pulled directly from the source OpenAPI
+    /// document and may be in any format the API selects.
+    pub fn api_version(&self) -> &'static str {
+        "9000"
+    }
+}
+
+impl Client {
+    ///Sends a `GET` request to `/uno`
+    ///
+    ///```ignore
+    /// let response = client.uno()
+    ///    .gateway(gateway)
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn uno(&self) -> builder::Uno {
+        builder::Uno::new(self)
+    }
+}
+
+/// Types for composing operation parameters.
+#[allow(clippy::all)]
+pub mod builder {
+    use super::types;
+    #[allow(unused_imports)]
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
+    ///Builder for [`Client::uno`]
+    ///
+    ///[`Client::uno`]: super::Client::uno
+    #[derive(Debug, Clone)]
+    pub struct Uno<'a> {
+        client: &'a super::Client,
+        gateway: Result<String, String>,
+        body: Result<types::builder::UnoBody, String>,
+    }
+
+    impl<'a> Uno<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                gateway: Err("gateway was not initialized".to_string()),
+                body: Ok(types::builder::UnoBody::default()),
+            }
+        }
+
+        pub fn gateway<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.gateway = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for gateway failed".to_string());
+            self
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::UnoBody>,
+            <V as std::convert::TryInto<types::UnoBody>>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| format!("conversion to `UnoBody` for body failed: {}", s));
+            self
+        }
+
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(types::builder::UnoBody) -> types::builder::UnoBody,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+
+        ///Sends a `GET` request to `/uno`
+        pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
+            let Self {
+                client,
+                gateway,
+                body,
+            } = self;
+            let gateway = gateway.map_err(Error::InvalidRequest)?;
+            let body = body
+                .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/uno", client.baseurl,);
+            let mut query = Vec::with_capacity(1usize);
+            query.push(("gateway", gateway.to_string()));
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).json(&body).query(&query).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+}
+
+/// Items consumers will typically use such as the Client.
+pub mod prelude {
+    pub use self::super::Client;
+}

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -1,0 +1,303 @@
+#[allow(unused_imports)]
+use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
+/// Types used as operation parameters and responses.
+#[allow(clippy::all)]
+pub mod types {
+    /// Error types.
+    pub mod error {
+        /// Error from a TryFrom or FromStr implementation.
+        pub struct ConversionError(::std::borrow::Cow<'static, str>);
+        impl ::std::error::Error for ConversionError {}
+        impl ::std::fmt::Display for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl ::std::fmt::Debug for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+
+        impl From<&'static str> for ConversionError {
+            fn from(value: &'static str) -> Self {
+                Self(value.into())
+            }
+        }
+
+        impl From<String> for ConversionError {
+            fn from(value: String) -> Self {
+                Self(value.into())
+            }
+        }
+    }
+
+    ///UnoBody
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "required"
+    ///  ],
+    ///  "properties": {
+    ///    "gateway": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    pub struct UnoBody {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub gateway: Option<String>,
+        pub required: ::serde_json::Value,
+    }
+
+    impl From<&UnoBody> for UnoBody {
+        fn from(value: &UnoBody) -> Self {
+            value.clone()
+        }
+    }
+
+    impl UnoBody {
+        pub fn builder() -> builder::UnoBody {
+            Default::default()
+        }
+    }
+
+    /// Types for composing complex structures.
+    pub mod builder {
+        #[derive(Clone, Debug)]
+        pub struct UnoBody {
+            gateway: Result<Option<String>, String>,
+            required: Result<::serde_json::Value, String>,
+        }
+
+        impl Default for UnoBody {
+            fn default() -> Self {
+                Self {
+                    gateway: Ok(Default::default()),
+                    required: Err("no value supplied for required".to_string()),
+                }
+            }
+        }
+
+        impl UnoBody {
+            pub fn gateway<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<Option<String>>,
+                T::Error: std::fmt::Display,
+            {
+                self.gateway = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for gateway: {}", e));
+                self
+            }
+            pub fn required<T>(mut self, value: T) -> Self
+            where
+                T: std::convert::TryInto<::serde_json::Value>,
+                T::Error: std::fmt::Display,
+            {
+                self.required = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for required: {}", e));
+                self
+            }
+        }
+
+        impl std::convert::TryFrom<UnoBody> for super::UnoBody {
+            type Error = super::error::ConversionError;
+            fn try_from(value: UnoBody) -> Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    gateway: value.gateway?,
+                    required: value.required?,
+                })
+            }
+        }
+
+        impl From<super::UnoBody> for UnoBody {
+            fn from(value: super::UnoBody) -> Self {
+                Self {
+                    gateway: Ok(value.gateway),
+                    required: Ok(value.required),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+///Client for CLI gen test
+///
+///Test case to exercise CLI generation
+///
+///Version: 9000
+pub struct Client {
+    pub(crate) baseurl: String,
+    pub(crate) client: reqwest::Client,
+}
+
+impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new(baseurl: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
+    }
+
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+
+    /// Get the base URL to which requests are made.
+    pub fn baseurl(&self) -> &String {
+        &self.baseurl
+    }
+
+    /// Get the internal `reqwest::Client` used to make requests.
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Get the version of this API.
+    ///
+    /// This string is pulled directly from the source OpenAPI
+    /// document and may be in any format the API selects.
+    pub fn api_version(&self) -> &'static str {
+        "9000"
+    }
+}
+
+impl Client {
+    ///Sends a `GET` request to `/uno`
+    ///
+    ///```ignore
+    /// let response = client.uno()
+    ///    .gateway(gateway)
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn uno(&self) -> builder::Uno {
+        builder::Uno::new(self)
+    }
+}
+
+/// Types for composing operation parameters.
+#[allow(clippy::all)]
+pub mod builder {
+    use super::types;
+    #[allow(unused_imports)]
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
+    ///Builder for [`Client::uno`]
+    ///
+    ///[`Client::uno`]: super::Client::uno
+    #[derive(Debug, Clone)]
+    pub struct Uno<'a> {
+        client: &'a super::Client,
+        gateway: Result<String, String>,
+        body: Result<types::builder::UnoBody, String>,
+    }
+
+    impl<'a> Uno<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                gateway: Err("gateway was not initialized".to_string()),
+                body: Ok(types::builder::UnoBody::default()),
+            }
+        }
+
+        pub fn gateway<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.gateway = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for gateway failed".to_string());
+            self
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::UnoBody>,
+            <V as std::convert::TryInto<types::UnoBody>>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| format!("conversion to `UnoBody` for body failed: {}", s));
+            self
+        }
+
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(types::builder::UnoBody) -> types::builder::UnoBody,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+
+        ///Sends a `GET` request to `/uno`
+        pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
+            let Self {
+                client,
+                gateway,
+                body,
+            } = self;
+            let gateway = gateway.map_err(Error::InvalidRequest)?;
+            let body = body
+                .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/uno", client.baseurl,);
+            let mut query = Vec::with_capacity(1usize);
+            query.push(("gateway", gateway.to_string()));
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).json(&body).query(&query).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+}
+
+/// Items consumers will typically use such as the Client and
+/// extension traits.
+pub mod prelude {
+    #[allow(unused_imports)]
+    pub use super::Client;
+}

--- a/progenitor-impl/tests/output/src/cli_gen_cli.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_cli.rs
@@ -21,7 +21,7 @@ impl<T: CliConfig> Cli<T> {
                 clap::Arg::new("gateway")
                     .long("gateway")
                     .value_parser(clap::value_parser!(String))
-                    .required(false),
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -48,7 +48,7 @@ impl<T: CliConfig> Cli<T> {
     pub async fn execute_uno(&self, matches: &clap::ArgMatches) -> anyhow::Result<()> {
         let mut request = self.client.uno();
         if let Some(value) = matches.get_one::<String>("gateway") {
-            request = request.body_map(|body| body.gateway(value.clone()))
+            request = request.gateway(value.clone());
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {

--- a/progenitor-impl/tests/output/src/cli_gen_cli.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_cli.rs
@@ -1,0 +1,112 @@
+use crate::cli_gen_builder::*;
+pub struct Cli<T: CliConfig> {
+    client: Client,
+    config: T,
+}
+
+impl<T: CliConfig> Cli<T> {
+    pub fn new(client: Client, config: T) -> Self {
+        Self { client, config }
+    }
+
+    pub fn get_command(cmd: CliCommand) -> clap::Command {
+        match cmd {
+            CliCommand::Uno => Self::cli_uno(),
+        }
+    }
+
+    pub fn cli_uno() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("gateway")
+                    .long("gateway")
+                    .value_parser(clap::value_parser!(String))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("json-body")
+                    .long("json-body")
+                    .value_name("JSON-FILE")
+                    .required(true)
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .help("Path to a file that contains the full json body."),
+            )
+            .arg(
+                clap::Arg::new("json-body-template")
+                    .long("json-body-template")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("XXX"),
+            )
+    }
+
+    pub async fn execute(&self, cmd: CliCommand, matches: &clap::ArgMatches) -> anyhow::Result<()> {
+        match cmd {
+            CliCommand::Uno => self.execute_uno(matches).await,
+        }
+    }
+
+    pub async fn execute_uno(&self, matches: &clap::ArgMatches) -> anyhow::Result<()> {
+        let mut request = self.client.uno();
+        if let Some(value) = matches.get_one::<String>("gateway") {
+            request = request.body_map(|body| body.gateway(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::UnoBody>(&body_txt).unwrap();
+            request = request.body(body_value);
+        }
+
+        self.config.execute_uno(matches, &mut request)?;
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                todo!()
+            }
+            Err(r) => {
+                self.config.error(&r);
+                Err(anyhow::Error::new(r))
+            }
+        }
+    }
+}
+
+pub trait CliConfig {
+    fn success_item<T>(&self, value: &ResponseValue<T>)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug;
+    fn success_no_item(&self, value: &ResponseValue<()>);
+    fn error<T>(&self, value: &Error<T>)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug;
+    fn list_start<T>(&self)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug;
+    fn list_item<T>(&self, value: &T)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug;
+    fn list_end_success<T>(&self)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug;
+    fn list_end_error<T>(&self, value: &Error<T>)
+    where
+        T: schemars::JsonSchema + serde::Serialize + std::fmt::Debug;
+    fn execute_uno(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::Uno,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum CliCommand {
+    Uno,
+}
+
+impl CliCommand {
+    pub fn iter() -> impl Iterator<Item = CliCommand> {
+        vec![CliCommand::Uno].into_iter()
+    }
+}

--- a/progenitor-impl/tests/output/src/cli_gen_httpmock.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_httpmock.rs
@@ -1,0 +1,73 @@
+pub mod operations {
+    #![doc = r" [`When`](httpmock::When) and [`Then`](httpmock::Then)"]
+    #![doc = r" wrappers for each operation. Each can be converted to"]
+    #![doc = r" its inner type with a call to `into_inner()`. This can"]
+    #![doc = r" be used to explicitly deviate from permitted values."]
+    use crate::cli_gen_builder::*;
+    pub struct UnoWhen(httpmock::When);
+    impl UnoWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(regex::Regex::new("^/uno$").unwrap()),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn gateway(self, value: &str) -> Self {
+            Self(self.0.query_param("gateway", value.to_string()))
+        }
+
+        pub fn body(self, value: &types::UnoBody) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+
+    pub struct UnoThen(httpmock::Then);
+    impl UnoThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn success(self, status: u16, value: serde_json::Value) -> Self {
+            assert_eq!(status / 100u16, 2u16);
+            Self(
+                self.0
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .json_body(value),
+            )
+        }
+    }
+}
+
+#[doc = r" An extension trait for [`MockServer`](httpmock::MockServer) that"]
+#[doc = r" adds a method for each operation. These are the equivalent of"]
+#[doc = r" type-checked [`mock()`](httpmock::MockServer::mock) calls."]
+pub trait MockServerExt {
+    fn uno<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::UnoWhen, operations::UnoThen);
+}
+
+impl MockServerExt for httpmock::MockServer {
+    fn uno<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::UnoWhen, operations::UnoThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::UnoWhen::new(when),
+                operations::UnoThen::new(then),
+            )
+        })
+    }
+}

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -1,0 +1,160 @@
+#[allow(unused_imports)]
+use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
+/// Types used as operation parameters and responses.
+#[allow(clippy::all)]
+pub mod types {
+    /// Error types.
+    pub mod error {
+        /// Error from a TryFrom or FromStr implementation.
+        pub struct ConversionError(::std::borrow::Cow<'static, str>);
+        impl ::std::error::Error for ConversionError {}
+        impl ::std::fmt::Display for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl ::std::fmt::Debug for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+
+        impl From<&'static str> for ConversionError {
+            fn from(value: &'static str) -> Self {
+                Self(value.into())
+            }
+        }
+
+        impl From<String> for ConversionError {
+            fn from(value: String) -> Self {
+                Self(value.into())
+            }
+        }
+    }
+
+    ///UnoBody
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "required"
+    ///  ],
+    ///  "properties": {
+    ///    "gateway": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    pub struct UnoBody {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub gateway: Option<String>,
+        pub required: ::serde_json::Value,
+    }
+
+    impl From<&UnoBody> for UnoBody {
+        fn from(value: &UnoBody) -> Self {
+            value.clone()
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+///Client for CLI gen test
+///
+///Test case to exercise CLI generation
+///
+///Version: 9000
+pub struct Client {
+    pub(crate) baseurl: String,
+    pub(crate) client: reqwest::Client,
+}
+
+impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new(baseurl: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
+    }
+
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+
+    /// Get the base URL to which requests are made.
+    pub fn baseurl(&self) -> &String {
+        &self.baseurl
+    }
+
+    /// Get the internal `reqwest::Client` used to make requests.
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Get the version of this API.
+    ///
+    /// This string is pulled directly from the source OpenAPI
+    /// document and may be in any format the API selects.
+    pub fn api_version(&self) -> &'static str {
+        "9000"
+    }
+}
+
+#[allow(clippy::all)]
+impl Client {
+    ///Sends a `GET` request to `/uno`
+    pub async fn uno<'a>(
+        &'a self,
+        gateway: &'a str,
+        body: &'a types::UnoBody,
+    ) -> Result<ResponseValue<ByteStream>, Error<()>> {
+        let url = format!("{}/uno", self.baseurl,);
+        let mut query = Vec::with_capacity(1usize);
+        query.push(("gateway", gateway.to_string()));
+        #[allow(unused_mut)]
+        let mut request = self.client.get(url).json(&body).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+}
+
+/// Items consumers will typically use such as the Client.
+pub mod prelude {
+    #[allow(unused_imports)]
+    pub use super::Client;
+}

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -167,6 +167,11 @@ fn test_param_collision() {
     verify_apis("param-collision.json");
 }
 
+#[test]
+fn test_cli_gen() {
+    verify_apis("cli-gen.json");
+}
+
 // TODO this file is full of inconsistencies and incorrectly specified types.
 // It's an interesting test to consider whether we try to do our best to
 // interpret the intent or just fail.

--- a/sample_openapi/cli-gen.json
+++ b/sample_openapi/cli-gen.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "description": "Test case to exercise CLI generation",
+    "title": "CLI gen test",
+    "version": "9000"
+  },
+  "paths": {
+    "/uno": {
+      "get": {
+        "operationId": "uno",
+        "parameters": [
+          {
+            "name": "gateway",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "gateway": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
In https://github.com/oxidecomputer/oxide.rs/pull/853 we had a situation where a parameter (query) had the same name as a top-level field in the POST body. In this case, we prioritized the body field over the parameter. This led to the CLI subcommand being unusable. While this particular case turned out to be a mistake in the API, if such a situation were to occur, this PR causes us to ignore the body field (thus making the body required if the field was required).

This PR has a commit that introduces the new test for this condition and then a commit that contains the fix.