### PR TITLE
Show source chain with alt format for Error

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -322,31 +322,42 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::InvalidRequest(s) => {
-                write!(f, "Invalid Request: {}", s)
+                write!(f, "Invalid Request: {}", s)?;
             }
             Error::CommunicationError(e) => {
-                write!(f, "Communication Error: {}", e)
+                write!(f, "Communication Error: {}", e)?;
             }
             Error::ErrorResponse(rve) => {
                 write!(f, "Error Response: ")?;
-                rve.fmt_info(f)
+                rve.fmt_info(f)?;
             }
             Error::InvalidUpgrade(e) => {
-                write!(f, "Invalid Response Upgrade: {}", e)
+                write!(f, "Invalid Response Upgrade: {}", e)?;
             }
             Error::ResponseBodyError(e) => {
-                write!(f, "Invalid Response Body Bytes: {}", e)
+                write!(f, "Invalid Response Body Bytes: {}", e)?;
             }
             Error::InvalidResponsePayload(b, e) => {
-                write!(f, "Invalid Response Payload ({:?}): {}", b, e)
+                write!(f, "Invalid Response Payload ({:?}): {}", b, e)?;
             }
             Error::UnexpectedResponse(r) => {
-                write!(f, "Unexpected Response: {:?}", r)
+                write!(f, "Unexpected Response: {:?}", r)?;
             }
             Error::PreHookError(s) => {
-                write!(f, "Pre-hook Error: {}", s)
+                write!(f, "Pre-hook Error: {}", s)?;
             }
         }
+
+        if f.alternate() {
+            use std::error::Error as _;
+
+            let mut src = self.source().and_then(|e| e.source());
+            while let Some(s) = src {
+                write!(f, ": {s}")?;
+                src = s.source();
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
For debugging purposes it can be useful to expose the full details of an error, but this output is often too verbose to show in the default Display format. The anyhow crate is a widely used example of this approach, exposing the full backtrace chain when the `{:#}` alternate formatting modifier is used.

Add an alternate Display formatting modifier for Error that will show the full source chain. We skip the first source, as this is already printed as part of the outermost error.