### PR TITLE
Return source of wrapped errors

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -391,10 +391,10 @@ where
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::CommunicationError(e) => Some(e),
-            Error::InvalidUpgrade(e) => Some(e),
-            Error::ResponseBodyError(e) => Some(e),
-            Error::InvalidResponsePayload(_b, e) => Some(e),
+            Error::CommunicationError(e) => e.source(),
+            Error::InvalidUpgrade(e) => e.source(),
+            Error::ResponseBodyError(e) => e.source(),
+            Error::InvalidResponsePayload(_b, e) => e.source(),
             _ => None,
         }
     }


### PR DESCRIPTION
The `Display` impl for `Error` wraps the original error received with a message, e.g., "Communication error: {original_error_message}". The `source` method returns the same error, though, so iterating over the error chain will cause the same error message to be printed twice.

Update `source` to return the source error of the original error, not our wrapper, to avoid this duplication.