### PR TITLE
Implement From<Infallible> for client error

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -295,8 +295,8 @@ impl<E> Error<E> {
 }
 
 impl<E> From<std::convert::Infallible> for Error<E> {
-    fn from(_: std::convert::Infallible) -> Self {
-        unreachable!()
+    fn from(x: std::convert::Infallible) -> Self {
+        match x {}
     }
 }
 

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -294,6 +294,12 @@ impl<E> Error<E> {
     }
 }
 
+impl<E> From<std::convert::Infallible> for Error<E> {
+    fn from(_: std::convert::Infallible) -> Self {
+        unreachable!()
+    }
+}
+
 impl<E> From<reqwest::Error> for Error<E> {
     fn from(e: reqwest::Error) -> Self {
         Self::CommunicationError(e)


### PR DESCRIPTION
This is required if the spec contains schema types like

```
"CustomId": {
  "type": "string",
  "example": "WUjhaGp4EKah_ur11rSfHkzeV",
},
```