### PR TITLE
add async post_hook function support

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -352,7 +352,7 @@ where
                 write!(f, "Pre-hook Error: {}", s)?;
             }
             Error::PostHookError(s) => {
-                write!(f, "Post-hook Error: {}", s)
+                write!(f, "Post-hook Error: {}", s)?;
             }
         }
 

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -258,6 +258,9 @@ pub enum Error<E = ()> {
 
     /// An error occurred in the processing of a request pre-hook.
     PreHookError(String),
+
+    /// An error occurred in the processing of a request post-hook.
+    PostHookError(String),
 }
 
 impl<E> Error<E> {
@@ -266,6 +269,7 @@ impl<E> Error<E> {
         match self {
             Error::InvalidRequest(_) => None,
             Error::PreHookError(_) => None,
+            Error::PostHookError(_) => None,
             Error::CommunicationError(e) => e.status(),
             Error::ErrorResponse(rv) => Some(rv.status()),
             Error::InvalidUpgrade(e) => e.status(),
@@ -283,6 +287,7 @@ impl<E> Error<E> {
         match self {
             Error::InvalidRequest(s) => Error::InvalidRequest(s),
             Error::PreHookError(s) => Error::PreHookError(s),
+            Error::PostHookError(s) => Error::PostHookError(s),
             Error::CommunicationError(e) => Error::CommunicationError(e),
             Error::ErrorResponse(ResponseValue {
                 inner: _,
@@ -345,6 +350,9 @@ where
             }
             Error::PreHookError(s) => {
                 write!(f, "Pre-hook Error: {}", s)
+            }
+            Error::PostHookError(s) => {
+                write!(f, "Post-hook Error: {}", s)
             }
         }
     }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -64,6 +64,7 @@ pub struct GenerationSettings {
     pre_hook: Option<TokenStream>,
     pre_hook_async: Option<TokenStream>,
     post_hook: Option<TokenStream>,
+    post_hook_async: Option<TokenStream>,
     extra_derives: Vec<String>,
 
     unknown_crates: UnknownPolicy,
@@ -149,6 +150,16 @@ impl GenerationSettings {
     /// Hook invoked prior to receiving the HTTP response.
     pub fn with_post_hook(&mut self, post_hook: TokenStream) -> &mut Self {
         self.post_hook = Some(post_hook);
+        self
+    }
+
+    /// Hook invoked prior to receiving the HTTP response.
+    /// Any hook requires the inner type to be set via
+    /// [Self::with_inner_type], otherwise the code will not compile.
+    /// The signature for the post hook function should be
+    /// `post_hook_func(&InnerType, &Result<reqwest::Response,reqwest::Error>) -> ()`
+    pub fn with_post_hook_async(&mut self, post_hook_async: TokenStream) -> &mut Self {
+        self.post_hook_async = Some(post_hook_async);
         self
     }
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -154,12 +154,11 @@ impl GenerationSettings {
     }
 
     /// Hook invoked prior to receiving the HTTP response.
-    /// Any hook requires the inner type to be set via
-    /// [Self::with_inner_type], otherwise the code will not compile.
-    /// The signature for the post hook function should be
-    /// `post_hook_func(&InnerType, &Result<reqwest::Response,reqwest::Error>) -> ()`
-    pub fn with_post_hook_async(&mut self, post_hook_async: TokenStream) -> &mut Self {
-        self.post_hook_async = Some(post_hook_async);
+    pub fn with_post_hook_async(
+        &mut self,
+        post_hook: TokenStream,
+    ) -> &mut Self {
+        self.post_hook_async = Some(post_hook);
         self
     }
 

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1155,7 +1155,7 @@ impl Generator {
         });
         let post_hook_async = self.settings.post_hook_async.as_ref().map(|hook| {
             quote! {
-                match (#hook)(&#client.inner, &#result_ident).await {
+                match (#hook)(#inner &#result_ident).await {
                     Ok(_) => (),
                     Err(e) => return Err(Error::PostHookError(e.to_string())),
                 }

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1147,6 +1147,14 @@ impl Generator {
                 (#hook)(&#client.inner, &#result_ident);
             }
         });
+        let post_hook_async = self.settings.post_hook_async.as_ref().map(|hook| {
+            quote! {
+                match (#hook)(&#client.inner, &#result_ident).await {
+                    Ok(_) => (),
+                    Err(e) => return Err(Error::PostHookError(e.to_string())),
+                }
+            }
+        });
 
         let method_func = format_ident!("{}", method.method.as_str());
 
@@ -1172,6 +1180,7 @@ impl Generator {
                 .execute(#request_ident)
                 .await;
             #post_hook
+            #post_hook_async
 
             let #response_ident = #result_ident?;
 


### PR DESCRIPTION
Currently, the builder offers `with_pre_hook()`, `with_pre_hook_async()` and `with_post_hook()`. However, there is no async variant for post call hooks. This PR adds that hook function.

I actually found I needed it because I needed to act on HTTP responses by sending a message via a tokio mpsc channel - and that is only possible within an async function context.