### PR TITLE
E does not need to implement std::fmt::Debug in ResponseValue::from_response

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -63,7 +63,7 @@ pub struct ResponseValue<T> {
 
 impl<T: DeserializeOwned> ResponseValue<T> {
     #[doc(hidden)]
-    pub async fn from_response<E: std::fmt::Debug>(
+    pub async fn from_response<E>(
         response: reqwest::Response,
     ) -> Result<Self, Error<E>> {
         let status = response.status();


### PR DESCRIPTION
I was getting compilation errors in my progenitor generated code when the generated error type is `Error<ByteStream>`, because ByteStream does not implement std::fmt::Debug.

I cannot find any evidence that E needs to impl std::fmt::Debug from this function.

So I removed the trait bound from it.