### PR TITLE
allow OAS 3.0.4 and other versions starting with '3.0.'

### DIFF
--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -655,8 +655,6 @@ pub fn space_out_items(content: String) -> Result<String> {
 
 fn validate_openapi_spec_version(spec_version: &str) -> Result<()> {
     // progenitor currenlty only support OAS 3.0.x
-    // (a limitation coming from using the openapiv3 crate, see
-    // https://github.com/glademiller/openapiv3/issues/50)
     if spec_version.trim().starts_with("3.0.") {
         Ok(())
     } else {


### PR DESCRIPTION
Previously, progenitor explicitely check for support OAS versions. So it used to have a list of specific versions (3.0.0 .. 3.0.3) to match a version against.

Because minor spec updates are considered to be fully compatibly (according to semver) it makes more sense to check we're within the OAS 3.0.x version realm (so ignore the patch version component).

I briefly considered using a regex for matching, but using `.starts_with("3.0.")` seemed a fairly low overhead solution.