### PR TITLE
incorrect handling of unit and newtype variants as query params

### DIFF
--- a/progenitor-client/tests/client_test.rs
+++ b/progenitor-client/tests/client_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -101,10 +101,12 @@ fn test_query_enum_external() {
         Object { a: u64, b: u64 },
     }
     let value = Value::Simple;
-    encode_query_param("ignored", &value).expect_err("variant not supported");
+    let result = encode_query_param("paramValue", &value).unwrap();
+    assert_eq!(result, "paramValue=simple");
 
     let value = Value::Newtype(42);
-    encode_query_param("ignored", &value).expect_err("variant not supported");
+    let result = encode_query_param("ignored", &value).unwrap();
+    assert_eq!(result, "newtype=42");
 
     let value = Value::Tuple(1, 2);
     encode_query_param("ignored", &value).expect_err("variant not supported");


### PR DESCRIPTION
Fixes #1032 

#1017 regressed the handling of simple (unit) variants such as this as query params:

```rust
    pub enum NameOrIdSortMode {
        NameAscending,
        NameDescending,
        IdAscending,
    }
```

This results in an error like this: `Communication Error: builder error: builder error: top-level serializer supports only maps and structs`

This PR corrects the handling of these query params and also adds support for newtype variants.