### PR TITLE
handle array-like and map-like query parameters

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,11 +41,9 @@ jobs:
       with:
         components: rustfmt
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: rustfmt
-        default: true
     - name: Build
       run: cargo build --locked --tests --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1088,7 +1088,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2179,7 +2179,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2485,7 +2485,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "typify"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/typify#fa65d747632c2c95d06df9d702cca1d04684e3c2"
+source = "git+https://github.com/oxidecomputer/typify#0d08ac16d864fdb3b2dc25e5e6aadbef58bca67b"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "typify-impl"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/typify#fa65d747632c2c95d06df9d702cca1d04684e3c2"
+source = "git+https://github.com/oxidecomputer/typify#0d08ac16d864fdb3b2dc25e5e6aadbef58bca67b"
 dependencies = [
  "heck",
  "log",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "typify-macro"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/typify#fa65d747632c2c95d06df9d702cca1d04684e3c2"
+source = "git+https://github.com/oxidecomputer/typify#0d08ac16d864fdb3b2dc25e5e6aadbef58bca67b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3096,7 +3096,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "synstructure",
 ]
 
@@ -3137,7 +3137,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "synstructure",
 ]
 
@@ -3166,5 +3166,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "dropshot"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,14 +974,142 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.3"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1068,6 +1207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
 name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,12 +1232,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1390,6 +1529,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1991,6 +2132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2170,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "system-configuration"
@@ -2167,19 +2325,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.5.1"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -2374,25 +2527,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2420,15 +2558,26 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -2916,6 +3065,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,7 +3121,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "typify"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/typify#0d08ac16d864fdb3b2dc25e5e6aadbef58bca67b"
+source = "git+https://github.com/oxidecomputer/typify#fa65d747632c2c95d06df9d702cca1d04684e3c2"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "typify-impl"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/typify#0d08ac16d864fdb3b2dc25e5e6aadbef58bca67b"
+source = "git+https://github.com/oxidecomputer/typify#fa65d747632c2c95d06df9d702cca1d04684e3c2"
 dependencies = [
  "heck",
  "log",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "typify-macro"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/typify#0d08ac16d864fdb3b2dc25e5e6aadbef58bca67b"
+source = "git+https://github.com/oxidecomputer/typify#fa65d747632c2c95d06df9d702cca1d04684e3c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tokio = { version = "1.42.0", features = ["rt", "net"] }
 # change when publishing
 # typify = { version = "0.2.0" }
 typify = { git = "https://github.com/oxidecomputer/typify" }
+url = "2.5.4"
 unicode-ident = "1.0.14"
 uuid = { version = "1.11.0", features = ["serde", "v4"] }
 

--- a/progenitor-client/Cargo.toml
+++ b/progenitor-client/Cargo.toml
@@ -14,3 +14,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }
+
+[dev-dependencies]
+url = { workspace = true }
+uuid = { workspace = true }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -456,7 +456,7 @@ impl<'a, T> QueryParam<'a, T> {
         Self { name, value }
     }
 }
-impl<'a, T> Serialize for QueryParam<'a, T>
+impl<T> Serialize for QueryParam<'_, T>
 where
     T: Serialize,
 {
@@ -480,7 +480,7 @@ pub(crate) struct QuerySerializer<'a, S> {
 macro_rules! serialize_scalar {
     ($f:ident, $t:ty) => {
         fn $f(self, v: $t) -> Result<Self::Ok, Self::Error> {
-            Ok([(self.name, v)].serialize(self.inner).unwrap())
+            [(self.name, v)].serialize(self.inner)
         }
     };
 }
@@ -518,7 +518,7 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Ok(self.inner.serialize_none().unwrap())
+        self.inner.serialize_none()
     }
 
     fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
@@ -634,7 +634,7 @@ pub struct QuerySeq<'a, S> {
     name: &'a str,
 }
 
-impl<'a, S> serde::ser::SerializeSeq for QuerySeq<'a, S>
+impl<S> serde::ser::SerializeSeq for QuerySeq<'_, S>
 where
     S: serde::ser::SerializeSeq,
 {

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -527,7 +527,7 @@ where
     {
         // Serialize the value through self which will proxy into the inner
         // Serializer as appropriate.
-        Ok(value.serialize(self).unwrap())
+        value.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 #![allow(dead_code)]
 
@@ -441,5 +441,218 @@ impl<E> RequestBuilderExt<E> for RequestBuilder {
                 serde_urlencoded::to_string(body)
                     .map_err(|_| Error::InvalidRequest("failed to serialize body".to_string()))?,
             ))
+    }
+}
+
+#[doc(hidden)]
+pub struct QueryParam<'a, T> {
+    name: &'a str,
+    value: &'a T,
+}
+
+impl<'a, T> QueryParam<'a, T> {
+    #[doc(hidden)]
+    pub fn new(name: &'a str, value: &'a T) -> Self {
+        Self { name, value }
+    }
+}
+impl<'a, T> Serialize for QueryParam<'a, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, inner: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let serializer = QuerySerializer {
+            inner,
+            name: self.name,
+        };
+        self.value.serialize(serializer)
+    }
+}
+
+pub(crate) struct QuerySerializer<'a, S> {
+    inner: S,
+    name: &'a str,
+}
+
+macro_rules! serialize_scalar {
+    ($f:ident, $t:ty) => {
+        fn $f(self, v: $t) -> Result<Self::Ok, Self::Error> {
+            Ok([(self.name, v)].serialize(self.inner).unwrap())
+        }
+    };
+}
+
+impl<'a, S> serde::Serializer for QuerySerializer<'a, S>
+where
+    S: serde::Serializer,
+{
+    type Ok = S::Ok;
+    type Error = S::Error;
+    type SerializeSeq = QuerySeq<'a, S::SerializeSeq>;
+    type SerializeTuple = S::SerializeTuple;
+    type SerializeTupleStruct = S::SerializeTupleStruct;
+    type SerializeTupleVariant = S::SerializeTupleVariant;
+    type SerializeMap = S::SerializeMap;
+    type SerializeStruct = S::SerializeStruct;
+    type SerializeStructVariant = S::SerializeStructVariant;
+
+    serialize_scalar!(serialize_bool, bool);
+    serialize_scalar!(serialize_i8, i8);
+    serialize_scalar!(serialize_i16, i16);
+    serialize_scalar!(serialize_i32, i32);
+    serialize_scalar!(serialize_i64, i64);
+    serialize_scalar!(serialize_u8, u8);
+    serialize_scalar!(serialize_u16, u16);
+    serialize_scalar!(serialize_u32, u32);
+    serialize_scalar!(serialize_u64, u64);
+    serialize_scalar!(serialize_f32, f32);
+    serialize_scalar!(serialize_f64, f64);
+    serialize_scalar!(serialize_char, char);
+    serialize_scalar!(serialize_str, &str);
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_bytes(v)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.inner.serialize_none().unwrap())
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        // Serialize the value through self which will proxy into the inner
+        // Serializer as appropriate.
+        Ok(value.serialize(self).unwrap())
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_unit()
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_unit_struct(name)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.inner
+            .serialize_unit_variant(name, variant_index, variant)
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        // TODO typify doesn't make newtype structs transparent, so we work
+        // around that here.
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.inner
+            .serialize_newtype_variant(name, variant_index, variant, value)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        let Self { inner, name, .. } = self;
+        Ok(QuerySeq {
+            inner: inner.serialize_seq(len)?,
+            name,
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.inner.serialize_tuple(len)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.inner.serialize_tuple_struct(name, len)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.inner
+            .serialize_tuple_variant(name, variant_index, variant, len)
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.inner.serialize_map(len)
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.inner.serialize_struct(name, len)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.inner
+            .serialize_struct_variant(name, variant_index, variant, len)
+    }
+}
+
+#[doc(hidden)]
+pub struct QuerySeq<'a, S> {
+    inner: S,
+    name: &'a str,
+}
+
+impl<'a, S> serde::ser::SerializeSeq for QuerySeq<'a, S>
+where
+    S: serde::ser::SerializeSeq,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let v = (self.name, value);
+        self.inner.serialize_element(&v)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.inner.end()
     }
 }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -550,15 +550,13 @@ where
 
     fn serialize_newtype_struct<T>(
         self,
-        _name: &'static str,
+        name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        // TODO typify doesn't make newtype structs transparent, so we work
-        // around that here.
-        value.serialize(self)
+        self.inner.serialize_newtype_struct(name, value)
     }
 
     fn serialize_newtype_variant<T>(

--- a/progenitor-client/tests/client_test.rs
+++ b/progenitor-client/tests/client_test.rs
@@ -1,8 +1,218 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
-use progenitor_client::encode_path;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    error::Error,
+};
+
+use progenitor_client::{encode_path, QueryParam};
+use serde::Serialize;
 
 #[test]
 fn test_path_segment_encoding() {
     assert_eq!(encode_path("192.168.0.0/24"), "192.168.0.0%2F24");
+}
+
+fn encode_query_param<T: Serialize>(param_name: &str, value: &T) -> Result<String, Box<dyn Error>> {
+    let mut url = url::Url::parse("https://localhost")?;
+    let mut pairs = url.query_pairs_mut();
+    let serializer = serde_urlencoded::Serializer::new(&mut pairs);
+
+    QueryParam::new(param_name, value).serialize(serializer)?;
+    drop(pairs);
+
+    Ok(url.query().unwrap().to_owned())
+}
+
+#[test]
+fn test_query_scalars() {
+    let value = "xyz".to_string();
+    let result = encode_query_param("param_name", &value).unwrap();
+    assert_eq!(result, "param_name=xyz");
+
+    let value = 42;
+    let result = encode_query_param("param_name", &value).unwrap();
+    assert_eq!(result, "param_name=42");
+
+    let value = -0.05;
+    let result = encode_query_param("param_name", &value).unwrap();
+    assert_eq!(result, "param_name=-0.05");
+}
+
+#[test]
+fn test_query_arrays() {
+    let value = vec!["a", "b", "c"];
+    let result = encode_query_param("paramName", &value).unwrap();
+
+    assert_eq!(result, "paramName=a&paramName=b&paramName=c");
+
+    let value = ["a", "b", "c"].into_iter().collect::<BTreeSet<_>>();
+    let result = encode_query_param("paramName", &value).unwrap();
+
+    assert_eq!(result, "paramName=a&paramName=b&paramName=c");
+
+    let value = ["a", "b", "c"].into_iter().collect::<HashSet<_>>();
+    let result = encode_query_param("paramName", &value).unwrap();
+
+    // Handle hash ordering.
+    assert_eq!(
+        result,
+        value
+            .iter()
+            .map(|v| format!("paramName={v}"))
+            .collect::<Vec<_>>()
+            .join("&")
+    );
+}
+
+#[test]
+fn test_query_object() {
+    #[derive(Serialize)]
+    struct Value {
+        a: String,
+        b: String,
+    }
+    let value = Value {
+        a: "a value".to_string(),
+        b: "b value".to_string(),
+    };
+    let result = encode_query_param("ignored", &value).unwrap();
+
+    assert_eq!(result, "a=a+value&b=b+value");
+}
+
+#[test]
+fn test_query_map() {
+    let value = [("a", "a value"), ("b", "b value")]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "a=a+value&b=b+value");
+}
+
+#[test]
+fn test_query_enum_external() {
+    #[derive(Serialize)]
+    #[serde(rename_all = "snake_case")]
+    enum Value {
+        Simple,
+        Newtype(u64),
+        Tuple(u64, u64),
+        Object { a: u64, b: u64 },
+    }
+    let value = Value::Simple;
+    encode_query_param("ignored", &value).expect_err("variant not supported");
+
+    let value = Value::Newtype(42);
+    encode_query_param("ignored", &value).expect_err("variant not supported");
+
+    let value = Value::Tuple(1, 2);
+    encode_query_param("ignored", &value).expect_err("variant not supported");
+
+    let value = Value::Object { a: 3, b: 4 };
+    encode_query_param("ignored", &value).expect_err("variant not supported");
+}
+
+#[test]
+fn test_query_enum_internal() {
+    #[derive(Serialize)]
+    #[serde(tag = "tag_name")]
+    #[serde(rename_all = "snake_case")]
+    enum Value {
+        Simple,
+        Object { a: u64, b: u64 },
+    }
+    let value = Value::Simple;
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "tag_name=simple");
+
+    let value = Value::Object { a: 3, b: 4 };
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "tag_name=object&a=3&b=4");
+}
+
+#[test]
+fn test_query_enum_adjacent() {
+    #[derive(Serialize)]
+    #[serde(tag = "tag_name", content = "content_name")]
+    #[serde(rename_all = "snake_case")]
+    enum Value {
+        Simple,
+        Newtype(u64),
+        Tuple(u64, u64),
+        Object { a: u64, b: u64 },
+    }
+    let value = Value::Simple;
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "tag_name=simple");
+
+    let value = Value::Newtype(42);
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "tag_name=newtype&content_name=42");
+
+    let value = Value::Tuple(1, 2);
+    encode_query_param("ignored", &value).expect_err("invalid variant");
+
+    let value = Value::Object { a: 3, b: 4 };
+    encode_query_param("ignored", &value).expect_err("invalid variant");
+}
+
+#[test]
+fn test_query_enum_untagged() {
+    #[derive(Serialize)]
+    #[serde(untagged)]
+    #[serde(rename_all = "snake_case")]
+    enum Value {
+        Simple,
+        Newtype(u64),
+        Tuple(u64, u64),
+        Object { a: u64, b: u64 },
+        Array(Vec<u64>),
+    }
+    let value = Value::Simple;
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "");
+
+    let value = Value::Newtype(42);
+    let result = encode_query_param("paramName", &value).unwrap();
+    assert_eq!(result, "paramName=42");
+
+    let value = Value::Tuple(1, 2);
+    encode_query_param("ignored", &value).expect_err("invalid variant");
+
+    let value = Value::Object { a: 3, b: 4 };
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "a=3&b=4");
+
+    let value = Value::Array(vec![1, 2, 3, 4]);
+    let result = encode_query_param("paramName", &value).unwrap();
+    assert_eq!(result, "paramName=1&paramName=2&paramName=3&paramName=4");
+
+    #[derive(Serialize)]
+    struct Name(String);
+    #[derive(Serialize)]
+    #[serde(untagged)]
+    enum NameOrId {
+        Name(Name),
+        Id(uuid::Uuid),
+    }
+    let value = Some(NameOrId::Name(Name("xyz".to_string())));
+    let result = encode_query_param("paramName", &value).unwrap();
+    assert_eq!(result, "paramName=xyz");
+
+    let id = uuid::Uuid::new_v4();
+    let value = Some(NameOrId::Id(id));
+    let result = encode_query_param("paramName", &value).unwrap();
+    assert_eq!(result, format!("paramName={id}"));
+}
+
+#[test]
+fn test_query_option() {
+    let value = Option::<u64>::None;
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "");
+
+    let value = Some(42);
+    let result = encode_query_param("paramName", &value).unwrap();
+    assert_eq!(result, "paramName=42");
 }

--- a/progenitor-client/tests/client_test.rs
+++ b/progenitor-client/tests/client_test.rs
@@ -189,6 +189,7 @@ fn test_query_enum_untagged() {
     assert_eq!(result, "paramName=1&paramName=2&paramName=3&paramName=4");
 
     #[derive(Serialize)]
+    #[serde(transparent)]
     struct Name(String);
     #[derive(Serialize)]
     #[serde(untagged)]

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2892,10 +2892,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2904,7 +2900,7 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("minseq", &minseq))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -37,6 +37,47 @@ pub mod types {
         }
     }
 
+    ///GetThingOrThingsId
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "oneOf": [
+    ///    {
+    ///      "type": "string"
+    ///    },
+    ///    {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    }
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
+    )]
+    #[serde(untagged)]
+    pub enum GetThingOrThingsId {
+        Variant0(::std::string::String),
+        Variant1(::std::vec::Vec<::std::string::String>),
+    }
+
+    impl From<&GetThingOrThingsId> for GetThingOrThingsId {
+        fn from(value: &GetThingOrThingsId) -> Self {
+            value.clone()
+        }
+    }
+
+    impl From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
+        fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
+            Self::Variant1(value)
+        }
+    }
+
     ///ObjWithOptionArray
     ///
     /// <details><summary>JSON schema</summary>
@@ -2611,6 +2652,18 @@ impl Client {
     pub fn workers_recycle(&self) -> builder::WorkersRecycle {
         builder::WorkersRecycle::new(self)
     }
+
+    ///Sends a `GET` request to `/v1/things`
+    ///
+    ///```ignore
+    /// let response = client.get_thing_or_things()
+    ///    .id(id)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn get_thing_or_things(&self) -> builder::GetThingOrThings {
+        builder::GetThingOrThings::new(self)
+    }
 }
 
 /// Types for composing operation parameters.
@@ -3630,6 +3683,58 @@ pub mod builder {
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    ///Builder for [`Client::get_thing_or_things`]
+    ///
+    ///[`Client::get_thing_or_things`]: super::Client::get_thing_or_things
+    #[derive(Debug, Clone)]
+    pub struct GetThingOrThings<'a> {
+        client: &'a super::Client,
+        id: Result<Option<types::GetThingOrThingsId>, String>,
+    }
+
+    impl<'a> GetThingOrThings<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                id: Ok(None),
+            }
+        }
+
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::GetThingOrThingsId>,
+        {
+            self.id = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `GetThingOrThingsId` for id failed".to_string());
+            self
+        }
+
+        ///Sends a `GET` request to `/v1/things`
+        pub async fn send(self) -> Result<ResponseValue<::std::string::String>, Error<()>> {
+            let Self { client, id } = self;
+            let id = id.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/v1/things", client.baseurl,);
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("id", &id))
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -66,13 +66,13 @@ pub mod types {
         Variant1(::std::vec::Vec<::std::string::String>),
     }
 
-    impl From<&GetThingOrThingsId> for GetThingOrThingsId {
+    impl ::std::convert::From<&GetThingOrThingsId> for GetThingOrThingsId {
         fn from(value: &GetThingOrThingsId) -> Self {
             value.clone()
         }
     }
 
-    impl From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
+    impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
         fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
             Self::Variant1(value)
         }

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -64,13 +64,13 @@ pub mod types {
         Variant1(::std::vec::Vec<::std::string::String>),
     }
 
-    impl From<&GetThingOrThingsId> for GetThingOrThingsId {
+    impl ::std::convert::From<&GetThingOrThingsId> for GetThingOrThingsId {
         fn from(value: &GetThingOrThingsId) -> Self {
             value.clone()
         }
     }
 
-    impl From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
+    impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
         fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
             Self::Variant1(value)
         }

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2852,10 +2852,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2864,7 +2860,7 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("minseq", &minseq))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -37,6 +37,45 @@ pub mod types {
         }
     }
 
+    ///GetThingOrThingsId
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "oneOf": [
+    ///    {
+    ///      "type": "string"
+    ///    },
+    ///    {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    }
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    #[serde(untagged)]
+    pub enum GetThingOrThingsId {
+        Variant0(::std::string::String),
+        Variant1(::std::vec::Vec<::std::string::String>),
+    }
+
+    impl From<&GetThingOrThingsId> for GetThingOrThingsId {
+        fn from(value: &GetThingOrThingsId) -> Self {
+            value.clone()
+        }
+    }
+
+    impl From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
+        fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
+            Self::Variant1(value)
+        }
+    }
+
     ///ObjWithOptionArray
     ///
     /// <details><summary>JSON schema</summary>
@@ -2571,6 +2610,18 @@ impl Client {
     pub fn workers_recycle(&self) -> builder::WorkersRecycle {
         builder::WorkersRecycle::new(self)
     }
+
+    ///Sends a `GET` request to `/v1/things`
+    ///
+    ///```ignore
+    /// let response = client.get_thing_or_things()
+    ///    .id(id)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn get_thing_or_things(&self) -> builder::GetThingOrThings {
+        builder::GetThingOrThings::new(self)
+    }
 }
 
 /// Types for composing operation parameters.
@@ -3590,6 +3641,58 @@ pub mod builder {
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    ///Builder for [`Client::get_thing_or_things`]
+    ///
+    ///[`Client::get_thing_or_things`]: super::Client::get_thing_or_things
+    #[derive(Debug, Clone)]
+    pub struct GetThingOrThings<'a> {
+        client: &'a super::Client,
+        id: Result<Option<types::GetThingOrThingsId>, String>,
+    }
+
+    impl<'a> GetThingOrThings<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                id: Ok(None),
+            }
+        }
+
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::GetThingOrThingsId>,
+        {
+            self.id = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `GetThingOrThingsId` for id failed".to_string());
+            self
+        }
+
+        ///Sends a `GET` request to `/v1/things`
+        pub async fn send(self) -> Result<ResponseValue<::std::string::String>, Error<()>> {
+            let Self { client, id } = self;
+            let id = id.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/v1/things", client.baseurl,);
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    reqwest::header::ACCEPT,
+                    reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("id", &id))
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -65,13 +65,13 @@ pub mod types {
         Variant1(::std::vec::Vec<::std::string::String>),
     }
 
-    impl From<&GetThingOrThingsId> for GetThingOrThingsId {
+    impl ::std::convert::From<&GetThingOrThingsId> for GetThingOrThingsId {
         fn from(value: &GetThingOrThingsId) -> Self {
             value.clone()
         }
     }
 
-    impl From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
+    impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
         fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
             Self::Variant1(value)
         }

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -1007,11 +1007,6 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &minseq {
-            query.push(("minseq", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1020,7 +1015,7 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("minseq", &minseq))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -38,6 +38,45 @@ pub mod types {
         }
     }
 
+    ///GetThingOrThingsId
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "oneOf": [
+    ///    {
+    ///      "type": "string"
+    ///    },
+    ///    {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    }
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    #[serde(untagged)]
+    pub enum GetThingOrThingsId {
+        Variant0(::std::string::String),
+        Variant1(::std::vec::Vec<::std::string::String>),
+    }
+
+    impl From<&GetThingOrThingsId> for GetThingOrThingsId {
+        fn from(value: &GetThingOrThingsId) -> Self {
+            value.clone()
+        }
+    }
+
+    impl From<::std::vec::Vec<::std::string::String>> for GetThingOrThingsId {
+        fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
+            Self::Variant1(value)
+        }
+    }
+
     ///ObjWithOptionArray
     ///
     /// <details><summary>JSON schema</summary>
@@ -1315,6 +1354,30 @@ impl Client {
         let response = result?;
         match response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+
+    ///Sends a `GET` request to `/v1/things`
+    pub async fn get_thing_or_things<'a>(
+        &'a self,
+        id: Option<&'a types::GetThingOrThingsId>,
+    ) -> Result<ResponseValue<::std::string::String>, Error<()>> {
+        let url = format!("{}/v1/things", self.baseurl,);
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .get(url)
+            .header(
+                reqwest::header::ACCEPT,
+                reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .query(&progenitor_client::QueryParam::new("id", &id))
+            .build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -288,10 +288,13 @@ pub mod builder {
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/uno", client.baseurl,);
-            let mut query = Vec::with_capacity(1usize);
-            query.push(("gateway", gateway.to_string()));
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).json(&body).query(&query).build()?;
+            let mut request = client
+                .client
+                .get(url)
+                .json(&body)
+                .query(&progenitor_client::QueryParam::new("gateway", &gateway))
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -286,10 +286,13 @@ pub mod builder {
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/uno", client.baseurl,);
-            let mut query = Vec::with_capacity(1usize);
-            query.push(("gateway", gateway.to_string()));
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).json(&body).query(&query).build()?;
+            let mut request = client
+                .client
+                .get(url)
+                .json(&body)
+                .query(&progenitor_client::QueryParam::new("gateway", &gateway))
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -142,10 +142,13 @@ impl Client {
         body: &'a types::UnoBody,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
         let url = format!("{}/uno", self.baseurl,);
-        let mut query = Vec::with_capacity(1usize);
-        query.push(("gateway", gateway.to_string()));
         #[allow(unused_mut)]
-        let mut request = self.client.get(url).json(&body).query(&query).build()?;
+        let mut request = self
+            .client
+            .get(url)
+            .json(&body)
+            .query(&progenitor_client::QueryParam::new("gateway", &gateway))
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -30822,16 +30822,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30840,7 +30830,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31332,16 +31327,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31350,7 +31335,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31948,16 +31938,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31966,7 +31946,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32485,16 +32470,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32503,7 +32478,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33010,19 +32990,6 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
-            }
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33031,7 +32998,16 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("end_time", &end_time))
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "start_time",
+                    &start_time,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33197,16 +33173,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33215,7 +33181,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33676,16 +33647,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33694,7 +33655,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34172,16 +34138,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34190,7 +34146,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34835,16 +34796,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34853,7 +34804,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35624,16 +35580,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
-            }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
-            }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35642,7 +35588,15 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "from_start",
+                    &from_start,
+                ))
+                .query(&progenitor_client::QueryParam::new("max_bytes", &max_bytes))
+                .query(&progenitor_client::QueryParam::new(
+                    "most_recent",
+                    &most_recent,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36239,16 +36193,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36257,7 +36201,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36719,16 +36668,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36737,7 +36676,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37563,16 +37507,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37581,7 +37515,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38256,16 +38195,6 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38274,7 +38203,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39006,16 +38940,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39024,7 +38948,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39700,16 +39629,6 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39718,7 +39637,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39948,13 +39872,6 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39963,7 +39880,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40192,16 +40113,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40210,7 +40121,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40339,16 +40255,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40357,7 +40263,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40861,16 +40772,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40879,7 +40780,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41205,16 +41111,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41223,7 +41119,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41352,16 +41253,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41370,7 +41261,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41559,16 +41455,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41577,7 +41463,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41784,16 +41675,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41802,7 +41683,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41931,16 +41817,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41949,7 +41825,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42269,16 +42150,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42287,7 +42158,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42698,13 +42574,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42713,7 +42582,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43024,13 +42897,6 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43039,7 +42905,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43329,20 +43199,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
-            }
-            query.push(("id", id.to_string()));
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43351,7 +43207,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("end_time", &end_time))
+                .query(&progenitor_client::QueryParam::new("id", &id))
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "start_time",
+                    &start_time,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43548,16 +43414,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43566,7 +43422,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43755,16 +43616,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43773,7 +43624,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44111,16 +43967,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44129,7 +43975,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44877,16 +44728,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44895,7 +44736,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45103,16 +44949,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45121,7 +44957,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45296,13 +45137,6 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45311,7 +45145,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45439,16 +45277,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45457,7 +45285,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45616,22 +45449,6 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45640,7 +45457,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45781,11 +45608,6 @@ pub mod builder {
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            query.push(("project", project.to_string()));
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45795,7 +45617,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45881,13 +45707,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45896,7 +45715,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45982,13 +45805,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45997,7 +45813,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46110,22 +45930,6 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46134,7 +45938,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46275,11 +46089,6 @@ pub mod builder {
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            query.push(("project", project.to_string()));
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46289,7 +46098,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46375,13 +46188,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46390,7 +46196,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46476,13 +46286,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46491,7 +46294,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46622,22 +46429,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46646,7 +46437,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46806,13 +46607,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46822,7 +46616,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46934,13 +46732,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46950,7 +46741,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47062,13 +46857,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47078,7 +46866,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47164,13 +46956,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47179,7 +46964,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47312,22 +47101,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
-            }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
-            }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47336,7 +47109,20 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "from_start",
+                    &from_start,
+                ))
+                .query(&progenitor_client::QueryParam::new("max_bytes", &max_bytes))
+                .query(&progenitor_client::QueryParam::new(
+                    "most_recent",
+                    &most_recent,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47425,18 +47211,15 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -47527,13 +47310,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47542,7 +47318,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47628,13 +47408,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47643,7 +47416,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47726,16 +47503,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47744,7 +47511,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48338,19 +48110,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48359,7 +48118,16 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48484,8 +48252,6 @@ pub mod builder {
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(1usize);
-            query.push(("organization", organization.to_string()));
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48495,7 +48261,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48566,10 +48335,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48578,7 +48343,10 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48675,10 +48443,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48688,7 +48452,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48759,10 +48526,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48771,7 +48534,10 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48844,10 +48610,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48856,7 +48618,10 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48957,10 +48722,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48970,7 +48731,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49054,16 +48818,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49072,7 +48826,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49203,16 +48962,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49221,7 +48970,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49567,16 +49321,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49585,7 +49329,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -30672,16 +30672,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30690,7 +30680,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31182,16 +31177,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31200,7 +31185,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31798,16 +31788,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31816,7 +31796,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32335,16 +32320,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32353,7 +32328,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32860,19 +32840,6 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
-            }
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32881,7 +32848,16 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("end_time", &end_time))
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "start_time",
+                    &start_time,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33047,16 +33023,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33065,7 +33031,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33526,16 +33497,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33544,7 +33505,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34022,16 +33988,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34040,7 +33996,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34685,16 +34646,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34703,7 +34654,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35474,16 +35430,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
-            }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
-            }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35492,7 +35438,15 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "from_start",
+                    &from_start,
+                ))
+                .query(&progenitor_client::QueryParam::new("max_bytes", &max_bytes))
+                .query(&progenitor_client::QueryParam::new(
+                    "most_recent",
+                    &most_recent,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36089,16 +36043,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36107,7 +36051,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36569,16 +36518,6 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36587,7 +36526,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37413,16 +37357,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37431,7 +37365,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38106,16 +38045,6 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38124,7 +38053,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38856,16 +38790,6 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38874,7 +38798,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39550,16 +39479,6 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39568,7 +39487,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39798,13 +39722,6 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39813,7 +39730,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40042,16 +39963,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40060,7 +39971,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40189,16 +40105,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40207,7 +40113,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40711,16 +40622,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40729,7 +40630,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41055,16 +40961,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41073,7 +40969,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41202,16 +41103,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41220,7 +41111,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41409,16 +41305,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41427,7 +41313,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41634,16 +41525,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41652,7 +41533,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41781,16 +41667,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41799,7 +41675,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42119,16 +42000,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42137,7 +42008,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42548,13 +42424,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42563,7 +42432,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42874,13 +42747,6 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42889,7 +42755,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43179,20 +43049,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
-            }
-            query.push(("id", id.to_string()));
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43201,7 +43057,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("end_time", &end_time))
+                .query(&progenitor_client::QueryParam::new("id", &id))
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "start_time",
+                    &start_time,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43398,16 +43264,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43416,7 +43272,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43605,16 +43466,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43623,7 +43474,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43961,16 +43817,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43979,7 +43825,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44727,16 +44578,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44745,7 +44586,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44953,16 +44799,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44971,7 +44807,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45146,13 +44987,6 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45161,7 +44995,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45289,16 +45127,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45307,7 +45135,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45466,22 +45299,6 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45490,7 +45307,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45631,11 +45458,6 @@ pub mod builder {
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            query.push(("project", project.to_string()));
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45645,7 +45467,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45731,13 +45557,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45746,7 +45565,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45832,13 +45655,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45847,7 +45663,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45960,22 +45780,6 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45984,7 +45788,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46125,11 +45939,6 @@ pub mod builder {
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            query.push(("project", project.to_string()));
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46139,7 +45948,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46225,13 +46038,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46240,7 +46046,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46326,13 +46136,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46341,7 +46144,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46472,22 +46279,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46496,7 +46287,17 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46656,13 +46457,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46672,7 +46466,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46784,13 +46582,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46800,7 +46591,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46912,13 +46707,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46928,7 +46716,11 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47014,13 +46806,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47029,7 +46814,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47162,22 +46951,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
-            }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
-            }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47186,7 +46959,20 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "from_start",
+                    &from_start,
+                ))
+                .query(&progenitor_client::QueryParam::new("max_bytes", &max_bytes))
+                .query(&progenitor_client::QueryParam::new(
+                    "most_recent",
+                    &most_recent,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47275,18 +47061,15 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -47377,13 +47160,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47392,7 +47168,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47478,13 +47258,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47493,7 +47266,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new("project", &project))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47576,16 +47353,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47594,7 +47361,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48188,19 +47960,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48209,7 +47968,16 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48334,8 +48102,6 @@ pub mod builder {
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(1usize);
-            query.push(("organization", organization.to_string()));
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48345,7 +48111,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48416,10 +48185,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48428,7 +48193,10 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48525,10 +48293,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48538,7 +48302,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48609,10 +48376,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48621,7 +48384,10 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48694,10 +48460,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48706,7 +48468,10 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48807,10 +48572,6 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48820,7 +48581,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new(
+                    "organization",
+                    &organization,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48904,16 +48668,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48922,7 +48676,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49053,16 +48812,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49071,7 +48820,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49417,16 +49171,6 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49435,7 +49179,12 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -14585,19 +14585,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/groups", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14606,7 +14593,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14836,19 +14828,6 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14857,7 +14836,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15179,19 +15163,6 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15200,7 +15171,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15466,19 +15442,6 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15487,7 +15450,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15719,23 +15687,6 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
-        let mut query = Vec::with_capacity(4usize);
-        if let Some(v) = &end_time {
-            query.push(("end_time", v.to_string()));
-        }
-
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &start_time {
-            query.push(("start_time", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15744,7 +15695,16 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("end_time", &end_time))
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new(
+                "start_time",
+                &start_time,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15858,19 +15818,6 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15879,7 +15826,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16109,19 +16061,6 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16130,7 +16069,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16360,19 +16304,6 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16381,7 +16312,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16665,19 +16601,6 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16686,7 +16609,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17024,19 +16952,6 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &from_start {
-            query.push(("from_start", v.to_string()));
-        }
-
-        if let Some(v) = &max_bytes {
-            query.push(("max_bytes", v.to_string()));
-        }
-
-        if let Some(v) = &most_recent {
-            query.push(("most_recent", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17045,7 +16960,15 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "from_start",
+                &from_start,
+            ))
+            .query(&progenitor_client::QueryParam::new("max_bytes", &max_bytes))
+            .query(&progenitor_client::QueryParam::new(
+                "most_recent",
+                &most_recent,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17306,19 +17229,6 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17327,7 +17237,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17549,19 +17464,6 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17570,7 +17472,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17920,19 +17827,6 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17941,7 +17835,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18227,19 +18126,6 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18248,7 +18134,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18544,19 +18435,6 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18565,7 +18443,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18849,19 +18732,6 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18870,7 +18740,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19028,15 +18903,6 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
         let url = format!("{}/roles", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19045,7 +18911,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19182,19 +19052,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/groups", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19203,7 +19060,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19276,19 +19138,6 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19297,7 +19146,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19589,19 +19443,6 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/certificates", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19610,7 +19451,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19795,19 +19641,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/disks", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19816,7 +19649,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19888,19 +19726,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/racks", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19909,7 +19734,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20018,19 +19848,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/sleds", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20039,7 +19856,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20154,19 +19976,6 @@ impl Client {
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20175,7 +19984,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20254,19 +20068,6 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/images", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20275,7 +20076,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20462,19 +20268,6 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20483,7 +20276,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20699,15 +20497,6 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20716,7 +20505,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20894,15 +20687,6 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20911,7 +20695,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21057,24 +20845,6 @@ impl Client {
             self.baseurl,
             encode_path(&metric_name.to_string()),
         );
-        let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &end_time {
-            query.push(("end_time", v.to_string()));
-        }
-
-        query.push(("id", id.to_string()));
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &start_time {
-            query.push(("start_time", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21083,7 +20853,17 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("end_time", &end_time))
+            .query(&progenitor_client::QueryParam::new("id", &id))
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new(
+                "start_time",
+                &start_time,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21177,19 +20957,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/sagas", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21198,7 +20965,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21306,19 +21078,6 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/silos", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21327,7 +21086,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21518,19 +21282,6 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21539,7 +21290,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21920,19 +21676,6 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21941,7 +21684,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22055,19 +21803,6 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/user", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22076,7 +21811,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22184,15 +21924,6 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
         let url = format!("{}/timeseries/schema", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22201,7 +21932,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22271,19 +22006,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
         let url = format!("{}/users", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22292,7 +22014,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22367,27 +22094,6 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
-        let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22396,7 +22102,17 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22465,12 +22181,6 @@ impl Client {
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        query.push(("project", project.to_string()));
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22480,7 +22190,11 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22510,15 +22224,6 @@ impl Client {
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22527,7 +22232,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22557,15 +22266,6 @@ impl Client {
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22574,7 +22274,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22610,27 +22314,6 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
-        let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22639,7 +22322,17 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22709,12 +22402,6 @@ impl Client {
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        query.push(("project", project.to_string()));
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22724,7 +22411,11 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22754,15 +22445,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22771,7 +22453,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22801,15 +22487,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22818,7 +22495,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22860,27 +22541,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22889,7 +22549,17 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22972,15 +22642,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22990,7 +22651,11 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23021,15 +22686,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23039,7 +22695,11 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23070,15 +22730,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23088,7 +22739,11 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23118,15 +22773,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23135,7 +22781,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23184,27 +22834,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &from_start {
-            query.push(("from_start", v.to_string()));
-        }
-
-        if let Some(v) = &max_bytes {
-            query.push(("max_bytes", v.to_string()));
-        }
-
-        if let Some(v) = &most_recent {
-            query.push(("most_recent", v.to_string()));
-        }
-
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23213,7 +22842,20 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "from_start",
+                &from_start,
+            ))
+            .query(&progenitor_client::QueryParam::new("max_bytes", &max_bytes))
+            .query(&progenitor_client::QueryParam::new(
+                "most_recent",
+                &most_recent,
+            ))
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23244,20 +22886,15 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
             .get(url)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -23292,15 +22929,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23309,7 +22937,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23339,15 +22971,6 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23356,7 +22979,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new("project", &project))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23388,19 +23015,6 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/organizations", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23409,7 +23023,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23694,23 +23313,6 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/projects", self.baseurl,);
-        let mut query = Vec::with_capacity(4usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23719,7 +23321,16 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23785,8 +23396,6 @@ impl Client {
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
         let url = format!("{}/v1/projects", self.baseurl,);
-        let mut query = Vec::with_capacity(1usize);
-        query.push(("organization", organization.to_string()));
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23796,7 +23405,10 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23825,11 +23437,6 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23838,7 +23445,10 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23868,11 +23478,6 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23882,7 +23487,10 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23911,11 +23519,6 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23924,7 +23527,10 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23953,11 +23559,6 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23966,7 +23567,10 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23996,11 +23600,6 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -24010,7 +23609,10 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new(
+                "organization",
+                &organization,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -24042,19 +23644,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/components", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -24063,7 +23652,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -24135,19 +23729,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/deployments", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -24156,7 +23737,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -24357,19 +23943,6 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/updates", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -24378,7 +23951,12 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
+            .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -245,14 +245,16 @@ pub mod builder {
                 _client.baseurl,
                 encode_path(&query.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
-            _query.push(("client", client.to_string()));
-            _query.push(("request", request.to_string()));
-            _query.push(("response", response.to_string()));
-            _query.push(("result", result.to_string()));
-            _query.push(("url", url.to_string()));
             #[allow(unused_mut)]
-            let mut _request = _client.client.get(_url).query(&_query).build()?;
+            let mut _request = _client
+                .client
+                .get(_url)
+                .query(&progenitor_client::QueryParam::new("client", &client))
+                .query(&progenitor_client::QueryParam::new("request", &request))
+                .query(&progenitor_client::QueryParam::new("response", &response))
+                .query(&progenitor_client::QueryParam::new("result", &result))
+                .query(&progenitor_client::QueryParam::new("url", &url))
+                .build()?;
             let _result = _client.client.execute(_request).await;
             let _response = _result?;
             match _response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -245,14 +245,16 @@ pub mod builder {
                 _client.baseurl,
                 encode_path(&query.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
-            _query.push(("client", client.to_string()));
-            _query.push(("request", request.to_string()));
-            _query.push(("response", response.to_string()));
-            _query.push(("result", result.to_string()));
-            _query.push(("url", url.to_string()));
             #[allow(unused_mut)]
-            let mut _request = _client.client.get(_url).query(&_query).build()?;
+            let mut _request = _client
+                .client
+                .get(_url)
+                .query(&progenitor_client::QueryParam::new("client", &client))
+                .query(&progenitor_client::QueryParam::new("request", &request))
+                .query(&progenitor_client::QueryParam::new("response", &response))
+                .query(&progenitor_client::QueryParam::new("result", &result))
+                .query(&progenitor_client::QueryParam::new("url", &url))
+                .build()?;
             let _result = _client.client.execute(_request).await;
             let _response = _result?;
             match _response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -125,14 +125,16 @@ impl Client {
         url: bool,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let _url = format!("{}/key/{}", self.baseurl, encode_path(&query.to_string()),);
-        let mut _query = Vec::with_capacity(5usize);
-        _query.push(("client", client.to_string()));
-        _query.push(("request", request.to_string()));
-        _query.push(("response", response.to_string()));
-        _query.push(("result", result.to_string()));
-        _query.push(("url", url.to_string()));
         #[allow(unused_mut)]
-        let mut _request = self.client.get(_url).query(&_query).build()?;
+        let mut _request = self
+            .client
+            .get(_url)
+            .query(&progenitor_client::QueryParam::new("client", &client))
+            .query(&progenitor_client::QueryParam::new("request", &request))
+            .query(&progenitor_client::QueryParam::new("response", &response))
+            .query(&progenitor_client::QueryParam::new("result", &result))
+            .query(&progenitor_client::QueryParam::new("url", &url))
+            .build()?;
         let _result = self.client.execute(_request).await;
         let _response = _result?;
         match _response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -180,15 +180,16 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &key {
-                query.push(("key", v.to_string()));
-            }
-            if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
-            }
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).query(&query).build()?;
+            let mut request = client
+                .client
+                .get(url)
+                .query(&progenitor_client::QueryParam::new("key", &key))
+                .query(&progenitor_client::QueryParam::new(
+                    "uniqueKey",
+                    &unique_key,
+                ))
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -180,15 +180,16 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &key {
-                query.push(("key", v.to_string()));
-            }
-            if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
-            }
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).query(&query).build()?;
+            let mut request = client
+                .client
+                .get(url)
+                .query(&progenitor_client::QueryParam::new("key", &key))
+                .query(&progenitor_client::QueryParam::new(
+                    "uniqueKey",
+                    &unique_key,
+                ))
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -119,17 +119,16 @@ impl Client {
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/key", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &key {
-            query.push(("key", v.to_string()));
-        }
-
-        if let Some(v) = &unique_key {
-            query.push(("uniqueKey", v.to_string()));
-        }
-
         #[allow(unused_mut)]
-        let mut request = self.client.get(url).query(&query).build()?;
+        let mut request = self
+            .client
+            .get(url)
+            .query(&progenitor_client::QueryParam::new("key", &key))
+            .query(&progenitor_client::QueryParam::new(
+                "uniqueKey",
+                &unique_key,
+            ))
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -158,10 +158,6 @@ impl Client {
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        query.push(("if", if_.to_string()));
-        query.push(("in", in_.to_string()));
-        query.push(("use", use_.to_string()));
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -170,7 +166,9 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("if", &if_))
+            .query(&progenitor_client::QueryParam::new("in", &in_))
+            .query(&progenitor_client::QueryParam::new("use", &use_))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -417,13 +417,6 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -432,7 +425,11 @@ pub mod builder {
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&progenitor_client::QueryParam::new("limit", &limit))
+                .query(&progenitor_client::QueryParam::new(
+                    "page_token",
+                    &page_token,
+                ))
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -201,15 +201,6 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::Uint32ResultsPage>, Error<types::Error>> {
         let url = format!("{}/", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -218,7 +209,11 @@ impl Client {
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&progenitor_client::QueryParam::new("limit", &limit))
+            .query(&progenitor_client::QueryParam::new(
+                "page_token",
+                &page_token,
+            ))
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/sample_openapi/buildomat.json
+++ b/sample_openapi/buildomat.json
@@ -473,6 +473,42 @@
           }
         }
       }
+    },
+    "/v1/things": {
+      "get": {
+        "operationId": "get_thing_or_things",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "yes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
Closes #268, #409, #692, #724, #994.

Query parameters can be scalar values (string, numbers, etc.) today, but per the spec they may be arrays or objects. This PR addresses that gap by adding a proxy `serde::Serializer` (called `progenitor_client::QueryParam`) that adds proper handling of arrays. It also modifies code generation to properly handle all valid input types for query parameters. See #692 for a discussion of the alternatives.

Here's an example of the before and after for generated code:

before
```rust
            let mut query = Vec::with_capacity(1usize);
            if let Some(v) = &minseq {
                query.push(("minseq", v.to_string()));
            }
            #[allow(unused_mut)]
            let mut request = client
                .client
                .get(url)
                .header(
                    reqwest::header::ACCEPT,
                    reqwest::header::HeaderValue::from_static("application/json"),
                )
                .query(&query)
                .build()?;
```

after
```rust
            #[allow(unused_mut)]
            let mut request = client
                .client
                .get(url)
                .header(
                    reqwest::header::ACCEPT,
                    reqwest::header::HeaderValue::from_static("application/json"),
                )
                .query(&progenitor_client::QueryParam::new("minseq", &minseq))
                .build()?;
```

Note that due to behavior in `reqwest` described in #692, this does not address the existing gap regarding query parameters that are not `style=form` and `explode=true` (i.e. the default).