### PR TITLE
generate api-version headers for each request

### DIFF
--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -827,7 +827,7 @@ impl Generator {
             })
             .collect::<Vec<_>>();
 
-        let headers_size = headers.len();
+        let headers_size = headers.len() + 1;
         let headers_build = quote! {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(#headers_size);
             header_map.append(

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -827,19 +827,19 @@ impl Generator {
             })
             .collect::<Vec<_>>();
 
-        let (headers_build, headers_use) = if headers.is_empty() {
-            (quote! {}, quote! {})
-        } else {
-            let size = headers.len();
-            let headers_build = quote! {
-                let mut header_map = ::reqwest::header::HeaderMap::with_capacity(#size);
-                #(#headers)*
-            };
-            let headers_use = quote! {
-                .headers(header_map)
-            };
+        let headers_size = headers.len();
+        let headers_build = quote! {
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(#headers_size);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(#client.api_version()),
+            );
 
-            (headers_build, headers_use)
+            #(#headers)*
+        };
+
+        let headers_use = quote! {
+            .headers(header_map)
         };
 
         let websock_hdrs = if method.dropshot_websocket {

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2814,7 +2814,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -2855,7 +2855,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -2907,7 +2907,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -2948,7 +2948,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3016,7 +3016,7 @@ pub mod builder {
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3097,7 +3097,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3160,7 +3160,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3238,7 +3238,7 @@ pub mod builder {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3298,7 +3298,7 @@ pub mod builder {
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3340,7 +3340,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3397,7 +3397,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/whoami/name", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3466,7 +3466,7 @@ pub mod builder {
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3508,7 +3508,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3595,7 +3595,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3665,7 +3665,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3757,7 +3757,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3839,7 +3839,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3877,7 +3877,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3918,7 +3918,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3967,7 +3967,7 @@ pub mod builder {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/things", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -4027,7 +4027,7 @@ pub mod builder {
             } = self;
             let accept_language = accept_language.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/header-arg", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2814,6 +2814,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2822,6 +2827,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2849,8 +2855,13 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).build()?;
+            let mut request = client.client.post(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2896,6 +2907,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2904,6 +2920,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2931,6 +2948,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2939,6 +2961,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2993,6 +3016,11 @@ pub mod builder {
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3002,6 +3030,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3068,6 +3097,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3077,6 +3111,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .query(&progenitor_client::QueryParam::new("minseq", &minseq))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3125,6 +3160,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3133,6 +3173,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3197,8 +3238,13 @@ pub mod builder {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).build()?;
+            let mut request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3252,6 +3298,11 @@ pub mod builder {
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3261,6 +3312,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3288,6 +3340,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3296,6 +3353,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3339,6 +3397,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/whoami/name", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3348,6 +3411,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("text/plain"),
                 )
                 .body(body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3402,6 +3466,11 @@ pub mod builder {
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3411,6 +3480,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3438,6 +3508,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3446,6 +3521,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3519,8 +3595,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3579,6 +3665,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3592,6 +3683,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3665,8 +3757,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3737,8 +3839,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3765,6 +3877,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3773,6 +3890,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3800,8 +3918,13 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).build()?;
+            let mut request = client.client.post(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3844,6 +3967,11 @@ pub mod builder {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/things", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3853,6 +3981,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .query(&progenitor_client::QueryParam::new("id", &id))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3899,6 +4028,10 @@ pub mod builder {
             let accept_language = accept_language.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/header-arg", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             if let Some(value) = accept_language {
                 header_map.append("accept-language", value.to_string().try_into()?);
             }

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2771,7 +2771,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -2812,7 +2812,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -2864,7 +2864,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -2905,7 +2905,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -2973,7 +2973,7 @@ pub mod builder {
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3054,7 +3054,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3117,7 +3117,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3195,7 +3195,7 @@ pub mod builder {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3255,7 +3255,7 @@ pub mod builder {
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3297,7 +3297,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3354,7 +3354,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/whoami/name", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3423,7 +3423,7 @@ pub mod builder {
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3465,7 +3465,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3552,7 +3552,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3622,7 +3622,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3714,7 +3714,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3796,7 +3796,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3834,7 +3834,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3875,7 +3875,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3924,7 +3924,7 @@ pub mod builder {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/things", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3984,7 +3984,7 @@ pub mod builder {
             } = self;
             let accept_language = accept_language.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/header-arg", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2771,6 +2771,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2779,6 +2784,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2806,8 +2812,13 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).build()?;
+            let mut request = client.client.post(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2853,6 +2864,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2861,6 +2877,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2888,6 +2905,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2896,6 +2918,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2950,6 +2973,11 @@ pub mod builder {
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -2959,6 +2987,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3025,6 +3054,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3034,6 +3068,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .query(&progenitor_client::QueryParam::new("minseq", &minseq))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3082,6 +3117,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3090,6 +3130,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3154,8 +3195,13 @@ pub mod builder {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).build()?;
+            let mut request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3209,6 +3255,11 @@ pub mod builder {
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3218,6 +3269,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3245,6 +3297,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3253,6 +3310,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3296,6 +3354,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/whoami/name", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3305,6 +3368,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("text/plain"),
                 )
                 .body(body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3359,6 +3423,11 @@ pub mod builder {
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3368,6 +3437,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3395,6 +3465,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3403,6 +3478,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3476,8 +3552,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3536,6 +3622,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3549,6 +3640,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3622,8 +3714,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3694,8 +3796,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3722,6 +3834,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3730,6 +3847,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3757,8 +3875,13 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).build()?;
+            let mut request = client.client.post(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3801,6 +3924,11 @@ pub mod builder {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/things", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3810,6 +3938,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .query(&progenitor_client::QueryParam::new("id", &id))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3856,6 +3985,10 @@ pub mod builder {
             let accept_language = accept_language.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/header-arg", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             if let Some(value) = accept_language {
                 header_map.append("accept-language", value.to_string().try_into()?);
             }

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -1026,7 +1026,7 @@ impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/hold", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1052,7 +1052,7 @@ impl Client {
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/resume", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1077,7 +1077,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1105,7 +1105,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1134,7 +1134,7 @@ impl Client {
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1169,7 +1169,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1203,7 +1203,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1238,7 +1238,7 @@ impl Client {
             encode_path(&task.to_string()),
             encode_path(&output.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1259,7 +1259,7 @@ impl Client {
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
         let url = format!("{}/v1/users", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1286,7 +1286,7 @@ impl Client {
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
         let url = format!("{}/v1/whoami", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1315,7 +1315,7 @@ impl Client {
         body: String,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/whoami/name", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1345,7 +1345,7 @@ impl Client {
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
         let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1374,7 +1374,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
         let url = format!("{}/v1/worker/ping", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1408,7 +1408,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1439,7 +1439,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1478,7 +1478,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1509,7 +1509,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1534,7 +1534,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
         let url = format!("{}/v1/workers", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1560,7 +1560,7 @@ impl Client {
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/workers/recycle", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1581,7 +1581,7 @@ impl Client {
         id: Option<&'a types::GetThingOrThingsId>,
     ) -> Result<ResponseValue<::std::string::String>, Error<()>> {
         let url = format!("{}/v1/things", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1611,7 +1611,7 @@ impl Client {
         accept_language: Option<types::HeaderArgAcceptLanguage>,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/header-arg", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -1026,6 +1026,11 @@ impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/hold", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1034,6 +1039,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1046,8 +1052,13 @@ impl Client {
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/resume", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).build()?;
+        let mut request = self.client.post(url).headers(header_map).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1066,6 +1077,11 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1074,6 +1090,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1088,6 +1105,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1096,6 +1118,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1111,6 +1134,11 @@ impl Client {
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1120,6 +1148,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1140,6 +1169,11 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1149,6 +1183,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .query(&progenitor_client::QueryParam::new("minseq", &minseq))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1168,6 +1203,11 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1176,6 +1216,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1197,8 +1238,13 @@ impl Client {
             encode_path(&task.to_string()),
             encode_path(&output.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.get(url).build()?;
+        let mut request = self.client.get(url).headers(header_map).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1213,6 +1259,11 @@ impl Client {
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
         let url = format!("{}/v1/users", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1222,6 +1273,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1234,6 +1286,11 @@ impl Client {
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
         let url = format!("{}/v1/whoami", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1242,6 +1299,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1257,6 +1315,11 @@ impl Client {
         body: String,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/whoami/name", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1266,6 +1329,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("text/plain"),
             )
             .body(body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1281,6 +1345,11 @@ impl Client {
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
         let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1290,6 +1359,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1304,6 +1374,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
         let url = format!("{}/v1/worker/ping", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1312,6 +1387,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1332,8 +1408,18 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).json(&body).build()?;
+        let mut request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1353,6 +1439,11 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1366,6 +1457,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1386,8 +1478,18 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).json(&body).build()?;
+        let mut request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1407,8 +1509,18 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).json(&body).build()?;
+        let mut request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1422,6 +1534,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
         let url = format!("{}/v1/workers", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1430,6 +1547,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1442,8 +1560,13 @@ impl Client {
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/workers/recycle", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).build()?;
+        let mut request = self.client.post(url).headers(header_map).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1458,6 +1581,11 @@ impl Client {
         id: Option<&'a types::GetThingOrThingsId>,
     ) -> Result<ResponseValue<::std::string::String>, Error<()>> {
         let url = format!("{}/v1/things", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1467,6 +1595,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .query(&progenitor_client::QueryParam::new("id", &id))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1483,6 +1612,10 @@ impl Client {
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/header-arg", self.baseurl,);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         if let Some(value) = accept_language {
             header_map.append("accept-language", value.to_string().try_into()?);
         }

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -284,12 +284,18 @@ pub mod builder {
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/uno", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("gateway", &gateway))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -284,7 +284,7 @@ pub mod builder {
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/uno", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -282,7 +282,7 @@ pub mod builder {
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/uno", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -282,12 +282,18 @@ pub mod builder {
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/uno", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
                 .json(&body)
                 .query(&progenitor_client::QueryParam::new("gateway", &gateway))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -140,7 +140,7 @@ impl Client {
         body: &'a types::UnoBody,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
         let url = format!("{}/uno", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -140,12 +140,18 @@ impl Client {
         body: &'a types::UnoBody,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
         let url = format!("{}/uno", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
             .get(url)
             .json(&body)
             .query(&progenitor_client::QueryParam::new("gateway", &gateway))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1484,7 +1484,7 @@ pub mod builder {
                 .and_then(|v| types::EnrolBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1541,7 +1541,7 @@ pub mod builder {
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/global/jobs", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1601,7 +1601,7 @@ pub mod builder {
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ping", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1689,7 +1689,7 @@ pub mod builder {
                 .and_then(|v| types::ReportFinishBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1778,7 +1778,7 @@ pub mod builder {
                 .and_then(|v| types::ReportOutputBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1865,7 +1865,7 @@ pub mod builder {
                 .and_then(|v| types::ReportStartBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1485,6 +1485,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1538,6 +1542,10 @@ pub mod builder {
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1594,6 +1602,10 @@ pub mod builder {
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ping", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1678,6 +1690,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1763,6 +1779,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1846,6 +1866,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1465,6 +1465,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1518,6 +1522,10 @@ pub mod builder {
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1574,6 +1582,10 @@ pub mod builder {
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ping", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1658,6 +1670,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1743,6 +1759,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client
@@ -1826,6 +1846,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
             let mut request = client

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1464,7 +1464,7 @@ pub mod builder {
                 .and_then(|v| types::EnrolBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1521,7 +1521,7 @@ pub mod builder {
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/global/jobs", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1581,7 +1581,7 @@ pub mod builder {
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ping", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1669,7 +1669,7 @@ pub mod builder {
                 .and_then(|v| types::ReportFinishBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1758,7 +1758,7 @@ pub mod builder {
                 .and_then(|v| types::ReportOutputBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -1845,7 +1845,7 @@ pub mod builder {
                 .and_then(|v| types::ReportStartBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -521,6 +521,10 @@ impl Client {
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/enrol", self.baseurl,);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
         let mut request = self
@@ -547,6 +551,10 @@ impl Client {
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
         let url = format!("{}/global/jobs", self.baseurl,);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
         let mut request = self
@@ -576,6 +584,10 @@ impl Client {
     ) -> Result<ResponseValue<types::PingResult>, Error<()>> {
         let url = format!("{}/ping", self.baseurl,);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
         let mut request = self
@@ -607,6 +619,10 @@ impl Client {
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/finish", self.baseurl,);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
         let mut request = self
@@ -639,6 +655,10 @@ impl Client {
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/output", self.baseurl,);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
         let mut request = self
@@ -671,6 +691,10 @@ impl Client {
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/start", self.baseurl,);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
         let mut request = self

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -520,7 +520,7 @@ impl Client {
         body: &'a types::EnrolBody,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/enrol", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -550,7 +550,7 @@ impl Client {
         authorization: &'a str,
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
         let url = format!("{}/global/jobs", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -583,7 +583,7 @@ impl Client {
         authorization: &'a str,
     ) -> Result<ResponseValue<types::PingResult>, Error<()>> {
         let url = format!("{}/ping", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -618,7 +618,7 @@ impl Client {
         body: &'a types::ReportFinishBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/finish", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -654,7 +654,7 @@ impl Client {
         body: &'a types::ReportOutputBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/output", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -690,7 +690,7 @@ impl Client {
         body: &'a types::ReportStartBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/start", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -30059,6 +30059,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30067,6 +30072,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30119,6 +30125,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30127,6 +30138,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30179,6 +30191,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30187,6 +30204,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30241,6 +30259,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30249,6 +30272,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30301,6 +30325,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30309,6 +30338,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30361,6 +30391,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30369,6 +30404,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30421,6 +30457,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30429,6 +30470,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30481,6 +30523,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30489,6 +30536,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30541,6 +30589,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30549,6 +30602,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30601,6 +30655,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30609,6 +30668,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30661,6 +30721,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30669,6 +30734,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30731,8 +30797,18 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .form_urlencoded(&body)?
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -30788,6 +30864,11 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30797,6 +30878,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30863,8 +30945,18 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .form_urlencoded(&body)?
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -30940,6 +31032,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30954,6 +31051,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31060,6 +31158,11 @@ pub mod builder {
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31069,6 +31172,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31157,8 +31261,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -31228,8 +31342,13 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).build()?;
+            let mut request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -31313,6 +31432,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31322,6 +31446,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31355,6 +31480,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31363,6 +31493,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31445,6 +31576,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31459,6 +31595,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31567,6 +31704,11 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31576,6 +31718,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31631,6 +31774,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31639,6 +31787,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31722,6 +31871,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31731,6 +31885,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31786,6 +31941,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31794,6 +31954,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31851,6 +32012,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31859,6 +32025,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31946,6 +32113,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31955,6 +32127,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32056,6 +32229,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32070,6 +32248,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32199,6 +32378,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32208,6 +32392,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32279,6 +32464,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32287,6 +32477,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32384,6 +32575,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32393,6 +32589,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32464,6 +32661,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32472,6 +32674,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32588,6 +32791,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32602,6 +32810,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32746,6 +32955,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32755,6 +32969,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32842,6 +33057,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32850,6 +33070,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32937,6 +33158,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32945,6 +33171,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33109,6 +33336,11 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33127,6 +33359,7 @@ pub mod builder {
                     "start_time",
                     &start_time,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33292,6 +33525,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33306,6 +33544,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33450,6 +33689,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33459,6 +33703,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33546,6 +33791,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33554,6 +33804,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33641,6 +33892,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33649,6 +33905,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33766,6 +34023,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33780,6 +34042,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33926,6 +34189,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33935,6 +34203,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34022,6 +34291,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34030,6 +34304,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34117,6 +34392,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34125,6 +34405,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34257,6 +34538,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34271,6 +34557,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34432,6 +34719,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34441,6 +34733,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34554,6 +34847,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34563,6 +34861,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34652,6 +34951,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34660,6 +34964,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34773,6 +35078,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34782,6 +35092,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34915,6 +35226,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34929,6 +35245,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35096,6 +35413,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35105,6 +35427,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35209,6 +35532,11 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35217,6 +35545,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35351,6 +35680,11 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35360,6 +35694,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35462,6 +35797,11 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35470,6 +35810,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35557,6 +35898,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35565,6 +35911,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35699,6 +36046,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35716,6 +36068,7 @@ pub mod builder {
                     "most_recent",
                     &most_recent,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35805,10 +36158,16 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
+                .headers(header_map)
                 .header(::reqwest::header::CONNECTION, "Upgrade")
                 .header(::reqwest::header::UPGRADE, "websocket")
                 .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -35901,6 +36260,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35909,6 +36273,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35996,6 +36361,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36004,6 +36374,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36077,6 +36448,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36085,6 +36461,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36186,6 +36563,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36195,6 +36577,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36312,6 +36695,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36326,6 +36714,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36472,6 +36861,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36481,6 +36875,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36568,6 +36963,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36576,6 +36976,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36663,6 +37064,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36671,6 +37077,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36787,6 +37194,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36801,6 +37213,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36945,6 +37358,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36954,6 +37372,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37041,6 +37460,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37049,6 +37473,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37162,6 +37587,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37171,6 +37601,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37258,6 +37689,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37266,6 +37702,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37355,6 +37792,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37363,6 +37805,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37485,6 +37928,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37494,6 +37942,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37626,6 +38075,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37640,6 +38094,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37801,6 +38256,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37810,6 +38270,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37912,6 +38373,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37920,6 +38386,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38048,6 +38515,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38057,6 +38529,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38159,6 +38632,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38167,6 +38645,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38314,6 +38793,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38328,6 +38812,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38510,6 +38995,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38519,6 +39009,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38636,6 +39127,11 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38644,6 +39140,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38793,6 +39290,11 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38802,6 +39304,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38919,6 +39422,11 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38927,6 +39435,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39059,6 +39568,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39073,6 +39587,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39234,6 +39749,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39243,6 +39763,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39345,6 +39866,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39353,6 +39879,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39481,6 +40008,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39490,6 +40022,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39592,6 +40125,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39600,6 +40138,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39748,6 +40287,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39762,6 +40306,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39845,6 +40390,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39853,6 +40403,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39915,6 +40466,11 @@ pub mod builder {
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39924,6 +40480,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39991,6 +40548,11 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40004,6 +40566,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40101,6 +40664,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40109,6 +40677,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40142,6 +40711,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40150,6 +40724,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40232,6 +40807,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40246,6 +40826,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40374,6 +40955,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40388,6 +40974,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40494,6 +41081,11 @@ pub mod builder {
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40503,6 +41095,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40558,6 +41151,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40566,6 +41164,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40621,6 +41220,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40629,6 +41233,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40681,6 +41286,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40689,6 +41299,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40741,6 +41352,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40749,6 +41365,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40801,6 +41418,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40809,6 +41431,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40891,6 +41514,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40905,6 +41533,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41013,6 +41642,11 @@ pub mod builder {
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41022,6 +41656,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41077,6 +41712,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41085,6 +41725,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41140,6 +41781,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41148,6 +41794,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41230,6 +41877,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41244,6 +41896,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41372,6 +42025,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41386,6 +42044,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41484,6 +42143,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41492,6 +42156,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41574,6 +42239,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41588,6 +42258,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41686,6 +42357,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41694,6 +42370,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41794,6 +42471,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41808,6 +42490,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41936,6 +42619,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41950,6 +42638,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42058,6 +42747,11 @@ pub mod builder {
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42067,6 +42761,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42119,6 +42814,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42127,6 +42827,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42179,6 +42880,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42187,6 +42893,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42269,6 +42976,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42283,6 +42995,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42389,6 +43102,11 @@ pub mod builder {
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42398,6 +43116,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42450,6 +43169,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42458,6 +43182,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42539,6 +43264,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42548,6 +43278,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42600,6 +43331,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42608,6 +43344,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42693,6 +43430,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42706,6 +43448,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42820,6 +43563,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42829,6 +43577,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42899,6 +43648,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42908,6 +43662,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42941,6 +43696,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42949,6 +43709,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43016,6 +43777,11 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43029,6 +43795,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43122,6 +43889,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43131,6 +43903,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43179,6 +43952,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43188,6 +43966,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43319,6 +44098,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43338,6 +44122,7 @@ pub mod builder {
                     "start_time",
                     &start_time,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43373,6 +44158,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43381,6 +44171,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43443,6 +44234,11 @@ pub mod builder {
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43452,6 +44248,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43534,6 +44331,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43548,6 +44350,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43646,6 +44449,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43654,6 +44462,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43736,6 +44545,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43750,6 +44564,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43856,6 +44671,11 @@ pub mod builder {
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43865,6 +44685,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43917,6 +44738,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43925,6 +44751,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43977,6 +44804,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43985,6 +44817,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44087,6 +44920,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44101,6 +44939,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44230,6 +45069,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44239,6 +45083,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44310,6 +45155,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44318,6 +45168,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44404,6 +45255,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44413,6 +45269,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44504,6 +45361,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44513,6 +45375,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44586,6 +45449,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44594,6 +45462,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44648,6 +45517,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44656,6 +45530,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44739,6 +45614,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44748,6 +45628,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44848,6 +45729,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44862,6 +45748,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44979,6 +45866,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44987,6 +45879,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45069,6 +45962,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45083,6 +45981,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45181,6 +46080,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45189,6 +46093,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45257,6 +46162,11 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45270,6 +46180,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45397,6 +46308,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45411,6 +46327,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45569,6 +46486,11 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45588,6 +46510,7 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45728,6 +46651,11 @@ pub mod builder {
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45742,6 +46670,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45827,6 +46756,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45840,6 +46774,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45925,6 +46860,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45938,6 +46878,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46050,6 +46991,11 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46069,6 +47015,7 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46209,6 +47156,11 @@ pub mod builder {
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46223,6 +47175,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46308,6 +47261,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46321,6 +47279,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46406,6 +47365,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46419,6 +47383,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46549,6 +47514,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46568,6 +47538,7 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46727,6 +47698,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46741,6 +47717,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46852,6 +47829,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46866,6 +47848,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46977,6 +47960,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46991,6 +47979,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47076,6 +48065,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47089,6 +48083,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47221,6 +48216,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47243,6 +48243,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47331,6 +48332,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47340,6 +48346,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .header(::reqwest::header::CONNECTION, "Upgrade")
                 .header(::reqwest::header::UPGRADE, "websocket")
                 .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -47430,6 +48437,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47443,6 +48455,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47528,6 +48541,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47541,6 +48559,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47623,6 +48642,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47637,6 +48661,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47745,6 +48770,11 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47754,6 +48784,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47809,6 +48840,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47817,6 +48853,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47900,6 +48937,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47909,6 +48951,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47964,6 +49007,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47972,6 +49020,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48029,6 +49078,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48037,6 +49091,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48124,6 +49179,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48133,6 +49193,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48230,6 +49291,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48248,6 +49314,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48372,6 +49439,11 @@ pub mod builder {
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48385,6 +49457,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48455,6 +49528,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48467,6 +49545,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48563,6 +49642,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48576,6 +49660,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48646,6 +49731,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48658,6 +49748,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48730,6 +49821,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48742,6 +49838,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48842,6 +49939,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48855,6 +49957,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48938,6 +50041,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48952,6 +50060,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49082,6 +50191,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49096,6 +50210,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49196,6 +50311,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49204,6 +50324,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49237,6 +50358,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49245,6 +50371,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49309,6 +50436,11 @@ pub mod builder {
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/start", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49318,6 +50450,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49351,6 +50484,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49359,6 +50497,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49441,6 +50580,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49455,6 +50599,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49553,6 +50698,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49561,6 +50711,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49616,6 +50767,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49624,6 +50780,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49659,6 +50816,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/version", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49667,6 +50829,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -30059,7 +30059,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30125,7 +30125,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30191,7 +30191,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30259,7 +30259,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30325,7 +30325,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30391,7 +30391,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30457,7 +30457,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30523,7 +30523,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30589,7 +30589,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30655,7 +30655,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30721,7 +30721,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30797,7 +30797,7 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30864,7 +30864,7 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30945,7 +30945,7 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31032,7 +31032,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31158,7 +31158,7 @@ pub mod builder {
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31261,7 +31261,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31342,7 +31342,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31432,7 +31432,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31480,7 +31480,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31576,7 +31576,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31704,7 +31704,7 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31774,7 +31774,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31871,7 +31871,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31941,7 +31941,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32012,7 +32012,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32113,7 +32113,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32229,7 +32229,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32378,7 +32378,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32464,7 +32464,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32575,7 +32575,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32661,7 +32661,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32791,7 +32791,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32955,7 +32955,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33057,7 +33057,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33158,7 +33158,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33336,7 +33336,7 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33525,7 +33525,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33689,7 +33689,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33791,7 +33791,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33892,7 +33892,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34023,7 +34023,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34189,7 +34189,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34291,7 +34291,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34392,7 +34392,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34538,7 +34538,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34719,7 +34719,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34847,7 +34847,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34951,7 +34951,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35078,7 +35078,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35226,7 +35226,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35413,7 +35413,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35532,7 +35532,7 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35680,7 +35680,7 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35797,7 +35797,7 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35898,7 +35898,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36046,7 +36046,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36158,7 +36158,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36260,7 +36260,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36361,7 +36361,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36448,7 +36448,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36563,7 +36563,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36695,7 +36695,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36861,7 +36861,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36963,7 +36963,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37064,7 +37064,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37194,7 +37194,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37358,7 +37358,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37460,7 +37460,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37587,7 +37587,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37689,7 +37689,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37792,7 +37792,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37928,7 +37928,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38075,7 +38075,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38256,7 +38256,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38373,7 +38373,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38515,7 +38515,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38632,7 +38632,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38793,7 +38793,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38995,7 +38995,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39127,7 +39127,7 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39290,7 +39290,7 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39422,7 +39422,7 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39568,7 +39568,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39749,7 +39749,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39866,7 +39866,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40008,7 +40008,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40125,7 +40125,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40287,7 +40287,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40390,7 +40390,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40466,7 +40466,7 @@ pub mod builder {
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40548,7 +40548,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40664,7 +40664,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40711,7 +40711,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40807,7 +40807,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40955,7 +40955,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41081,7 +41081,7 @@ pub mod builder {
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41151,7 +41151,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41220,7 +41220,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41286,7 +41286,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41352,7 +41352,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41418,7 +41418,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41514,7 +41514,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41642,7 +41642,7 @@ pub mod builder {
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41712,7 +41712,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41781,7 +41781,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41877,7 +41877,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42025,7 +42025,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42143,7 +42143,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42239,7 +42239,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42357,7 +42357,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42471,7 +42471,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42619,7 +42619,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42747,7 +42747,7 @@ pub mod builder {
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42814,7 +42814,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42880,7 +42880,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42976,7 +42976,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43102,7 +43102,7 @@ pub mod builder {
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43169,7 +43169,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43264,7 +43264,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43331,7 +43331,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43430,7 +43430,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43563,7 +43563,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43648,7 +43648,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43696,7 +43696,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43777,7 +43777,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43889,7 +43889,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43952,7 +43952,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44098,7 +44098,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44158,7 +44158,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44234,7 +44234,7 @@ pub mod builder {
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44331,7 +44331,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44449,7 +44449,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44545,7 +44545,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44671,7 +44671,7 @@ pub mod builder {
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44738,7 +44738,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44804,7 +44804,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44920,7 +44920,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45069,7 +45069,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45155,7 +45155,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45255,7 +45255,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45361,7 +45361,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45449,7 +45449,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45517,7 +45517,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45614,7 +45614,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45729,7 +45729,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45866,7 +45866,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45962,7 +45962,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46080,7 +46080,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46162,7 +46162,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46308,7 +46308,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46486,7 +46486,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46651,7 +46651,7 @@ pub mod builder {
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46756,7 +46756,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46860,7 +46860,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46991,7 +46991,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47156,7 +47156,7 @@ pub mod builder {
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47261,7 +47261,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47365,7 +47365,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47514,7 +47514,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47698,7 +47698,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47829,7 +47829,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47960,7 +47960,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48065,7 +48065,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48216,7 +48216,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48332,7 +48332,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48437,7 +48437,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48541,7 +48541,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48642,7 +48642,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48770,7 +48770,7 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48840,7 +48840,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48937,7 +48937,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49007,7 +49007,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49078,7 +49078,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49179,7 +49179,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49291,7 +49291,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49439,7 +49439,7 @@ pub mod builder {
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49528,7 +49528,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49642,7 +49642,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49731,7 +49731,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49821,7 +49821,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49939,7 +49939,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50041,7 +50041,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50191,7 +50191,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50311,7 +50311,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50358,7 +50358,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50436,7 +50436,7 @@ pub mod builder {
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/start", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50484,7 +50484,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50580,7 +50580,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50698,7 +50698,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50767,7 +50767,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50816,7 +50816,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/version", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -29908,7 +29908,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -29974,7 +29974,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30040,7 +30040,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30109,7 +30109,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30175,7 +30175,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30241,7 +30241,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30307,7 +30307,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30373,7 +30373,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30439,7 +30439,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30505,7 +30505,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30571,7 +30571,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30647,7 +30647,7 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30714,7 +30714,7 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30795,7 +30795,7 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -30882,7 +30882,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31008,7 +31008,7 @@ pub mod builder {
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31111,7 +31111,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31192,7 +31192,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31282,7 +31282,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31330,7 +31330,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31426,7 +31426,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31554,7 +31554,7 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31624,7 +31624,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31721,7 +31721,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31791,7 +31791,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31862,7 +31862,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -31963,7 +31963,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32079,7 +32079,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32228,7 +32228,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32314,7 +32314,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32425,7 +32425,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32511,7 +32511,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32641,7 +32641,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32805,7 +32805,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -32907,7 +32907,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33008,7 +33008,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33186,7 +33186,7 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33375,7 +33375,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33539,7 +33539,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33641,7 +33641,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33742,7 +33742,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -33873,7 +33873,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34039,7 +34039,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34141,7 +34141,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34242,7 +34242,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34388,7 +34388,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34569,7 +34569,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34697,7 +34697,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34801,7 +34801,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -34928,7 +34928,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35076,7 +35076,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35263,7 +35263,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35382,7 +35382,7 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35530,7 +35530,7 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35647,7 +35647,7 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35748,7 +35748,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -35896,7 +35896,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36008,7 +36008,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36110,7 +36110,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36211,7 +36211,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36298,7 +36298,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36413,7 +36413,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36545,7 +36545,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36711,7 +36711,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36813,7 +36813,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -36914,7 +36914,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37044,7 +37044,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37208,7 +37208,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37310,7 +37310,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37437,7 +37437,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37539,7 +37539,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37642,7 +37642,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37778,7 +37778,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -37925,7 +37925,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38106,7 +38106,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38223,7 +38223,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38365,7 +38365,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38482,7 +38482,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38643,7 +38643,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38845,7 +38845,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -38977,7 +38977,7 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39140,7 +39140,7 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39272,7 +39272,7 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39418,7 +39418,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39599,7 +39599,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39716,7 +39716,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39858,7 +39858,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -39975,7 +39975,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40137,7 +40137,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40240,7 +40240,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40316,7 +40316,7 @@ pub mod builder {
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40398,7 +40398,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40514,7 +40514,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40561,7 +40561,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40657,7 +40657,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40805,7 +40805,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -40931,7 +40931,7 @@ pub mod builder {
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41001,7 +41001,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41070,7 +41070,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41136,7 +41136,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41202,7 +41202,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41268,7 +41268,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41364,7 +41364,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41492,7 +41492,7 @@ pub mod builder {
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41562,7 +41562,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41631,7 +41631,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41727,7 +41727,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41875,7 +41875,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -41993,7 +41993,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42089,7 +42089,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42207,7 +42207,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42321,7 +42321,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42469,7 +42469,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42597,7 +42597,7 @@ pub mod builder {
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42664,7 +42664,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42730,7 +42730,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42826,7 +42826,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -42952,7 +42952,7 @@ pub mod builder {
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43019,7 +43019,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43114,7 +43114,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43181,7 +43181,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43280,7 +43280,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43413,7 +43413,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43498,7 +43498,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43546,7 +43546,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43627,7 +43627,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43739,7 +43739,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43802,7 +43802,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -43948,7 +43948,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44008,7 +44008,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44084,7 +44084,7 @@ pub mod builder {
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/policy", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44181,7 +44181,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44299,7 +44299,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44395,7 +44395,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44521,7 +44521,7 @@ pub mod builder {
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44588,7 +44588,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44654,7 +44654,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44770,7 +44770,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -44919,7 +44919,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45005,7 +45005,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45105,7 +45105,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45211,7 +45211,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45299,7 +45299,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45367,7 +45367,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45464,7 +45464,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45579,7 +45579,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45716,7 +45716,7 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45812,7 +45812,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -45930,7 +45930,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46012,7 +46012,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46158,7 +46158,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46336,7 +46336,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46501,7 +46501,7 @@ pub mod builder {
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46606,7 +46606,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46710,7 +46710,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -46841,7 +46841,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47006,7 +47006,7 @@ pub mod builder {
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47111,7 +47111,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47215,7 +47215,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47364,7 +47364,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47548,7 +47548,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47679,7 +47679,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47810,7 +47810,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -47915,7 +47915,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48066,7 +48066,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48182,7 +48182,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48287,7 +48287,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48391,7 +48391,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48492,7 +48492,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48620,7 +48620,7 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48690,7 +48690,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48787,7 +48787,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48857,7 +48857,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -48928,7 +48928,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49029,7 +49029,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49141,7 +49141,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49289,7 +49289,7 @@ pub mod builder {
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49378,7 +49378,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49492,7 +49492,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49581,7 +49581,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49671,7 +49671,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49789,7 +49789,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -49891,7 +49891,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50041,7 +50041,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50161,7 +50161,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50208,7 +50208,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50286,7 +50286,7 @@ pub mod builder {
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/start", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50334,7 +50334,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50430,7 +50430,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50548,7 +50548,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50617,7 +50617,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -50666,7 +50666,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/version", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -29908,6 +29908,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -29916,6 +29921,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -29968,6 +29974,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -29976,6 +29987,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30028,6 +30040,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30036,6 +30053,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30091,6 +30109,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30099,6 +30122,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30151,6 +30175,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30159,6 +30188,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30211,6 +30241,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30219,6 +30254,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30271,6 +30307,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30279,6 +30320,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30331,6 +30373,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30339,6 +30386,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30391,6 +30439,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30399,6 +30452,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30451,6 +30505,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30459,6 +30518,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30511,6 +30571,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30519,6 +30584,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30581,8 +30647,18 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .form_urlencoded(&body)?
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -30638,6 +30714,11 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30647,6 +30728,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30713,8 +30795,18 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .form_urlencoded(&body)?
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -30790,6 +30882,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30804,6 +30901,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -30910,6 +31008,11 @@ pub mod builder {
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -30919,6 +31022,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31007,8 +31111,18 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -31078,8 +31192,13 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.get(url).build()?;
+            let mut request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -31163,6 +31282,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31172,6 +31296,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31205,6 +31330,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31213,6 +31343,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31295,6 +31426,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31309,6 +31445,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31417,6 +31554,11 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31426,6 +31568,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31481,6 +31624,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31489,6 +31637,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31572,6 +31721,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31581,6 +31735,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31636,6 +31791,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31644,6 +31804,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31701,6 +31862,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31709,6 +31875,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31796,6 +31963,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31805,6 +31977,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -31906,6 +32079,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -31920,6 +32098,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32049,6 +32228,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32058,6 +32242,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32129,6 +32314,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32137,6 +32327,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32234,6 +32425,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32243,6 +32439,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32314,6 +32511,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32322,6 +32524,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32438,6 +32641,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32452,6 +32660,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32596,6 +32805,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32605,6 +32819,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32692,6 +32907,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32700,6 +32920,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32787,6 +33008,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32795,6 +33021,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -32959,6 +33186,11 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -32977,6 +33209,7 @@ pub mod builder {
                     "start_time",
                     &start_time,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33142,6 +33375,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33156,6 +33394,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33300,6 +33539,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33309,6 +33553,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33396,6 +33641,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33404,6 +33654,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33491,6 +33742,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33499,6 +33755,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33616,6 +33873,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33630,6 +33892,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33776,6 +34039,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33785,6 +34053,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33872,6 +34141,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33880,6 +34154,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -33967,6 +34242,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -33975,6 +34255,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34107,6 +34388,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34121,6 +34407,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34282,6 +34569,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34291,6 +34583,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34404,6 +34697,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34413,6 +34711,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34502,6 +34801,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34510,6 +34814,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34623,6 +34928,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34632,6 +34942,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34765,6 +35076,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34779,6 +35095,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -34946,6 +35263,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -34955,6 +35277,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35059,6 +35382,11 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35067,6 +35395,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35201,6 +35530,11 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35210,6 +35544,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35312,6 +35647,11 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35320,6 +35660,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35407,6 +35748,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35415,6 +35761,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35549,6 +35896,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35566,6 +35918,7 @@ pub mod builder {
                     "most_recent",
                     &most_recent,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35655,10 +36008,16 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
+                .headers(header_map)
                 .header(::reqwest::header::CONNECTION, "Upgrade")
                 .header(::reqwest::header::UPGRADE, "websocket")
                 .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -35751,6 +36110,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35759,6 +36123,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35846,6 +36211,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35854,6 +36224,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -35927,6 +36298,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -35935,6 +36311,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36036,6 +36413,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36045,6 +36427,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36162,6 +36545,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36176,6 +36564,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36322,6 +36711,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36331,6 +36725,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36418,6 +36813,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36426,6 +36826,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36513,6 +36914,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36521,6 +36927,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36637,6 +37044,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36651,6 +37063,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36795,6 +37208,11 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36804,6 +37222,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -36891,6 +37310,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -36899,6 +37323,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37012,6 +37437,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37021,6 +37451,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37108,6 +37539,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37116,6 +37552,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37205,6 +37642,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37213,6 +37655,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37335,6 +37778,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37344,6 +37792,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37476,6 +37925,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37490,6 +37944,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37651,6 +38106,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37660,6 +38120,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37762,6 +38223,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37770,6 +38236,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -37898,6 +38365,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -37907,6 +38379,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38009,6 +38482,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38017,6 +38495,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38164,6 +38643,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38178,6 +38662,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38360,6 +38845,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38369,6 +38859,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38486,6 +38977,11 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38494,6 +38990,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38643,6 +39140,11 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38652,6 +39154,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38769,6 +39272,11 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38777,6 +39285,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -38909,6 +39418,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -38923,6 +39437,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39084,6 +39599,11 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39093,6 +39613,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39195,6 +39716,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39203,6 +39729,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39331,6 +39858,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39340,6 +39872,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39442,6 +39975,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39450,6 +39988,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39598,6 +40137,11 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39612,6 +40156,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39695,6 +40240,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39703,6 +40253,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39765,6 +40316,11 @@ pub mod builder {
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39774,6 +40330,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39841,6 +40398,11 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39854,6 +40416,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39951,6 +40514,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -39959,6 +40527,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -39992,6 +40561,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40000,6 +40574,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40082,6 +40657,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40096,6 +40676,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40224,6 +40805,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40238,6 +40824,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40344,6 +40931,11 @@ pub mod builder {
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40353,6 +40945,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40408,6 +41001,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40416,6 +41014,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40471,6 +41070,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40479,6 +41083,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40531,6 +41136,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40539,6 +41149,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40591,6 +41202,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40599,6 +41215,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40651,6 +41268,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40659,6 +41281,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40741,6 +41364,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40755,6 +41383,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40863,6 +41492,11 @@ pub mod builder {
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40872,6 +41506,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40927,6 +41562,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40935,6 +41575,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -40990,6 +41631,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -40998,6 +41644,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41080,6 +41727,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41094,6 +41746,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41222,6 +41875,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41236,6 +41894,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41334,6 +41993,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41342,6 +42006,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41424,6 +42089,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41438,6 +42108,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41536,6 +42207,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41544,6 +42220,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41644,6 +42321,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41658,6 +42340,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41786,6 +42469,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41800,6 +42488,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41908,6 +42597,11 @@ pub mod builder {
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41917,6 +42611,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -41969,6 +42664,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -41977,6 +42677,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42029,6 +42730,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42037,6 +42743,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42119,6 +42826,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42133,6 +42845,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42239,6 +42952,11 @@ pub mod builder {
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42248,6 +42966,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42300,6 +43019,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42308,6 +43032,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42389,6 +43114,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42398,6 +43128,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42450,6 +43181,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42458,6 +43194,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42543,6 +43280,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42556,6 +43298,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42670,6 +43413,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42679,6 +43427,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42749,6 +43498,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42758,6 +43512,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42791,6 +43546,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42799,6 +43559,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42866,6 +43627,11 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42879,6 +43645,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -42972,6 +43739,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -42981,6 +43753,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43029,6 +43802,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43038,6 +43816,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43169,6 +43948,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43188,6 +43972,7 @@ pub mod builder {
                     "start_time",
                     &start_time,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43223,6 +44008,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43231,6 +44021,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43293,6 +44084,11 @@ pub mod builder {
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/policy", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43302,6 +44098,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43384,6 +44181,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43398,6 +44200,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43496,6 +44299,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43504,6 +44312,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43586,6 +44395,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43600,6 +44414,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43706,6 +44521,11 @@ pub mod builder {
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43715,6 +44535,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43767,6 +44588,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43775,6 +44601,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43827,6 +44654,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43835,6 +44667,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -43937,6 +44770,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -43951,6 +44789,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44080,6 +44919,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44089,6 +44933,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44160,6 +45005,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44168,6 +45018,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44254,6 +45105,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44263,6 +45119,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44354,6 +45211,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44363,6 +45225,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44436,6 +45299,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44444,6 +45312,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44498,6 +45367,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44506,6 +45380,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44589,6 +45464,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44598,6 +45478,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44698,6 +45579,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44712,6 +45598,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44829,6 +45716,11 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44837,6 +45729,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -44919,6 +45812,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -44933,6 +45831,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45031,6 +45930,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45039,6 +45943,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45107,6 +46012,11 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45120,6 +46030,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45247,6 +46158,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45261,6 +46177,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45419,6 +46336,11 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45438,6 +46360,7 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45578,6 +46501,11 @@ pub mod builder {
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45592,6 +46520,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45677,6 +46606,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45690,6 +46624,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45775,6 +46710,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45788,6 +46728,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -45900,6 +46841,11 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -45919,6 +46865,7 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46059,6 +47006,11 @@ pub mod builder {
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46073,6 +47025,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46158,6 +47111,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46171,6 +47129,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46256,6 +47215,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46269,6 +47233,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46399,6 +47364,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46418,6 +47388,7 @@ pub mod builder {
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46577,6 +47548,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46591,6 +47567,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46702,6 +47679,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46716,6 +47698,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46827,6 +47810,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46841,6 +47829,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -46926,6 +47915,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -46939,6 +47933,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47071,6 +48066,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47093,6 +48093,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47181,6 +48182,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47190,6 +48196,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .header(::reqwest::header::CONNECTION, "Upgrade")
                 .header(::reqwest::header::UPGRADE, "websocket")
                 .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -47280,6 +48287,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47293,6 +48305,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47378,6 +48391,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47391,6 +48409,7 @@ pub mod builder {
                     &organization,
                 ))
                 .query(&progenitor_client::QueryParam::new("project", &project))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47473,6 +48492,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47487,6 +48511,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47595,6 +48620,11 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47604,6 +48634,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47659,6 +48690,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47667,6 +48703,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47750,6 +48787,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47759,6 +48801,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47814,6 +48857,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47822,6 +48870,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47879,6 +48928,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47887,6 +48941,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -47974,6 +49029,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -47983,6 +49043,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48080,6 +49141,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48098,6 +49164,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48222,6 +49289,11 @@ pub mod builder {
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48235,6 +49307,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48305,6 +49378,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48317,6 +49395,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48413,6 +49492,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48426,6 +49510,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48496,6 +49581,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48508,6 +49598,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48580,6 +49671,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48592,6 +49688,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48692,6 +49789,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48705,6 +49807,7 @@ pub mod builder {
                     "organization",
                     &organization,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48788,6 +49891,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48802,6 +49910,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -48932,6 +50041,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -48946,6 +50060,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49046,6 +50161,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49054,6 +50174,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49087,6 +50208,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49095,6 +50221,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49159,6 +50286,11 @@ pub mod builder {
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/start", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49168,6 +50300,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49201,6 +50334,11 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49209,6 +50347,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49291,6 +50430,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49305,6 +50449,7 @@ pub mod builder {
                     &page_token,
                 ))
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49403,6 +50548,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49411,6 +50561,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49466,6 +50617,11 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49474,6 +50630,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -49509,6 +50666,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/version", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -49517,6 +50679,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -14108,6 +14108,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14116,6 +14121,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14143,6 +14149,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14151,6 +14162,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14178,6 +14190,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14186,6 +14203,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14213,6 +14231,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14221,6 +14244,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14250,6 +14274,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14258,6 +14287,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14287,6 +14317,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14295,6 +14330,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14322,6 +14358,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14330,6 +14371,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14357,6 +14399,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14365,6 +14412,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14392,6 +14440,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14400,6 +14453,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14427,6 +14481,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14435,6 +14494,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14462,6 +14522,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14470,6 +14535,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14497,8 +14563,18 @@ impl Client {
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/device/auth", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        let mut request = self
+            .client
+            .post(url)
+            .form_urlencoded(&body)?
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -14520,6 +14596,11 @@ impl Client {
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/device/confirm", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14529,6 +14610,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14555,8 +14637,18 @@ impl Client {
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/device/token", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        let mut request = self
+            .client
+            .post(url)
+            .form_urlencoded(&body)?
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -14581,6 +14673,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/groups", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14595,6 +14692,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14655,6 +14753,11 @@ impl Client {
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/login", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14664,6 +14767,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14692,8 +14796,18 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).json(&body).build()?;
+        let mut request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -14725,8 +14839,13 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.get(url).build()?;
+        let mut request = self.client.get(url).headers(header_map).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -14756,6 +14875,11 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14765,6 +14889,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14783,6 +14908,11 @@ impl Client {
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/logout", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14791,6 +14921,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14824,6 +14955,11 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14838,6 +14974,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14905,6 +15042,11 @@ impl Client {
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14914,6 +15056,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14946,6 +15089,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14954,6 +15102,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -14988,6 +15137,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -14997,6 +15151,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15029,6 +15184,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15037,6 +15197,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15069,6 +15230,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15077,6 +15243,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15111,6 +15278,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15120,6 +15292,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15159,6 +15332,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15173,6 +15351,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15251,6 +15430,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15260,6 +15444,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15296,6 +15481,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15304,6 +15494,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15342,6 +15533,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15351,6 +15547,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15387,6 +15584,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15395,6 +15597,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15438,6 +15641,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15452,6 +15660,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15540,6 +15749,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15549,6 +15763,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15584,6 +15799,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15592,6 +15812,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15625,6 +15846,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15633,6 +15859,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15683,6 +15910,11 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15701,6 +15933,7 @@ impl Client {
                 "start_time",
                 &start_time,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15814,6 +16047,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15828,6 +16066,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15919,6 +16158,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15928,6 +16172,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -15963,6 +16208,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -15971,6 +16221,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16008,6 +16259,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16016,6 +16272,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16057,6 +16314,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16071,6 +16333,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16160,6 +16423,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16169,6 +16437,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16204,6 +16473,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16212,6 +16486,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16245,6 +16520,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16253,6 +16533,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16300,6 +16581,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16314,6 +16600,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16412,6 +16699,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16421,6 +16713,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16457,6 +16750,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16466,6 +16764,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16499,6 +16798,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16507,6 +16811,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16543,6 +16848,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16552,6 +16862,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16597,6 +16908,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16611,6 +16927,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16706,6 +17023,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16715,6 +17037,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16750,6 +17073,11 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16758,6 +17086,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16794,6 +17123,11 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16803,6 +17137,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16843,6 +17178,11 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16851,6 +17191,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16886,6 +17227,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16894,6 +17240,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -16948,6 +17295,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -16965,6 +17317,7 @@ impl Client {
                 "most_recent",
                 &most_recent,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17000,10 +17353,16 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
             .get(url)
+            .headers(header_map)
             .header(::reqwest::header::CONNECTION, "Upgrade")
             .header(::reqwest::header::UPGRADE, "websocket")
             .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -17044,6 +17403,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17052,6 +17416,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17087,6 +17452,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17095,6 +17465,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17131,6 +17502,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17139,6 +17515,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17175,6 +17552,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17184,6 +17566,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17225,6 +17608,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17239,6 +17627,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17328,6 +17717,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17337,6 +17731,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17370,6 +17765,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17378,6 +17778,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17411,6 +17812,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17419,6 +17825,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17460,6 +17867,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17474,6 +17886,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17560,6 +17973,11 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17569,6 +17987,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17602,6 +18021,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17610,6 +18034,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17644,6 +18069,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17653,6 +18083,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17686,6 +18117,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17694,6 +18130,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17727,6 +18164,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17735,6 +18177,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17769,6 +18212,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17778,6 +18226,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17823,6 +18272,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17837,6 +18291,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17932,6 +18387,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17941,6 +18401,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -17976,6 +18437,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -17984,6 +18450,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18020,6 +18487,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18029,6 +18501,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18064,6 +18537,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18072,6 +18550,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18122,6 +18601,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18136,6 +18620,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18240,6 +18725,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18249,6 +18739,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18286,6 +18777,11 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18294,6 +18790,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18332,6 +18829,11 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18341,6 +18843,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18378,6 +18881,11 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18386,6 +18894,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18431,6 +18940,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18445,6 +18959,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18540,6 +19055,11 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18549,6 +19069,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18584,6 +19105,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18592,6 +19118,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18628,6 +19155,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18637,6 +19169,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18672,6 +19205,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18680,6 +19218,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18728,6 +19267,11 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18742,6 +19286,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18830,6 +19375,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
         let url = format!("{}/policy", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18838,6 +19388,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18861,6 +19412,11 @@ impl Client {
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
         let url = format!("{}/policy", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18870,6 +19426,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18899,6 +19456,11 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
         let url = format!("{}/roles", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18912,6 +19474,7 @@ impl Client {
                 "page_token",
                 &page_token,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -18979,6 +19542,11 @@ impl Client {
             self.baseurl,
             encode_path(&role_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -18987,6 +19555,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19009,6 +19578,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
         let url = format!("{}/session/me", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19017,6 +19591,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19048,6 +19623,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/groups", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19062,6 +19642,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19134,6 +19715,11 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19148,6 +19734,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19214,6 +19801,11 @@ impl Client {
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19223,6 +19815,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19253,6 +19846,11 @@ impl Client {
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19261,6 +19859,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19291,6 +19890,11 @@ impl Client {
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19299,6 +19903,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19326,6 +19931,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19334,6 +19944,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19361,6 +19972,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19369,6 +19985,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19396,6 +20013,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19404,6 +20026,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19439,6 +20062,11 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/certificates", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19453,6 +20081,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19523,6 +20152,11 @@ impl Client {
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
         let url = format!("{}/system/certificates", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19532,6 +20166,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19561,6 +20196,11 @@ impl Client {
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19569,6 +20209,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19598,6 +20239,11 @@ impl Client {
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19606,6 +20252,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19637,6 +20284,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/disks", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19651,6 +20303,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19722,6 +20375,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/racks", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19736,6 +20394,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19805,6 +20464,11 @@ impl Client {
             self.baseurl,
             encode_path(&rack_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19813,6 +20477,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19844,6 +20509,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/sleds", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19858,6 +20528,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19927,6 +20598,11 @@ impl Client {
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19935,6 +20611,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -19972,6 +20649,11 @@ impl Client {
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -19986,6 +20668,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20064,6 +20747,11 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/images", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20078,6 +20766,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20148,6 +20837,11 @@ impl Client {
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
         let url = format!("{}/system/images", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20157,6 +20851,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20186,6 +20881,11 @@ impl Client {
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20194,6 +20894,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20225,6 +20926,11 @@ impl Client {
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20233,6 +20939,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20264,6 +20971,11 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20278,6 +20990,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20340,6 +21053,11 @@ impl Client {
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20349,6 +21067,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20376,6 +21095,11 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20384,6 +21108,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20412,6 +21137,11 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20421,6 +21151,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20448,6 +21179,11 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20456,6 +21192,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20493,6 +21230,11 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20506,6 +21248,7 @@ impl Client {
                 "page_token",
                 &page_token,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20576,6 +21319,11 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20585,6 +21333,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20613,6 +21362,11 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20622,6 +21376,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20644,6 +21399,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20652,6 +21412,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20683,6 +21444,11 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20696,6 +21462,7 @@ impl Client {
                 "page_token",
                 &page_token,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20759,6 +21526,11 @@ impl Client {
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20768,6 +21540,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20791,6 +21564,11 @@ impl Client {
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20800,6 +21578,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20841,6 +21620,11 @@ impl Client {
             self.baseurl,
             encode_path(&metric_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20860,6 +21644,7 @@ impl Client {
                 "start_time",
                 &start_time,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20882,6 +21667,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
         let url = format!("{}/system/policy", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20890,6 +21680,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20913,6 +21704,11 @@ impl Client {
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
         let url = format!("{}/system/policy", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20922,6 +21718,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -20953,6 +21750,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/sagas", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -20967,6 +21769,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21033,6 +21836,11 @@ impl Client {
             self.baseurl,
             encode_path(&saga_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21041,6 +21849,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21074,6 +21883,11 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/silos", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21088,6 +21902,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21152,6 +21967,11 @@ impl Client {
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
         let url = format!("{}/system/silos", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21161,6 +21981,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21193,6 +22014,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21201,6 +22027,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21233,6 +22060,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21241,6 +22073,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21278,6 +22111,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21292,6 +22130,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21372,6 +22211,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21381,6 +22225,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21415,6 +22260,11 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21423,6 +22273,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21463,6 +22314,11 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21472,6 +22328,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21505,6 +22362,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21514,6 +22376,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21548,6 +22411,11 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21556,6 +22424,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21586,6 +22455,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21594,6 +22468,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21626,6 +22501,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21635,6 +22515,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21672,6 +22553,11 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21686,6 +22572,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21760,6 +22647,11 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21768,6 +22660,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21799,6 +22692,11 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/user", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21813,6 +22711,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21883,6 +22782,11 @@ impl Client {
             self.baseurl,
             encode_path(&user_name.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21891,6 +22795,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -21920,6 +22825,11 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
         let url = format!("{}/timeseries/schema", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -21933,6 +22843,7 @@ impl Client {
                 "page_token",
                 &page_token,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22002,6 +22913,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
         let url = format!("{}/users", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22016,6 +22932,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22090,6 +23007,11 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22109,6 +23031,7 @@ impl Client {
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22177,6 +23100,11 @@ impl Client {
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22191,6 +23119,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22220,6 +23149,11 @@ impl Client {
             self.baseurl,
             encode_path(&disk.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22233,6 +23167,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22262,6 +23197,11 @@ impl Client {
             self.baseurl,
             encode_path(&disk.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22275,6 +23215,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22310,6 +23251,11 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22329,6 +23275,7 @@ impl Client {
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22398,6 +23345,11 @@ impl Client {
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22412,6 +23364,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22441,6 +23394,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22454,6 +23412,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22483,6 +23442,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22496,6 +23460,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22537,6 +23502,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22556,6 +23526,7 @@ impl Client {
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22638,6 +23609,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22652,6 +23628,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22682,6 +23659,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22696,6 +23678,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22726,6 +23709,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22740,6 +23728,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22769,6 +23758,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22782,6 +23776,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22830,6 +23825,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22852,6 +23852,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22882,6 +23883,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22891,6 +23897,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .header(::reqwest::header::CONNECTION, "Upgrade")
             .header(::reqwest::header::UPGRADE, "websocket")
             .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -22925,6 +23932,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22938,6 +23950,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -22967,6 +23980,11 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -22980,6 +23998,7 @@ impl Client {
                 &organization,
             ))
             .query(&progenitor_client::QueryParam::new("project", &project))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23011,6 +24030,11 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/organizations", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23025,6 +24049,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23088,6 +24113,11 @@ impl Client {
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!("{}/v1/organizations", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23097,6 +24127,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23124,6 +24155,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23132,6 +24168,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23160,6 +24197,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23169,6 +24211,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23196,6 +24239,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23204,6 +24252,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23231,6 +24280,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23239,6 +24293,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23267,6 +24322,11 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23276,6 +24336,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23309,6 +24370,11 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/projects", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23327,6 +24393,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23392,6 +24459,11 @@ impl Client {
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
         let url = format!("{}/v1/projects", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23405,6 +24477,7 @@ impl Client {
                 "organization",
                 &organization,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23433,6 +24506,11 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23445,6 +24523,7 @@ impl Client {
                 "organization",
                 &organization,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23474,6 +24553,11 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23487,6 +24571,7 @@ impl Client {
                 "organization",
                 &organization,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23515,6 +24600,11 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23527,6 +24617,7 @@ impl Client {
                 "organization",
                 &organization,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23555,6 +24646,11 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23567,6 +24663,7 @@ impl Client {
                 "organization",
                 &organization,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23596,6 +24693,11 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23609,6 +24711,7 @@ impl Client {
                 "organization",
                 &organization,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23640,6 +24743,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/components", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23654,6 +24762,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23725,6 +24834,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/deployments", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23739,6 +24853,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23806,6 +24921,11 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23814,6 +24934,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23836,6 +24957,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/refresh", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23844,6 +24970,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23867,6 +24994,11 @@ impl Client {
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/start", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23876,6 +25008,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23900,6 +25033,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/stop", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23908,6 +25046,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -23939,6 +25078,11 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/updates", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -23953,6 +25097,7 @@ impl Client {
                 &page_token,
             ))
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -24020,6 +25165,11 @@ impl Client {
             self.baseurl,
             encode_path(&version.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -24028,6 +25178,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -24056,6 +25207,11 @@ impl Client {
             self.baseurl,
             encode_path(&version.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -24064,6 +25220,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -24086,6 +25243,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/version", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -24094,6 +25256,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -14108,7 +14108,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14149,7 +14149,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14190,7 +14190,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14231,7 +14231,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14274,7 +14274,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14317,7 +14317,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14358,7 +14358,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14399,7 +14399,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14440,7 +14440,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14481,7 +14481,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14522,7 +14522,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14563,7 +14563,7 @@ impl Client {
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/device/auth", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14596,7 +14596,7 @@ impl Client {
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/device/confirm", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14637,7 +14637,7 @@ impl Client {
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/device/token", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14673,7 +14673,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/groups", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14753,7 +14753,7 @@ impl Client {
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/login", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14796,7 +14796,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14839,7 +14839,7 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14875,7 +14875,7 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14908,7 +14908,7 @@ impl Client {
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/logout", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -14955,7 +14955,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15042,7 +15042,7 @@ impl Client {
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15089,7 +15089,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15137,7 +15137,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15184,7 +15184,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15230,7 +15230,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15278,7 +15278,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15332,7 +15332,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15430,7 +15430,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15481,7 +15481,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15533,7 +15533,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15584,7 +15584,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15641,7 +15641,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15749,7 +15749,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15799,7 +15799,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15846,7 +15846,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -15910,7 +15910,7 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16047,7 +16047,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16158,7 +16158,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16208,7 +16208,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16259,7 +16259,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16314,7 +16314,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16423,7 +16423,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16473,7 +16473,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16520,7 +16520,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16581,7 +16581,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16699,7 +16699,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16750,7 +16750,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16798,7 +16798,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16848,7 +16848,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -16908,7 +16908,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17023,7 +17023,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17073,7 +17073,7 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17123,7 +17123,7 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17178,7 +17178,7 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17227,7 +17227,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17295,7 +17295,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17353,7 +17353,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17403,7 +17403,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17452,7 +17452,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17502,7 +17502,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17552,7 +17552,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17608,7 +17608,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17717,7 +17717,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17765,7 +17765,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17812,7 +17812,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17867,7 +17867,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -17973,7 +17973,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18021,7 +18021,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18069,7 +18069,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18117,7 +18117,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18164,7 +18164,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18212,7 +18212,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18272,7 +18272,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18387,7 +18387,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18437,7 +18437,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18487,7 +18487,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18537,7 +18537,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18601,7 +18601,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18725,7 +18725,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18777,7 +18777,7 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18829,7 +18829,7 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18881,7 +18881,7 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -18940,7 +18940,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19055,7 +19055,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19105,7 +19105,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19155,7 +19155,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19205,7 +19205,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19267,7 +19267,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19375,7 +19375,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
         let url = format!("{}/policy", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19412,7 +19412,7 @@ impl Client {
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
         let url = format!("{}/policy", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19456,7 +19456,7 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
         let url = format!("{}/roles", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19542,7 +19542,7 @@ impl Client {
             self.baseurl,
             encode_path(&role_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19578,7 +19578,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
         let url = format!("{}/session/me", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19623,7 +19623,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/groups", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19715,7 +19715,7 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19801,7 +19801,7 @@ impl Client {
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19846,7 +19846,7 @@ impl Client {
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19890,7 +19890,7 @@ impl Client {
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19931,7 +19931,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -19972,7 +19972,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20013,7 +20013,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20062,7 +20062,7 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/certificates", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20152,7 +20152,7 @@ impl Client {
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
         let url = format!("{}/system/certificates", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20196,7 +20196,7 @@ impl Client {
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20239,7 +20239,7 @@ impl Client {
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20284,7 +20284,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/disks", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20375,7 +20375,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/racks", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20464,7 +20464,7 @@ impl Client {
             self.baseurl,
             encode_path(&rack_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20509,7 +20509,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/sleds", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20598,7 +20598,7 @@ impl Client {
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20649,7 +20649,7 @@ impl Client {
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20747,7 +20747,7 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/images", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20837,7 +20837,7 @@ impl Client {
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
         let url = format!("{}/system/images", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20881,7 +20881,7 @@ impl Client {
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20926,7 +20926,7 @@ impl Client {
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -20971,7 +20971,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21053,7 +21053,7 @@ impl Client {
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21095,7 +21095,7 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21137,7 +21137,7 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21179,7 +21179,7 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21230,7 +21230,7 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21319,7 +21319,7 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21362,7 +21362,7 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21399,7 +21399,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21444,7 +21444,7 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21526,7 +21526,7 @@ impl Client {
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21564,7 +21564,7 @@ impl Client {
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21620,7 +21620,7 @@ impl Client {
             self.baseurl,
             encode_path(&metric_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21667,7 +21667,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
         let url = format!("{}/system/policy", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21704,7 +21704,7 @@ impl Client {
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
         let url = format!("{}/system/policy", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21750,7 +21750,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/sagas", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21836,7 +21836,7 @@ impl Client {
             self.baseurl,
             encode_path(&saga_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21883,7 +21883,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/silos", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -21967,7 +21967,7 @@ impl Client {
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
         let url = format!("{}/system/silos", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22014,7 +22014,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22060,7 +22060,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22111,7 +22111,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22211,7 +22211,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22260,7 +22260,7 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22314,7 +22314,7 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22362,7 +22362,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22411,7 +22411,7 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22455,7 +22455,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22501,7 +22501,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22553,7 +22553,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22647,7 +22647,7 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22692,7 +22692,7 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/user", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22782,7 +22782,7 @@ impl Client {
             self.baseurl,
             encode_path(&user_name.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22825,7 +22825,7 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
         let url = format!("{}/timeseries/schema", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -22913,7 +22913,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
         let url = format!("{}/users", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23007,7 +23007,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23100,7 +23100,7 @@ impl Client {
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23149,7 +23149,7 @@ impl Client {
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23197,7 +23197,7 @@ impl Client {
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23251,7 +23251,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23345,7 +23345,7 @@ impl Client {
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23394,7 +23394,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23442,7 +23442,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23502,7 +23502,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23609,7 +23609,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23659,7 +23659,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23709,7 +23709,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23758,7 +23758,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23825,7 +23825,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23883,7 +23883,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23932,7 +23932,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -23980,7 +23980,7 @@ impl Client {
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24030,7 +24030,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/organizations", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24113,7 +24113,7 @@ impl Client {
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!("{}/v1/organizations", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24155,7 +24155,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24197,7 +24197,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24239,7 +24239,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24280,7 +24280,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24322,7 +24322,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24370,7 +24370,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/projects", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24459,7 +24459,7 @@ impl Client {
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
         let url = format!("{}/v1/projects", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24506,7 +24506,7 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24553,7 +24553,7 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24600,7 +24600,7 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24646,7 +24646,7 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24693,7 +24693,7 @@ impl Client {
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24743,7 +24743,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/components", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24834,7 +24834,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/deployments", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24921,7 +24921,7 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24957,7 +24957,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/refresh", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -24994,7 +24994,7 @@ impl Client {
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/start", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -25033,7 +25033,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/stop", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -25078,7 +25078,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/updates", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -25165,7 +25165,7 @@ impl Client {
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -25207,7 +25207,7 @@ impl Client {
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -25243,7 +25243,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/version", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -241,7 +241,7 @@ pub mod builder {
                 _client.baseurl,
                 encode_path(&query.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(_client.api_version()),

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -241,6 +241,11 @@ pub mod builder {
                 _client.baseurl,
                 encode_path(&query.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(_client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut _request = _client
                 .client
@@ -250,6 +255,7 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("response", &response))
                 .query(&progenitor_client::QueryParam::new("result", &result))
                 .query(&progenitor_client::QueryParam::new("url", &url))
+                .headers(header_map)
                 .build()?;
             let _result = _client.client.execute(_request).await;
             let _response = _result?;

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -241,7 +241,7 @@ pub mod builder {
                 _client.baseurl,
                 encode_path(&query.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(_client.api_version()),

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -241,6 +241,11 @@ pub mod builder {
                 _client.baseurl,
                 encode_path(&query.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(_client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut _request = _client
                 .client
@@ -250,6 +255,7 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("response", &response))
                 .query(&progenitor_client::QueryParam::new("result", &result))
                 .query(&progenitor_client::QueryParam::new("url", &url))
+                .headers(header_map)
                 .build()?;
             let _result = _client.client.execute(_request).await;
             let _response = _result?;

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -123,6 +123,11 @@ impl Client {
         url: bool,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let _url = format!("{}/key/{}", self.baseurl, encode_path(&query.to_string()),);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut _request = self
             .client
@@ -132,6 +137,7 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("response", &response))
             .query(&progenitor_client::QueryParam::new("result", &result))
             .query(&progenitor_client::QueryParam::new("url", &url))
+            .headers(header_map)
             .build()?;
         let _result = self.client.execute(_request).await;
         let _response = _result?;

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -123,7 +123,7 @@ impl Client {
         url: bool,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let _url = format!("{}/key/{}", self.baseurl, encode_path(&query.to_string()),);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -176,7 +176,7 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -176,6 +176,11 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -185,6 +190,7 @@ pub mod builder {
                     "uniqueKey",
                     &unique_key,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -176,7 +176,7 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -176,6 +176,11 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -185,6 +190,7 @@ pub mod builder {
                     "uniqueKey",
                     &unique_key,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -117,7 +117,7 @@ impl Client {
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/key", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -117,6 +117,11 @@ impl Client {
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/key", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -126,6 +131,7 @@ impl Client {
                 "uniqueKey",
                 &unique_key,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3153,6 +3153,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3161,6 +3166,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3227,6 +3233,11 @@ pub mod builder {
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3236,6 +3247,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3307,6 +3319,11 @@ pub mod builder {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3315,6 +3332,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3385,6 +3403,11 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/migrate/status", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3394,6 +3417,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3429,10 +3453,16 @@ pub mod builder {
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
+                .headers(header_map)
                 .header(::reqwest::header::CONNECTION, "Upgrade")
                 .header(::reqwest::header::UPGRADE, "websocket")
                 .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -3486,6 +3516,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3495,6 +3530,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3565,6 +3601,11 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state-monitor", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3574,6 +3615,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3153,7 +3153,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3233,7 +3233,7 @@ pub mod builder {
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3319,7 +3319,7 @@ pub mod builder {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3403,7 +3403,7 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3453,7 +3453,7 @@ pub mod builder {
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3516,7 +3516,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3601,7 +3601,7 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -3108,6 +3108,11 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3116,6 +3121,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3182,6 +3188,11 @@ pub mod builder {
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3191,6 +3202,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3262,6 +3274,11 @@ pub mod builder {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3270,6 +3287,7 @@ pub mod builder {
                     ::reqwest::header::ACCEPT,
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3340,6 +3358,11 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/migrate/status", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3349,6 +3372,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3384,10 +3408,16 @@ pub mod builder {
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
                 .get(url)
+                .headers(header_map)
                 .header(::reqwest::header::CONNECTION, "Upgrade")
                 .header(::reqwest::header::UPGRADE, "websocket")
                 .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -3441,6 +3471,11 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3450,6 +3485,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -3520,6 +3556,11 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state-monitor", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -3529,6 +3570,7 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -3108,7 +3108,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3188,7 +3188,7 @@ pub mod builder {
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3274,7 +3274,7 @@ pub mod builder {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3358,7 +3358,7 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3408,7 +3408,7 @@ pub mod builder {
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3471,7 +3471,7 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),
@@ -3556,7 +3556,7 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1567,7 +1567,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
         let url = format!("{}/instance", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1602,7 +1602,7 @@ impl Client {
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
         let url = format!("{}/instance", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1646,7 +1646,7 @@ impl Client {
             encode_path(&id.to_string()),
             encode_path(&snapshot_id.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1681,7 +1681,7 @@ impl Client {
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
         let url = format!("{}/instance/migrate/status", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1716,7 +1716,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
         let url = format!("{}/instance/serial", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1752,7 +1752,7 @@ impl Client {
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/instance/state", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),
@@ -1788,7 +1788,7 @@ impl Client {
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
         let url = format!("{}/instance/state-monitor", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1567,6 +1567,11 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
         let url = format!("{}/instance", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1575,6 +1580,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1596,6 +1602,11 @@ impl Client {
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
         let url = format!("{}/instance", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1605,6 +1616,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1634,6 +1646,11 @@ impl Client {
             encode_path(&id.to_string()),
             encode_path(&snapshot_id.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1642,6 +1659,7 @@ impl Client {
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1663,6 +1681,11 @@ impl Client {
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
         let url = format!("{}/instance/migrate/status", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1672,6 +1695,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1692,10 +1716,16 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
         let url = format!("{}/instance/serial", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
             .get(url)
+            .headers(header_map)
             .header(::reqwest::header::CONNECTION, "Upgrade")
             .header(::reqwest::header::UPGRADE, "websocket")
             .header(::reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -1722,6 +1752,11 @@ impl Client {
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/instance/state", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1731,6 +1766,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -1752,6 +1788,11 @@ impl Client {
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
         let url = format!("{}/instance/state-monitor", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -1761,6 +1802,7 @@ impl Client {
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -447,8 +447,18 @@ pub mod builder {
                 .and_then(|v| types::BodyWithDefaults::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
-            let mut request = client.client.post(url).json(&body).build()?;
+            let mut request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -447,7 +447,7 @@ pub mod builder {
                 .and_then(|v| types::BodyWithDefaults::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -212,8 +212,18 @@ impl Client {
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.post(url).json(&body).build()?;
+        let mut request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -212,7 +212,7 @@ impl Client {
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -144,8 +144,13 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
-        let mut request = self.client.get(url).build()?;
+        let mut request = self.client.get(url).headers(header_map).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -144,7 +144,7 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -156,6 +156,11 @@ impl Client {
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -167,6 +172,7 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("if", &if_))
             .query(&progenitor_client::QueryParam::new("in", &in_))
             .query(&progenitor_client::QueryParam::new("use", &use_))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -156,7 +156,7 @@ impl Client {
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -413,7 +413,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(client.api_version()),

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -413,6 +413,11 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -426,6 +431,7 @@ pub mod builder {
                     "page_token",
                     &page_token,
                 ))
+                .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -199,7 +199,7 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::Uint32ResultsPage>, Error<types::Error>> {
         let url = format!("{}/", self.baseurl,);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
             ::reqwest::header::HeaderValue::from_static(self.api_version()),

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -199,6 +199,11 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::Uint32ResultsPage>, Error<types::Error>> {
         let url = format!("{}/", self.baseurl,);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(0usize);
+        header_map.append(
+            ::reqwest::header::HeaderName::from_static("api-version"),
+            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+        );
         #[allow(unused_mut)]
         let mut request = self
             .client
@@ -212,6 +217,7 @@ impl Client {
                 "page_token",
                 &page_token,
             ))
+            .headers(header_map)
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;


### PR DESCRIPTION
Closes #564.

In #856 we tried modifying the `reqwest::Client` to have default headers... but that doesn't work if we're handed the `Client` rather than constructing it ourselves. This change instead generates the header explicitly for each operation. It means more code is generated, but... meh.