### PR TITLE
1105 progenitor requires operationid to be set

### DIFF
--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -24,7 +24,7 @@ struct CliOperation {
 impl Generator {
     /// Generate a `clap`-based CLI.
     pub fn cli(&mut self, spec: &OpenAPI, crate_name: &str) -> Result<TokenStream> {
-        validate_openapi(spec)?;
+        self.operation_ids = validate_openapi(spec)?;
 
         // Convert our components dictionary to schemars
         let schemas = spec.components.iter().flat_map(|components| {

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -30,7 +30,7 @@ impl Generator {
     /// the SDK. This can include `::` and instances of `-` in the crate name
     /// should be converted to `_`.
     pub fn httpmock(&mut self, spec: &OpenAPI, crate_path: &str) -> Result<TokenStream> {
-        validate_openapi(spec)?;
+        self.operation_ids = validate_openapi(spec)?;
 
         // Convert our components dictionary to schemars
         let schemas = spec.components.iter().flat_map(|components| {

--- a/progenitor-impl/src/opid.rs
+++ b/progenitor-impl/src/opid.rs
@@ -1,0 +1,259 @@
+use std::collections::BTreeMap;
+
+use super::{Error, Result};
+
+/// newtype for encapsulating the combination of path and method,
+/// which can uniquely identify a HTTP endpoint. The struct is
+/// designed to be used as a key for map implementations
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(super) struct PathMethod {
+    path: String,
+    method: String,
+}
+
+impl PathMethod {
+    /// Create new PathMethod. This may fail if path or method
+    /// are empty.
+    pub fn new(path: &str, method: &str) -> Result<Self> {
+        // disallow empty path/method
+        if path.is_empty() || method.is_empty() {
+            return Err(Error::InternalError(
+                "path and method may not be empty".to_string(),
+            ));
+        }
+
+        // NOTE: In the future, we may consider checking for the proper URL path
+        // format in the the future according to the RFC:
+        // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+
+        Ok(Self {
+            path: path.to_string(),
+            method: method.to_string(),
+        })
+    }
+}
+
+#[test]
+fn test_path_method() {
+    // check failure conditions
+    assert!(PathMethod::new("", "get").is_err());
+    assert!(PathMethod::new("/foo", "").is_err());
+    assert!(PathMethod::new("/foo", "get").is_ok());
+
+    // check content is actually stored
+    let pm = PathMethod::new("/foo", "get").unwrap();
+    assert_eq!(pm.path, "/foo");
+    assert_eq!(pm.method, "get");
+}
+
+/// Store for a one to one mapping between OAS operation IDs and
+/// path/method pairs. The store
+/// supports lookup in each direction.
+#[derive(Default, Debug)]
+pub struct OperationIds {
+    opid_to_path_method: BTreeMap<String, PathMethod>,
+    path_method_to_opid: BTreeMap<PathMethod, String>,
+}
+
+impl OperationIds {
+    /// Find operation ID for given path and method. Returns [`None`] if
+    /// no operation ID was found
+    pub fn opid_for_path_method(&self, path: &str, method: &str) -> Option<&str> {
+        let key = match PathMethod::new(path, method) {
+            Ok(path_method) => path_method,
+            Err(_) => return None,
+        };
+
+        self.path_method_to_opid.get(&key).map(|s| s.as_str())
+    }
+
+    /// Find path and method for a given operation ID. Returns [`None`] if
+    /// no path/method combination was fround for the given operation ID
+    pub fn path_method_for_opid(&self, operation_id: &str) -> Option<(&str, &str)> {
+        match self.opid_to_path_method.get(operation_id) {
+            Some(path_method) => Some((&path_method.path, &path_method.method)),
+            None => None,
+        }
+    }
+
+    /// Generate a new operation ID candidate for the given PathMethod, considering
+    /// the number of attempts that have already been made. The number of attempts
+    /// is included in the candiate name (unless it is 0), to help resolve name
+    /// collisions.
+    /// For generated operation IDs that would start with a number,
+    /// the character 'n' is prepended.
+    ///
+    /// The operation_id names are created with the pattern
+    /// `converted_path [attempt] converted_method`.
+    ///
+    /// For `GET /foo/bar`, this will yield an operation ID of `foo_bar_get`.
+    /// It was deliberately chosen to have the method part at the end of the
+    /// generated operation ID string, so that the main point of destinction
+    /// is the path.
+    /// This is useful when the operation ID is used to
+    /// generate client method names: `foo_bar_get` and `foo_bar_post` will
+    /// be listed next to each other in a method name list.
+    fn gen_operation_id(path_method: &PathMethod, attempt: u32) -> String {
+        let mut p: String = path_method
+            .path
+            .replace(|c: char| !c.is_alphanumeric(), "_")
+            .trim_matches('_')
+            .to_lowercase();
+        if p.starts_with(char::is_numeric) {
+            p.insert(0, 'n');
+        }
+
+        let m = path_method.method.to_lowercase();
+        if attempt == 0 {
+            format!("{p}_{m}")
+        } else {
+            format!("{p}{attempt}_{m}")
+        }
+    }
+
+    /// Insert a new operation ID with with it's path and method attached.
+    /// The method will fail if the operation ID, or the path and method
+    /// combination already exist in this [`OperationIds`] instance.
+    pub fn insert_opid_with_path_method(
+        &mut self,
+        operation_id: &str,
+        path: &str,
+        method: &str,
+    ) -> Result<()> {
+        let key = PathMethod::new(path, method)?;
+        if self.opid_to_path_method.contains_key(operation_id) {
+            return Err(Error::InternalError(format!(
+                "operation id is already present: {operation_id:?}"
+            )));
+        }
+        if self.path_method_to_opid.contains_key(&key) {
+            return Err(Error::InternalError(format!(
+                "the combination of path {} and method {} is already present",
+                key.path, key.method
+            )));
+        }
+
+        self.opid_to_path_method
+            .insert(operation_id.to_string(), key.clone());
+        self.path_method_to_opid
+            .insert(key, operation_id.to_string());
+        Ok(())
+    }
+
+    /// Insert a generated opid for the given path and method combination.
+    /// The method will choose an operation ID that does not collide
+    /// with pre existing operation IDs in this [`OperationIds`] instance.
+    /// The method will fail if the given path and methoc combination already
+    /// exists.
+    pub fn insert_synthetic_opid_for_path_method(
+        &mut self,
+        path: &str,
+        method: &str,
+    ) -> Result<()> {
+        let key = PathMethod::new(path, method)?;
+        if self.path_method_to_opid.contains_key(&key) {
+            return Err(Error::InternalError(format!(
+                "operation id is already present: {key:?}"
+            )));
+        }
+
+        let mut candidate;
+        let mut attempt = 0;
+
+        loop {
+            candidate = Self::gen_operation_id(&key, attempt);
+            attempt += 1;
+            if !self.opid_to_path_method.contains_key(&candidate) {
+                break;
+            }
+        }
+
+        self.path_method_to_opid
+            .insert(key.clone(), candidate.clone());
+        self.opid_to_path_method.insert(candidate, key);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+fn mk_pm(path: &str, method: &str) -> PathMethod {
+    PathMethod::new(path, method).unwrap()
+}
+
+#[test]
+fn test_operation_id_generation() {
+    assert_eq!(
+        OperationIds::gen_operation_id(&mk_pm("/foo/bar", "get"), 0),
+        "foo_bar_get"
+    );
+    assert_eq!(
+        OperationIds::gen_operation_id(&mk_pm("/foo/bar", "get"), 1),
+        "foo_bar1_get"
+    );
+    assert_eq!(
+        OperationIds::gen_operation_id(&mk_pm("/some.json", "get"), 0),
+        "some_json_get"
+    );
+}
+
+#[test]
+fn test_operation_ids() {
+    let mut opids = OperationIds::default();
+
+    // insert
+    opids
+        .insert_opid_with_path_method("foo_get", "/foo", "get")
+        .unwrap();
+    assert_eq!(opids.opid_for_path_method("/foo", "get"), Some("foo_get"));
+    assert_eq!(opids.path_method_for_opid("foo_get"), Some(("/foo", "get")));
+    opids
+        .insert_opid_with_path_method("foo_post", "/foo", "post")
+        .unwrap();
+    assert_eq!(opids.opid_for_path_method("/foo", "post"), Some("foo_post"));
+    assert_eq!(
+        opids.path_method_for_opid("foo_post"),
+        Some(("/foo", "post"))
+    );
+
+    // insert must fail because of collision with operation id
+    assert!(opids
+        .insert_opid_with_path_method("foo_get", "/bar", "get")
+        .is_err());
+
+    // insert must fail because of collision with path and method
+    assert!(opids
+        .insert_opid_with_path_method("bar_get", "/foo", "get")
+        .is_err());
+
+    // now check we can create synthetic operation ids:
+    assert!(opids
+        .insert_synthetic_opid_for_path_method("/bar", "get")
+        .is_ok());
+    assert_eq!(opids.opid_for_path_method("/bar", "get"), Some("bar_get"));
+    assert_eq!(opids.path_method_for_opid("bar_get"), Some(("/bar", "get")));
+    assert!(opids
+        .insert_synthetic_opid_for_path_method("/bar", "post")
+        .is_ok());
+    assert_eq!(opids.opid_for_path_method("/bar", "post"), Some("bar_post"));
+    assert_eq!(
+        opids.path_method_for_opid("bar_post"),
+        Some(("/bar", "post"))
+    );
+
+    // test collisions.
+    // we're going to collide with foo_bar_get
+    opids
+        .insert_opid_with_path_method("foo_bar_get", "/foobar", "get")
+        .unwrap();
+    opids
+        .insert_synthetic_opid_for_path_method("/foo/bar", "get")
+        .unwrap();
+    assert_eq!(
+        opids.opid_for_path_method("/foo/bar", "get"),
+        Some("foo_bar1_get")
+    );
+    assert_eq!(
+        opids.path_method_for_opid("foo_bar1_get"),
+        Some(("/foo/bar", "get"))
+    );
+}

--- a/progenitor-impl/src/opid.rs
+++ b/progenitor-impl/src/opid.rs
@@ -6,7 +6,7 @@ use super::{Error, Result};
 /// which can uniquely identify a HTTP endpoint. The struct is
 /// designed to be used as a key for map implementations
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(super) struct PathMethod {
+struct PathMethod {
     path: String,
     method: String,
 }

--- a/progenitor/tests/no_operation_id.rs
+++ b/progenitor/tests/no_operation_id.rs
@@ -2,6 +2,7 @@ mod no_operation_id_client {
     progenitor::generate_api!("../sample_openapi/no-operation-id.yaml");
 
     fn _ignore() {
+        let _ = Client::new("").root_get();
         let _ = Client::new("").bazooka();
         let _ = Client::new("").foo_bar_get();
         let _ = Client::new("").foo_bar_post();

--- a/progenitor/tests/no_operation_id.rs
+++ b/progenitor/tests/no_operation_id.rs
@@ -1,0 +1,9 @@
+mod no_operation_id_client {
+    progenitor::generate_api!("../sample_openapi/no-operation-id.yaml");
+
+    fn _ignore() {
+        let _ = Client::new("").bazooka();
+        let _ = Client::new("").foo_bar_get();
+        let _ = Client::new("").foo_bar_post();
+    }
+}

--- a/sample_openapi/no-operation-id.yaml
+++ b/sample_openapi/no-operation-id.yaml
@@ -4,8 +4,19 @@ info:
   title: Parameter override test
   version: v1
 paths:
+  "/":
+    # NOTE: the root path is special when generating an operationId
+    get:
+      responses:
+        "200":
+          description: return some JSON string
+          content:
+            "application/json":
+              schema:
+                type: string
   "/bazzz":
     get:
+      # NOTE: check if all is still well _with_ a set operationId
       operationId: "bazooka"
       responses:
         "200":
@@ -16,7 +27,7 @@ paths:
                 type: string
   "/foo/bar":
     get:
-      # NOTE: no operation_id is set
+      # NOTE: no operationId is set
       responses:
         "200":
           description: return some JSON string
@@ -25,7 +36,7 @@ paths:
               schema:
                 type: string
     post:
-      # NOTE: no operation_id is set
+      # NOTE: no operationId is set
       responses:
         "200":
           description: return some JSON string
@@ -35,7 +46,7 @@ paths:
                 type: string
   "/foo.bar":
     get:
-      # NOTE: no operation_id is set, however, the path will create a name collision
+      # NOTE: no operationId is set, however, the path will create a name collision
       # with GET /foo/bar
       responses:
         "200":

--- a/sample_openapi/no-operation-id.yaml
+++ b/sample_openapi/no-operation-id.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.0
+info:
+  description: Minimal API for testing parameter overrides
+  title: Parameter override test
+  version: v1
+paths:
+  "/bazzz":
+    get:
+      operationId: "bazooka"
+      responses:
+        "200":
+          description: return some JSON string
+          content:
+            "application/json":
+              schema:
+                type: string
+  "/foo/bar":
+    get:
+      # NOTE: no operation_id is set
+      responses:
+        "200":
+          description: return some JSON string
+          content:
+            "application/json":
+              schema:
+                type: string
+    post:
+      # NOTE: no operation_id is set
+      responses:
+        "200":
+          description: return some JSON string
+          content:
+            "application/json":
+              schema:
+                type: string
+  "/foo.bar":
+    get:
+      # NOTE: no operation_id is set, however, the path will create a name collision
+      # with GET /foo/bar
+      responses:
+        "200":
+          description: return some JSON string
+          content:
+            "application/json":
+              schema:
+                type: string


### PR DESCRIPTION
This PR modifies missing `operationId` handling from default-deny to default-generate. At this point there is no `GenerationSetting` for this to be configured, I expect the PR not to go through because of that (to add a `GenerationSetting` field I feel there is more discussion needed, however, I'm happy to it once it's clear how that is desired).

The algorithm used here tries to apply 'smart' heuristics and is, of course, opinionated. To capsule it all I introduced a the new module `opid` with a struct `OperationIds`, which stores mappings between the path method tuple and the `operationId` (generated or manually set).

The changes to `lib.rs` try to be minimal, most logic is in `opid.rs`, as well as most unit tests. 

`validate_openapi()` now runs two passes:
1. For all operations for which `operation_id` is present, store that in the `OperationIds` struct, together with their path/method mapping
2. For all operations that do not have an `operation_id, generate one and store it, again together with their path/method mapping

`OperationIds` is stored in the `Generator` instance.

Later, when requiring an `operation_id`, these are pulled from the `OperationIds` struct (rather than the `Operation` object directly as it has been previously).

Step 2 in above uses an algorithm to generate the name, which also handles collisions with both present `operationIds` and also its own generated ones. 

The name generation algorithm is described in detail in the `OperationIds::gen_operation_id()` method in the `opid.rs` file. The basic idea is that names derive from HTTP path and method, which are unique in combination. The path is stripped of non alphanumeric characters and lowercased, and the HTTP method is appended with a '_' prefix.
So 'GET /foo/bar' becomes `foo_bar_get`. There are more special cases which are documented and covered by the unit tests.

Thanks for reading all this, hope it helps with reviewing the PR :)