### PR TITLE
a body property named `default` generates non-compiling code

### DIFF
--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -283,10 +283,14 @@ pub mod types {
     ///{
     ///  "type": "object",
     ///  "required": [
+    ///    "default",
     ///    "name",
     ///    "script"
     ///  ],
     ///  "properties": {
+    ///    "default": {
+    ///      "type": "boolean"
+    ///    },
     ///    "name": {
     ///      "type": "string"
     ///    },
@@ -307,6 +311,7 @@ pub mod types {
         :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema,
     )]
     pub struct TaskSubmit {
+        pub default: bool,
         pub name: ::std::string::String,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub output_rules: ::std::vec::Vec<::std::string::String>,
@@ -1317,6 +1322,7 @@ pub mod types {
 
         #[derive(Clone, Debug)]
         pub struct TaskSubmit {
+            default: ::std::result::Result<bool, ::std::string::String>,
             name: ::std::result::Result<::std::string::String, ::std::string::String>,
             output_rules: ::std::result::Result<
                 ::std::vec::Vec<::std::string::String>,
@@ -1328,6 +1334,7 @@ pub mod types {
         impl ::std::default::Default for TaskSubmit {
             fn default() -> Self {
                 Self {
+                    default: Err("no value supplied for default".to_string()),
                     name: Err("no value supplied for name".to_string()),
                     output_rules: Ok(Default::default()),
                     script: Err("no value supplied for script".to_string()),
@@ -1336,6 +1343,16 @@ pub mod types {
         }
 
         impl TaskSubmit {
+            pub fn default<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<bool>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.default = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for default: {}", e));
+                self
+            }
             pub fn name<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::string::String>,
@@ -1374,6 +1391,7 @@ pub mod types {
                 value: TaskSubmit,
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
+                    default: value.default?,
                     name: value.name?,
                     output_rules: value.output_rules?,
                     script: value.script?,
@@ -1384,6 +1402,7 @@ pub mod types {
         impl ::std::convert::From<super::TaskSubmit> for TaskSubmit {
             fn from(value: super::TaskSubmit) -> Self {
                 Self {
+                    default: Ok(value.default),
                     name: Ok(value.name),
                     output_rules: Ok(value.output_rules),
                     script: Ok(value.script),
@@ -2786,7 +2805,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::TaskSubmit::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3049,7 +3068,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::UserCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3199,7 +3218,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::WorkerBootstrap::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3299,7 +3318,7 @@ pub mod builder {
             Self {
                 client: client,
                 task: Err("task was not initialized".to_string()),
-                body: Ok(types::builder::WorkerAppendTask::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3445,7 +3464,7 @@ pub mod builder {
             Self {
                 client: client,
                 task: Err("task was not initialized".to_string()),
-                body: Ok(types::builder::WorkerCompleteTask::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3519,7 +3538,7 @@ pub mod builder {
             Self {
                 client: client,
                 task: Err("task was not initialized".to_string()),
-                body: Ok(types::builder::WorkerAddOutput::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -275,10 +275,14 @@ pub mod types {
     ///{
     ///  "type": "object",
     ///  "required": [
+    ///    "default",
     ///    "name",
     ///    "script"
     ///  ],
     ///  "properties": {
+    ///    "default": {
+    ///      "type": "boolean"
+    ///    },
     ///    "name": {
     ///      "type": "string"
     ///    },
@@ -297,6 +301,7 @@ pub mod types {
     /// </details>
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
     pub struct TaskSubmit {
+        pub default: bool,
         pub name: ::std::string::String,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub output_rules: ::std::vec::Vec<::std::string::String>,
@@ -1277,6 +1282,7 @@ pub mod types {
 
         #[derive(Clone, Debug)]
         pub struct TaskSubmit {
+            default: ::std::result::Result<bool, ::std::string::String>,
             name: ::std::result::Result<::std::string::String, ::std::string::String>,
             output_rules: ::std::result::Result<
                 ::std::vec::Vec<::std::string::String>,
@@ -1288,6 +1294,7 @@ pub mod types {
         impl ::std::default::Default for TaskSubmit {
             fn default() -> Self {
                 Self {
+                    default: Err("no value supplied for default".to_string()),
                     name: Err("no value supplied for name".to_string()),
                     output_rules: Ok(Default::default()),
                     script: Err("no value supplied for script".to_string()),
@@ -1296,6 +1303,16 @@ pub mod types {
         }
 
         impl TaskSubmit {
+            pub fn default<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<bool>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.default = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for default: {}", e));
+                self
+            }
             pub fn name<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::string::String>,
@@ -1334,6 +1351,7 @@ pub mod types {
                 value: TaskSubmit,
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
+                    default: value.default?,
                     name: value.name?,
                     output_rules: value.output_rules?,
                     script: value.script?,
@@ -1344,6 +1362,7 @@ pub mod types {
         impl ::std::convert::From<super::TaskSubmit> for TaskSubmit {
             fn from(value: super::TaskSubmit) -> Self {
                 Self {
+                    default: Ok(value.default),
                     name: Ok(value.name),
                     output_rules: Ok(value.output_rules),
                     script: Ok(value.script),
@@ -2746,7 +2765,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::TaskSubmit::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3009,7 +3028,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::UserCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3159,7 +3178,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::WorkerBootstrap::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3259,7 +3278,7 @@ pub mod builder {
             Self {
                 client: client,
                 task: Err("task was not initialized".to_string()),
-                body: Ok(types::builder::WorkerAppendTask::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3405,7 +3424,7 @@ pub mod builder {
             Self {
                 client: client,
                 task: Err("task was not initialized".to_string()),
-                body: Ok(types::builder::WorkerCompleteTask::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3479,7 +3498,7 @@ pub mod builder {
             Self {
                 client: client,
                 task: Err("task was not initialized".to_string()),
-                body: Ok(types::builder::WorkerAddOutput::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/buildomat_cli.rs
+++ b/progenitor-impl/tests/output/src/buildomat_cli.rs
@@ -57,6 +57,12 @@ impl<T: CliConfig> Cli<T> {
     pub fn cli_task_submit() -> ::clap::Command {
         ::clap::Command::new("")
             .arg(
+                ::clap::Arg::new("default")
+                    .long("default")
+                    .value_parser(::clap::value_parser!(bool))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
                 ::clap::Arg::new("name")
                     .long("name")
                     .value_parser(::clap::value_parser!(::std::string::String))
@@ -416,6 +422,10 @@ impl<T: CliConfig> Cli<T> {
 
     pub async fn execute_task_submit(&self, matches: &::clap::ArgMatches) -> anyhow::Result<()> {
         let mut request = self.client.task_submit();
+        if let Some(value) = matches.get_one::<bool>("default") {
+            request = request.body_map(|body| body.default(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<::std::string::String>("name") {
             request = request.body_map(|body| body.name(value.clone()))
         }

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -252,10 +252,14 @@ pub mod types {
     ///{
     ///  "type": "object",
     ///  "required": [
+    ///    "default",
     ///    "name",
     ///    "script"
     ///  ],
     ///  "properties": {
+    ///    "default": {
+    ///      "type": "boolean"
+    ///    },
     ///    "name": {
     ///      "type": "string"
     ///    },
@@ -274,6 +278,7 @@ pub mod types {
     /// </details>
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
     pub struct TaskSubmit {
+        pub default: bool,
         pub name: ::std::string::String,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub output_rules: ::std::vec::Vec<::std::string::String>,

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -242,7 +242,7 @@ pub mod builder {
             Self {
                 client: client,
                 gateway: Err("gateway was not initialized".to_string()),
-                body: Ok(types::builder::UnoBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -240,7 +240,7 @@ pub mod builder {
             Self {
                 client: client,
                 gateway: Err("gateway was not initialized".to_string()),
-                body: Ok(types::builder::UnoBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1432,7 +1432,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::EnrolBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -1623,7 +1623,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::ReportFinishBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -1708,7 +1708,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::ReportOutputBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -1793,7 +1793,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::ReportStartBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1412,7 +1412,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::EnrolBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -1603,7 +1603,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::ReportFinishBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -1688,7 +1688,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::ReportOutputBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -1773,7 +1773,7 @@ pub mod builder {
             Self {
                 client: client,
                 authorization: Err("authorization was not initialized".to_string()),
-                body: Ok(types::builder::ReportStartBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -30580,7 +30580,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::DeviceAuthRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30637,7 +30637,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::DeviceAuthVerify::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30708,7 +30708,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::DeviceAccessTokenRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30916,7 +30916,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SpoofLoginBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30987,7 +30987,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::UsernamePasswordCredentials::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -31426,7 +31426,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::OrganizationCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -31562,7 +31562,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -31782,7 +31782,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -32045,7 +32045,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
-                body: Ok(types::builder::ProjectCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -32217,7 +32217,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::ProjectUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -32584,7 +32584,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::DiskCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -33296,7 +33296,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::ImageCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -33776,7 +33776,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::InstanceCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34274,7 +34274,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::DiskIdentifier::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34396,7 +34396,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::DiskIdentifier::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34615,7 +34615,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::InstanceMigrate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34937,7 +34937,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::NetworkInterfaceCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -35179,7 +35179,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
                 interface_name: Err("interface_name was not initialized".to_string()),
-                body: Ok(types::builder::NetworkInterfaceUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -36045,7 +36045,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::ProjectRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -36339,7 +36339,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::SnapshotCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -36818,7 +36818,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -37021,7 +37021,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -37335,7 +37335,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcFirewallRuleUpdateParams::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -37665,7 +37665,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcRouterCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -37899,7 +37899,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 router_name: Err("router_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcRouterUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -38360,7 +38360,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 router_name: Err("router_name was not initialized".to_string()),
-                body: Ok(types::builder::RouterRouteCreateParams::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -38630,7 +38630,7 @@ pub mod builder {
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 router_name: Err("router_name was not initialized".to_string()),
                 route_name: Err("route_name was not initialized".to_string()),
-                body: Ok(types::builder::RouterRouteUpdateParams::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -39108,7 +39108,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcSubnetCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -39342,7 +39342,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 subnet_name: Err("subnet_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcSubnetUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -39839,7 +39839,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SiloRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -40433,7 +40433,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SshKeyCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -40955,7 +40955,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::CertificateCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -42025,7 +42025,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::GlobalImageCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -42363,7 +42363,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::IpPoolCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -42494,7 +42494,7 @@ pub mod builder {
             Self {
                 client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
-                body: Ok(types::builder::IpPoolUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -43424,7 +43424,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::FleetRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -43849,7 +43849,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SiloCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -44208,7 +44208,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::UserCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -44473,7 +44473,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::SamlIdentityProviderCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -44716,7 +44716,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::SiloRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -45722,7 +45722,7 @@ pub mod builder {
                 client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
-                body: Ok(types::builder::DiskCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46216,7 +46216,7 @@ pub mod builder {
                 client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
-                body: Ok(types::builder::InstanceCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46730,7 +46730,7 @@ pub mod builder {
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
-                body: Ok(types::builder::DiskPath::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46858,7 +46858,7 @@ pub mod builder {
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
-                body: Ok(types::builder::DiskPath::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46986,7 +46986,7 @@ pub mod builder {
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
-                body: Ok(types::builder::InstanceMigrate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -47820,7 +47820,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::OrganizationCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -47956,7 +47956,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization: Err("organization was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48176,7 +48176,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization: Err("organization was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48438,7 +48438,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization: Err("organization was not initialized".to_string()),
-                body: Ok(types::builder::ProjectCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48612,7 +48612,7 @@ pub mod builder {
                 client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
-                body: Ok(types::builder::ProjectUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48890,7 +48890,7 @@ pub mod builder {
                 client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
-                body: Ok(types::builder::ProjectRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -49400,7 +49400,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SystemUpdateStart::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -30430,7 +30430,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::DeviceAuthRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30487,7 +30487,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::DeviceAuthVerify::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30558,7 +30558,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::DeviceAccessTokenRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30766,7 +30766,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SpoofLoginBody::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -30837,7 +30837,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::UsernamePasswordCredentials::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -31276,7 +31276,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::OrganizationCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -31412,7 +31412,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -31632,7 +31632,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -31895,7 +31895,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
-                body: Ok(types::builder::ProjectCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -32067,7 +32067,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::ProjectUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -32434,7 +32434,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::DiskCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -33146,7 +33146,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::ImageCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -33626,7 +33626,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::InstanceCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34124,7 +34124,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::DiskIdentifier::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34246,7 +34246,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::DiskIdentifier::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34465,7 +34465,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::InstanceMigrate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -34787,7 +34787,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
-                body: Ok(types::builder::NetworkInterfaceCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -35029,7 +35029,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
                 interface_name: Err("interface_name was not initialized".to_string()),
-                body: Ok(types::builder::NetworkInterfaceUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -35895,7 +35895,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::ProjectRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -36189,7 +36189,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::SnapshotCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -36668,7 +36668,7 @@ pub mod builder {
                 client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -36871,7 +36871,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -37185,7 +37185,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcFirewallRuleUpdateParams::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -37515,7 +37515,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcRouterCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -37749,7 +37749,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 router_name: Err("router_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcRouterUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -38210,7 +38210,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 router_name: Err("router_name was not initialized".to_string()),
-                body: Ok(types::builder::RouterRouteCreateParams::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -38480,7 +38480,7 @@ pub mod builder {
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 router_name: Err("router_name was not initialized".to_string()),
                 route_name: Err("route_name was not initialized".to_string()),
-                body: Ok(types::builder::RouterRouteUpdateParams::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -38958,7 +38958,7 @@ pub mod builder {
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcSubnetCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -39192,7 +39192,7 @@ pub mod builder {
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
                 subnet_name: Err("subnet_name was not initialized".to_string()),
-                body: Ok(types::builder::VpcSubnetUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -39689,7 +39689,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SiloRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -40283,7 +40283,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SshKeyCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -40805,7 +40805,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::CertificateCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -41875,7 +41875,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::GlobalImageCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -42213,7 +42213,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::IpPoolCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -42344,7 +42344,7 @@ pub mod builder {
             Self {
                 client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
-                body: Ok(types::builder::IpPoolUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -43274,7 +43274,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::FleetRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -43699,7 +43699,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SiloCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -44058,7 +44058,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::UserCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -44323,7 +44323,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::SamlIdentityProviderCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -44566,7 +44566,7 @@ pub mod builder {
             Self {
                 client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
-                body: Ok(types::builder::SiloRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -45572,7 +45572,7 @@ pub mod builder {
                 client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
-                body: Ok(types::builder::DiskCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46066,7 +46066,7 @@ pub mod builder {
                 client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
-                body: Ok(types::builder::InstanceCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46580,7 +46580,7 @@ pub mod builder {
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
-                body: Ok(types::builder::DiskPath::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46708,7 +46708,7 @@ pub mod builder {
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
-                body: Ok(types::builder::DiskPath::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -46836,7 +46836,7 @@ pub mod builder {
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
-                body: Ok(types::builder::InstanceMigrate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -47670,7 +47670,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::OrganizationCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -47806,7 +47806,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization: Err("organization was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48026,7 +48026,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization: Err("organization was not initialized".to_string()),
-                body: Ok(types::builder::OrganizationRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48288,7 +48288,7 @@ pub mod builder {
             Self {
                 client: client,
                 organization: Err("organization was not initialized".to_string()),
-                body: Ok(types::builder::ProjectCreate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48462,7 +48462,7 @@ pub mod builder {
                 client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
-                body: Ok(types::builder::ProjectUpdate::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -48740,7 +48740,7 @@ pub mod builder {
                 client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
-                body: Ok(types::builder::ProjectRolePolicy::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -49250,7 +49250,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::SystemUpdateStart::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3194,7 +3194,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::InstanceEnsureRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3348,7 +3348,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3528,7 +3528,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::InstanceStateMonitorRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -3149,7 +3149,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::InstanceEnsureRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3303,7 +3303,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 
@@ -3483,7 +3483,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::InstanceStateMonitorRequest::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -418,7 +418,7 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
-                body: Ok(types::builder::BodyWithDefaults::default()),
+                body: Ok(::std::default::Default::default()),
             }
         }
 

--- a/sample_openapi/buildomat.json
+++ b/sample_openapi/buildomat.json
@@ -568,9 +568,13 @@
           },
           "script": {
             "type": "string"
+          },
+          "default": {
+            "type": "boolean"
           }
         },
         "required": [
+          "default",
           "name",
           "script"
         ]


### PR DESCRIPTION
Fixes #557 

The problem was that we generated a builder like this:

```rust
            pub fn default<T>(mut self, value: T) -> Self
            where
                T: ::std::convert::TryInto<bool>,
                T::Error: ::std::fmt::Display,
            {
                self.default = value
                    .try_into()
                    .map_err(|e| format!("error converting supplied value for default: {}", e));
                self
            }
```

No problem there... until we tried to create the operation builder:

```rust
        pub fn new(client: &'a super::Client) -> Self {
            Self {
                client: client,
                body: Ok(types::builder::Foo::default()),
            }
        }
```

This PR changes the call to this:

```rust
        pub fn new(client: &'a super::Client) -> Self {
            Self {
                client: client,
                body: Ok(::std::default::Default::default()),
            }
        }
```