### PR TITLE
refactor(error): wrapped error responses print using debug formatting

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -330,17 +330,17 @@ where
                 write!(f, "Invalid Request: {}", s)?;
             }
             Error::CommunicationError(e) => {
-                write!(f, "Communication Error: {}", e)?;
+                write!(f, "Communication Error: {:?}", e)?;
             }
             Error::ErrorResponse(rve) => {
                 write!(f, "Error Response: ")?;
                 rve.fmt_info(f)?;
             }
             Error::InvalidUpgrade(e) => {
-                write!(f, "Invalid Response Upgrade: {}", e)?;
+                write!(f, "Invalid Response Upgrade: {:?}", e)?;
             }
             Error::ResponseBodyError(e) => {
-                write!(f, "Invalid Response Body Bytes: {}", e)?;
+                write!(f, "Invalid Response Body Bytes: {:?}", e)?;
             }
             Error::InvalidResponsePayload(b, e) => {
                 write!(f, "Invalid Response Payload ({:?}): {}", b, e)?;


### PR DESCRIPTION
## Reasoning

Debug formatting is preferred over Display as it will also print information about wrapped errors, including stack traces, which can make debugging much easier.

Note that this was already the case with `UnexpectedResponse` variant, this change standardises it across all error variants.

## Alternatives

`Debug` formatting in a `Display` implementation is a bit of an anti-pattern. The `Error` type is using the same string formatting implementation for both it's `Display` and `Debug` traits. I can split up this functionality so that the `Display` information can be slightly less verbose if this is desired.

