### PR TITLE
Implement hooks via a trait and autoref specialization

### DIFF
--- a/docs/progenitor-client.md
+++ b/docs/progenitor-client.md
@@ -84,6 +84,8 @@ There are seven sub-categories of error covered by the error type variants:
 
 - An unexpected status code in the response
 
+- A custom error, particular to the generated client
+
 These errors are covered by the variants of the `Error<E>` type:
 
 ```rust
@@ -95,5 +97,6 @@ pub enum Error<E = ()> {
     ResponseBodyError(reqwest::Error),
     InvalidResponsePayload(bytes::Bytes, reqwest::Error),
     UnexpectedResponse(reqwest::Response),
+    Custom(String),
 }
 ```

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -360,16 +360,10 @@ impl Generator {
 
         let types = self.type_space.to_stream();
 
-        // Generate an implementation of a `Self::as_inner` method, if an inner
-        // type is defined.
-        let maybe_inner = self.settings.inner_type.as_ref().map(|inner| {
-            quote! {
-                /// Return a reference to the inner type stored in `self`.
-                pub fn inner(&self) -> &#inner {
-                    &self.inner
-                }
-            }
-        });
+        let (inner_type, inner_fn_value) = match self.settings.inner_type.as_ref() {
+            Some(inner_type) => (inner_type.clone(), quote! { &self.inner }),
+            None => (quote! { () }, quote! { &() }),
+        };
 
         let inner_property = self.settings.inner_type.as_ref().map(|inner| {
             quote! {
@@ -411,12 +405,16 @@ impl Generator {
         // crate.
 
         let file = quote! {
-            // Re-export ResponseValue and Error since those are used by the
-            // public interface of Client.
+            // Re-export types that are used by the public interface of Client.
             #[allow(unused_imports)]
-            pub use progenitor_client::{ByteStream, Error, ResponseValue};
+            pub use progenitor_client::{
+                ByteStream,
+                ClientInfo,
+                Error,
+                ResponseValue,
+            };
             #[allow(unused_imports)]
-            use progenitor_client::{encode_path, RequestBuilderExt};
+            use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 
             /// Types used as operation parameters and responses.
             #[allow(clippy::all)]
@@ -473,27 +471,27 @@ impl Generator {
                         #inner_value
                     }
                 }
+            }
 
-                /// Get the base URL to which requests are made.
-                pub fn baseurl(&self) -> &String {
-                    &self.baseurl
-                }
-
-                /// Get the internal `reqwest::Client` used to make requests.
-                pub fn client(&self) -> &reqwest::Client {
-                    &self.client
-                }
-
-                /// Get the version of this API.
-                ///
-                /// This string is pulled directly from the source OpenAPI
-                /// document and may be in any format the API selects.
-                pub fn api_version(&self) -> &'static str {
+            impl ClientInfo<#inner_type> for Client {
+                fn api_version() -> &'static str {
                     #version_str
                 }
 
-                #maybe_inner
+                fn baseurl(&self) -> &str {
+                    self.baseurl.as_str()
+                }
+
+                fn client(&self) -> &reqwest::Client {
+                    &self.client
+                }
+
+                fn inner(&self) -> &#inner_type {
+                    #inner_fn_value
+                }
             }
+
+            impl ClientHooks<#inner_type> for &Client {}
 
             #operation_code
         };
@@ -559,6 +557,8 @@ impl Generator {
                 use super::{
                     encode_path,
                     ByteStream,
+                    ClientInfo,
+                    ClientHooks,
                     Error,
                     RequestBuilderExt,
                     ResponseValue,
@@ -604,6 +604,8 @@ impl Generator {
                 use super::{
                     encode_path,
                     ByteStream,
+                    ClientInfo,
+                    ClientHooks,
                     Error,
                     RequestBuilderExt,
                     ResponseValue,

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -414,7 +414,12 @@ impl Generator {
                 ResponseValue,
             };
             #[allow(unused_imports)]
-            use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+            use progenitor_client::{
+                encode_path,
+                ClientHooks,
+                OperationInfo,
+                RequestBuilderExt,
+            };
 
             /// Types used as operation parameters and responses.
             #[allow(clippy::all)]
@@ -560,6 +565,7 @@ impl Generator {
                     ClientInfo,
                     ClientHooks,
                     Error,
+                    OperationInfo,
                     RequestBuilderExt,
                     ResponseValue,
                 };
@@ -607,6 +613,7 @@ impl Generator {
                     ClientInfo,
                     ClientHooks,
                     Error,
+                    OperationInfo,
                     RequestBuilderExt,
                     ResponseValue,
                 };

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -2798,7 +2798,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::control_hold`]
     ///
@@ -2832,9 +2833,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "control_hold",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2867,9 +2871,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "control_resume",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -2929,9 +2936,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2972,9 +2982,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "tasks_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3043,9 +3056,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_submit",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3126,9 +3142,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("minseq", &minseq))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_events_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3190,9 +3209,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_outputs_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3262,9 +3284,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_output_download",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -3333,9 +3358,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "user_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3376,9 +3404,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "whoami",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3436,9 +3467,12 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "whoami_put_name",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3507,9 +3541,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_bootstrap",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3550,9 +3587,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_ping",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3636,9 +3676,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_append",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3716,9 +3759,12 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_upload_chunk",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3802,9 +3848,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_complete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3886,9 +3935,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_add_output",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3929,9 +3981,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "workers_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3964,9 +4019,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "workers_recycle",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -4024,9 +4082,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("id", &id))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "get_thing_or_things",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -4080,9 +4141,12 @@ pub mod builder {
             }
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "header_arg",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -2518,26 +2518,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "1.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "1.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     ///
@@ -2796,7 +2797,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
@@ -2817,7 +2820,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -2829,7 +2832,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2858,11 +2863,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -2910,7 +2917,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -2922,7 +2929,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2951,7 +2960,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -2963,7 +2972,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3019,7 +3030,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3032,7 +3043,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3100,7 +3113,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3113,7 +3126,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("minseq", &minseq))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3163,7 +3178,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3175,7 +3190,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3241,11 +3258,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -3301,7 +3320,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3314,7 +3333,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3343,7 +3364,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3355,7 +3376,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3400,7 +3423,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3413,7 +3436,9 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3469,7 +3494,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3482,7 +3507,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3511,7 +3538,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3523,7 +3550,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3598,7 +3627,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3607,7 +3636,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3668,7 +3699,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3685,7 +3716,9 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3760,7 +3793,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3769,7 +3802,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3842,7 +3877,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3851,7 +3886,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3880,7 +3917,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3892,7 +3929,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3921,11 +3960,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3970,7 +4011,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3983,7 +4024,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("id", &id))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -4030,14 +4073,16 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             if let Some(value) = accept_language {
                 header_map.append("accept-language", value.to_string().try_into()?);
             }
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -2755,7 +2755,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::control_hold`]
     ///
@@ -2789,9 +2790,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "control_hold",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2824,9 +2828,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "control_resume",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -2886,9 +2893,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2929,9 +2939,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "tasks_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3000,9 +3013,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_submit",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3083,9 +3099,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("minseq", &minseq))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_events_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3147,9 +3166,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_outputs_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3219,9 +3241,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "task_output_download",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -3290,9 +3315,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "user_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3333,9 +3361,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "whoami",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3393,9 +3424,12 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "whoami_put_name",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3464,9 +3498,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_bootstrap",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3507,9 +3544,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_ping",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3593,9 +3633,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_append",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3673,9 +3716,12 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_upload_chunk",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3759,9 +3805,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_complete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3843,9 +3892,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "worker_task_add_output",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3886,9 +3938,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "workers_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3921,9 +3976,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "workers_recycle",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3981,9 +4039,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("id", &id))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "get_thing_or_things",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -4037,9 +4098,12 @@ pub mod builder {
             }
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "header_arg",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -2475,26 +2475,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "1.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "1.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     ///
@@ -2753,7 +2754,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
@@ -2774,7 +2777,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -2786,7 +2789,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2815,11 +2820,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -2867,7 +2874,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -2879,7 +2886,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2908,7 +2917,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -2920,7 +2929,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -2976,7 +2987,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -2989,7 +3000,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3057,7 +3070,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3070,7 +3083,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("minseq", &minseq))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3120,7 +3135,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3132,7 +3147,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3198,11 +3215,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -3258,7 +3277,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3271,7 +3290,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3300,7 +3321,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3312,7 +3333,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3357,7 +3380,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3370,7 +3393,9 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3426,7 +3451,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3439,7 +3464,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3468,7 +3495,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3480,7 +3507,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3555,7 +3584,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3564,7 +3593,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3625,7 +3656,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3642,7 +3673,9 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3717,7 +3750,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3726,7 +3759,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3799,7 +3834,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3808,7 +3843,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -3837,7 +3874,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3849,7 +3886,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3878,11 +3917,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.post(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),
@@ -3927,7 +3968,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3940,7 +3981,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("id", &id))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3987,14 +4030,16 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             if let Some(value) = accept_language {
                 header_map.append("accept-language", value.to_string().try_into()?);
             }
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -1,6 +1,6 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -1042,9 +1042,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "control_hold",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1062,9 +1065,12 @@ impl Client {
         );
         #[allow(unused_mut)]
         let mut request = self.client.post(url).headers(header_map).build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "control_resume",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(response)),
@@ -1097,9 +1103,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "task_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1127,9 +1136,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "tasks_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1159,9 +1171,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "task_submit",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -1196,9 +1211,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("minseq", &minseq))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "task_events_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1231,9 +1249,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "task_outputs_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1260,9 +1281,12 @@ impl Client {
         );
         #[allow(unused_mut)]
         let mut request = self.client.get(url).headers(header_map).build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "task_output_download",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -1292,9 +1316,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "user_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -1320,9 +1347,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "whoami",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1352,9 +1382,12 @@ impl Client {
             .body(body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "whoami_put_name",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(response)),
@@ -1384,9 +1417,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "worker_bootstrap",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -1414,9 +1450,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "worker_ping",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1447,9 +1486,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "worker_task_append",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => Ok(ResponseValue::empty(response)),
@@ -1488,9 +1530,12 @@ impl Client {
             .body(body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "worker_task_upload_chunk",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -1521,9 +1566,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "worker_task_complete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(response)),
@@ -1554,9 +1602,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "worker_task_add_output",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => Ok(ResponseValue::empty(response)),
@@ -1584,9 +1635,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "workers_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1604,9 +1658,12 @@ impl Client {
         );
         #[allow(unused_mut)]
         let mut request = self.client.post(url).headers(header_map).build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "workers_recycle",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(response)),
@@ -1636,9 +1693,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("id", &id))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "get_thing_or_things",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1663,9 +1723,12 @@ impl Client {
 
         #[allow(unused_mut)]
         let mut request = self.client.get(url).headers(header_map).build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "header_arg",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -224,7 +224,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::uno`]
     ///
@@ -300,9 +301,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("gateway", &gateway))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "uno",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -182,26 +182,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "9000"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "9000"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/uno`
     ///
@@ -222,7 +223,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::uno`]
     ///
     ///[`Client::uno`]: super::Client::uno
@@ -287,7 +290,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -297,7 +300,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("gateway", &gateway))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -222,7 +222,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::uno`]
     ///
@@ -298,9 +299,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("gateway", &gateway))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "uno",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -1,8 +1,8 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -110,26 +110,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "9000"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "9000"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -143,7 +144,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -153,7 +154,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("gateway", &gateway))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -1,6 +1,6 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -154,9 +154,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("gateway", &gateway))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "uno",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -1303,26 +1303,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "1.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "1.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/enrol`
     ///
@@ -1422,7 +1423,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
@@ -1487,7 +1490,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1497,7 +1500,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -1544,7 +1549,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1557,7 +1562,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1604,7 +1611,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1617,7 +1624,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1692,7 +1701,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1706,7 +1715,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1781,7 +1792,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1795,7 +1806,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1868,7 +1881,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1882,7 +1895,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -1424,7 +1424,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::enrol`]
     ///
@@ -1500,9 +1501,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "enrol",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -1562,9 +1566,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "global_jobs",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1624,9 +1631,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ping",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1715,9 +1725,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "report_finish",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1806,9 +1819,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "report_output",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1895,9 +1911,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "report_start",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -1404,7 +1404,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::enrol`]
     ///
@@ -1480,9 +1481,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "enrol",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -1542,9 +1546,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "global_jobs",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1604,9 +1611,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ping",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1695,9 +1705,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "report_finish",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1786,9 +1799,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "report_output",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1875,9 +1891,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "report_start",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -1283,26 +1283,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "1.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "1.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/enrol`
     ///
@@ -1402,7 +1403,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
@@ -1467,7 +1470,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1477,7 +1480,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(response)),
@@ -1524,7 +1529,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1537,7 +1542,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1584,7 +1591,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1597,7 +1604,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1672,7 +1681,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1686,7 +1695,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1761,7 +1772,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1775,7 +1786,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -1848,7 +1861,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             header_map.append("Authorization", authorization.to_string().try_into()?);
             #[allow(unused_mut)]
@@ -1862,7 +1875,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -1,8 +1,8 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -486,26 +486,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "1.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "1.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -523,7 +524,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
@@ -533,7 +534,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => Ok(ResponseValue::empty(response)),
@@ -553,7 +556,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
@@ -566,7 +569,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -586,7 +591,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
@@ -599,7 +604,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -621,7 +628,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
@@ -635,7 +642,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -657,7 +666,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
@@ -671,7 +680,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -693,7 +704,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         header_map.append("Authorization", authorization.to_string().try_into()?);
         #[allow(unused_mut)]
@@ -707,7 +718,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -1,6 +1,6 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -534,9 +534,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "enrol",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => Ok(ResponseValue::empty(response)),
@@ -569,9 +572,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "global_jobs",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -604,9 +610,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ping",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -642,9 +651,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "report_finish",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -680,9 +692,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "report_output",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -718,9 +733,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "report_start",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -30024,7 +30024,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::disk_view_by_id`]
     ///
@@ -30077,9 +30078,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30145,9 +30149,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30213,9 +30220,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30283,9 +30293,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30351,9 +30364,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30419,9 +30435,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30487,9 +30506,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30555,9 +30577,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30623,9 +30648,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30691,9 +30719,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30759,9 +30790,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30834,9 +30868,12 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "device_auth_request",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -30907,9 +30944,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "device_auth_confirm",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -30986,9 +31026,12 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "device_access_token",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31084,9 +31127,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "group_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31207,9 +31253,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_spoof",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31308,9 +31357,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_local",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31386,9 +31438,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_saml_begin",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31487,9 +31542,12 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_saml",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31536,9 +31594,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "logout",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31640,9 +31701,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31765,9 +31829,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -31836,9 +31903,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31936,9 +32006,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32007,9 +32080,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -32080,9 +32156,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32184,9 +32263,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32307,9 +32389,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32453,9 +32538,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -32540,9 +32628,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32654,9 +32745,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32741,9 +32835,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -32879,9 +32976,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33040,9 +33140,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -33143,9 +33246,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33246,9 +33352,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -33436,9 +33545,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_metrics_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33623,9 +33735,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33784,9 +33899,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -33887,9 +34005,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33990,9 +34111,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -34129,9 +34253,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34292,9 +34419,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -34395,9 +34525,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34498,9 +34631,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -34652,9 +34788,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34830,9 +34969,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_attach",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -34960,9 +35102,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_detach",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -35065,9 +35210,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_external_ip_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35195,9 +35343,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_migrate",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35350,9 +35501,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35534,9 +35688,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -35654,9 +35811,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35805,9 +35965,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35923,9 +36086,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -36026,9 +36192,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_reboot",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36185,9 +36354,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36296,9 +36468,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console_stream",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -36394,9 +36569,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_start",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36497,9 +36675,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_stop",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36586,9 +36767,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36704,9 +36888,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36843,9 +37030,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37006,9 +37196,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -37109,9 +37302,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37212,9 +37408,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37350,9 +37549,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37511,9 +37713,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -37614,9 +37819,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37744,9 +37952,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37847,9 +38058,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37952,9 +38166,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_firewall_rules_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38091,9 +38308,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_firewall_rules_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38245,9 +38465,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38423,9 +38646,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -38541,9 +38767,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38686,9 +38915,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38804,9 +39036,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -38973,9 +39208,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39172,9 +39410,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -39305,9 +39546,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39471,9 +39715,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39604,9 +39851,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -39758,9 +40008,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39936,9 +40189,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -40054,9 +40310,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40199,9 +40458,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40317,9 +40579,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -40487,9 +40752,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_list_network_interfaces",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40586,9 +40854,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40665,9 +40936,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40753,9 +41027,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "role_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40866,9 +41143,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "role_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40915,9 +41195,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_me",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41019,9 +41302,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_me_groups",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41169,9 +41455,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41292,9 +41581,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41363,9 +41655,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41434,9 +41729,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -41502,9 +41800,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41570,9 +41871,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41638,9 +41942,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41742,9 +42049,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41867,9 +42177,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41938,9 +42251,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42009,9 +42325,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -42113,9 +42432,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "physical_disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42263,9 +42585,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "rack_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42377,9 +42702,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "rack_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42481,9 +42809,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "sled_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42595,9 +42926,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "sled_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42717,9 +43051,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "sled_physical_disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42867,9 +43204,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42992,9 +43332,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43060,9 +43403,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43128,9 +43474,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43232,9 +43581,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43355,9 +43707,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43423,9 +43778,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43521,9 +43879,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43589,9 +43950,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43695,9 +44059,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_range_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43826,9 +44193,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_range_add",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43913,9 +44283,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_range_remove",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43962,9 +44335,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44050,9 +44426,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_range_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44160,9 +44539,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_range_add",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -44225,9 +44607,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_range_remove",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -44383,9 +44768,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_metric",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44434,9 +44822,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44513,9 +44904,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44617,9 +45011,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saga_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44731,9 +45128,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saga_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44835,9 +45235,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44958,9 +45361,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45026,9 +45432,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45094,9 +45503,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45218,9 +45630,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_identity_provider_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45364,9 +45779,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "local_idp_user_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45451,9 +45869,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "local_idp_user_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45554,9 +45975,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "local_idp_user_set_password",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45662,9 +46086,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saml_identity_provider_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45751,9 +46178,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saml_identity_provider_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45821,9 +46251,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45921,9 +46354,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46043,9 +46479,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_users_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46176,9 +46615,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_user_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46280,9 +46722,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_user_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46394,9 +46839,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_user_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46483,9 +46931,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "timeseries_schema_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46632,9 +47083,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "user_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46817,9 +47271,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46979,9 +47436,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -47085,9 +47545,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47191,9 +47654,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -47330,9 +47796,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47492,9 +47961,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -47598,9 +48070,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47704,9 +48179,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -47861,9 +48339,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48042,9 +48523,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_attach_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48175,9 +48659,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_detach_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48308,9 +48795,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_migrate_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48414,9 +48904,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_reboot_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48576,9 +49069,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48691,9 +49187,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console_stream_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -48792,9 +49291,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_start_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48898,9 +49400,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_stop_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -49002,9 +49507,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49127,9 +49635,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -49198,9 +49709,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49298,9 +49812,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49369,9 +49886,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -49442,9 +49962,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49546,9 +50069,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49669,9 +50195,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49814,9 +50343,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -49904,9 +50436,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50021,9 +50556,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50111,9 +50649,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50203,9 +50744,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50324,9 +50868,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50429,9 +50976,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_component_version_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50581,9 +51131,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "update_deployments_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50697,9 +51250,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "update_deployment_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50746,9 +51302,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_refresh",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50827,9 +51386,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_start",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -50876,9 +51438,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_stop",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50980,9 +51545,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -51094,9 +51662,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -51165,9 +51736,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_components_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -51216,9 +51790,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_version",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -26358,26 +26358,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "0.0.1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "0.0.1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Fetch a disk by id
     ///
@@ -30022,7 +30023,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::disk_view_by_id`]
     ///
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
@@ -30062,7 +30065,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30074,7 +30077,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30128,7 +30133,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30140,7 +30145,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30194,7 +30201,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30206,7 +30213,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30262,7 +30271,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30274,7 +30283,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30328,7 +30339,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30340,7 +30351,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30394,7 +30407,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30406,7 +30419,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30460,7 +30475,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30472,7 +30487,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30526,7 +30543,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30538,7 +30555,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30592,7 +30611,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30604,7 +30623,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30658,7 +30679,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30670,7 +30691,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30724,7 +30747,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30736,7 +30759,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30800,7 +30825,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30809,7 +30834,9 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -30867,7 +30894,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30880,7 +30907,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -30948,7 +30977,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30957,7 +30986,9 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31035,7 +31066,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31053,7 +31084,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31161,7 +31194,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31174,7 +31207,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31264,7 +31299,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31273,7 +31308,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31345,11 +31382,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31435,7 +31474,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31448,7 +31487,9 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31483,7 +31524,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31495,7 +31536,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31579,7 +31622,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31597,7 +31640,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31707,7 +31752,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31720,7 +31765,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -31777,7 +31824,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31789,7 +31836,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31874,7 +31923,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31887,7 +31936,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31944,7 +31995,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31956,7 +32007,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -32015,7 +32068,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32027,7 +32080,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32116,7 +32171,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32129,7 +32184,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32232,7 +32289,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32250,7 +32307,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32381,7 +32440,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32394,7 +32453,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -32467,7 +32528,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32479,7 +32540,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32578,7 +32641,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32591,7 +32654,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32664,7 +32729,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32676,7 +32741,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -32794,7 +32861,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32812,7 +32879,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32958,7 +33027,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32971,7 +33040,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -33060,7 +33131,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33072,7 +33143,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33161,7 +33234,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33173,7 +33246,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -33339,7 +33414,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33361,7 +33436,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33528,7 +33605,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33546,7 +33623,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33692,7 +33771,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33705,7 +33784,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -33794,7 +33875,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33806,7 +33887,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33895,7 +33978,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33907,7 +33990,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -34026,7 +34111,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34044,7 +34129,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34192,7 +34279,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34205,7 +34292,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -34294,7 +34383,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34306,7 +34395,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34395,7 +34486,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34407,7 +34498,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -34541,7 +34634,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34559,7 +34652,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34722,7 +34817,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34735,7 +34830,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -34850,7 +34947,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34863,7 +34960,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -34954,7 +35053,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34966,7 +35065,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35081,7 +35182,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35094,7 +35195,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35229,7 +35332,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35247,7 +35350,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35416,7 +35521,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35429,7 +35534,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -35535,7 +35642,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35547,7 +35654,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35683,7 +35792,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35696,7 +35805,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35800,7 +35911,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35812,7 +35923,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -35901,7 +36014,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35913,7 +36026,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36049,7 +36164,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36070,7 +36185,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36161,7 +36278,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36179,7 +36296,9 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -36263,7 +36382,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36275,7 +36394,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36364,7 +36485,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36376,7 +36497,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36451,7 +36574,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36463,7 +36586,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36566,7 +36691,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36579,7 +36704,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36698,7 +36825,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36716,7 +36843,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36864,7 +36993,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36877,7 +37006,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -36966,7 +37097,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36978,7 +37109,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37067,7 +37200,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37079,7 +37212,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37197,7 +37332,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37215,7 +37350,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37361,7 +37498,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37374,7 +37511,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -37463,7 +37602,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37475,7 +37614,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37590,7 +37731,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37603,7 +37744,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37692,7 +37835,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37704,7 +37847,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37795,7 +37940,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37807,7 +37952,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37931,7 +38078,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37944,7 +38091,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38078,7 +38227,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38096,7 +38245,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38259,7 +38410,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38272,7 +38423,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -38376,7 +38529,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38388,7 +38541,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38518,7 +38673,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38531,7 +38686,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38635,7 +38792,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38647,7 +38804,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -38796,7 +38955,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38814,7 +38973,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38998,7 +39159,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39011,7 +39172,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -39130,7 +39293,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39142,7 +39305,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39293,7 +39458,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39306,7 +39471,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39425,7 +39592,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39437,7 +39604,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -39571,7 +39740,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39589,7 +39758,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39752,7 +39923,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39765,7 +39936,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -39869,7 +40042,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39881,7 +40054,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40011,7 +40186,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40024,7 +40199,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40128,7 +40305,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40140,7 +40317,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -40290,7 +40469,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40308,7 +40487,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40393,7 +40574,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40405,7 +40586,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40469,7 +40652,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40482,7 +40665,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40551,7 +40736,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40568,7 +40753,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40667,7 +40854,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40679,7 +40866,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40714,7 +40903,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40726,7 +40915,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40810,7 +41001,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40828,7 +41019,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40958,7 +41151,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40976,7 +41169,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41084,7 +41279,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41097,7 +41292,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41154,7 +41351,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41166,7 +41363,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41223,7 +41422,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41235,7 +41434,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -41289,7 +41490,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41301,7 +41502,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41355,7 +41558,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41367,7 +41570,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41421,7 +41626,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41433,7 +41638,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41517,7 +41724,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41535,7 +41742,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41645,7 +41854,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41658,7 +41867,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41715,7 +41926,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41727,7 +41938,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41784,7 +41997,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41796,7 +42009,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -41880,7 +42095,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41898,7 +42113,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42028,7 +42245,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42046,7 +42263,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42146,7 +42365,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42158,7 +42377,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42242,7 +42463,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42260,7 +42481,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42360,7 +42583,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42372,7 +42595,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42474,7 +42699,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42492,7 +42717,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42622,7 +42849,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42640,7 +42867,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42750,7 +42979,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42763,7 +42992,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -42817,7 +43048,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42829,7 +43060,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42883,7 +43116,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42895,7 +43128,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -42979,7 +43214,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42997,7 +43232,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43105,7 +43342,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43118,7 +43355,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43172,7 +43411,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43184,7 +43423,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43267,7 +43508,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43280,7 +43521,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43334,7 +43577,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43346,7 +43589,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43433,7 +43678,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43450,7 +43695,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43566,7 +43813,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43579,7 +43826,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43651,7 +43900,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43664,7 +43913,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43699,7 +43950,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43711,7 +43962,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43780,7 +44033,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43797,7 +44050,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43892,7 +44147,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43905,7 +44160,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43955,7 +44212,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43968,7 +44225,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -44101,7 +44360,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44124,7 +44383,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44161,7 +44422,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44173,7 +44434,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44237,7 +44500,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44250,7 +44513,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44334,7 +44599,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44352,7 +44617,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44452,7 +44719,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44464,7 +44731,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44548,7 +44817,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44566,7 +44835,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44674,7 +44945,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44687,7 +44958,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -44741,7 +45014,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44753,7 +45026,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44807,7 +45082,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44819,7 +45094,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -44923,7 +45200,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44941,7 +45218,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45072,7 +45351,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45085,7 +45364,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45158,7 +45439,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45170,7 +45451,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45258,7 +45541,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45271,7 +45554,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45364,7 +45649,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45377,7 +45662,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45452,7 +45739,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45464,7 +45751,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45520,7 +45809,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45532,7 +45821,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45617,7 +45908,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45630,7 +45921,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45732,7 +46025,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45750,7 +46043,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45869,7 +46164,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45881,7 +46176,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45965,7 +46262,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45983,7 +46280,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46083,7 +46382,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46095,7 +46394,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46165,7 +46466,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46182,7 +46483,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46311,7 +46614,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46329,7 +46632,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46489,7 +46794,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46512,7 +46817,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46654,7 +46961,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46672,7 +46979,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -46759,7 +47068,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46776,7 +47085,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46863,7 +47174,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46880,7 +47191,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -46994,7 +47307,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47017,7 +47330,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47159,7 +47474,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47177,7 +47492,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -47264,7 +47581,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47281,7 +47598,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47368,7 +47687,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47385,7 +47704,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -47517,7 +47838,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47540,7 +47861,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47701,7 +48024,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47719,7 +48042,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -47832,7 +48157,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47850,7 +48175,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -47963,7 +48290,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47981,7 +48308,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48068,7 +48397,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48085,7 +48414,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48219,7 +48550,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48245,7 +48576,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48335,7 +48668,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48358,7 +48691,9 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -48440,7 +48775,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48457,7 +48792,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48544,7 +48881,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48561,7 +48898,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48645,7 +48984,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48663,7 +49002,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48773,7 +49114,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48786,7 +49127,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -48843,7 +49186,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48855,7 +49198,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48940,7 +49285,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48953,7 +49298,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49010,7 +49357,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49022,7 +49369,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -49081,7 +49430,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49093,7 +49442,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49182,7 +49533,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49195,7 +49546,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49294,7 +49647,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49316,7 +49669,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49442,7 +49797,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49459,7 +49814,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -49531,7 +49888,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49547,7 +49904,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49645,7 +50004,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49662,7 +50021,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49734,7 +50095,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49750,7 +50111,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -49824,7 +50187,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49840,7 +50203,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49942,7 +50307,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49959,7 +50324,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50044,7 +50411,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50062,7 +50429,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50194,7 +50563,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50212,7 +50581,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50314,7 +50685,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50326,7 +50697,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50361,7 +50734,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50373,7 +50746,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50439,7 +50814,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50452,7 +50827,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -50487,7 +50864,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50499,7 +50876,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50583,7 +50962,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50601,7 +50980,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50701,7 +51082,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50713,7 +51094,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50770,7 +51153,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50782,7 +51165,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50819,7 +51204,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50831,7 +51216,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -29873,7 +29873,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`ClientDisksExt::disk_view_by_id`]
     ///
@@ -29926,9 +29927,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -29994,9 +29998,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30062,9 +30069,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30133,9 +30143,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30201,9 +30214,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30269,9 +30285,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30337,9 +30356,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30405,9 +30427,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30473,9 +30498,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30541,9 +30569,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30609,9 +30640,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30684,9 +30718,12 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "device_auth_request",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -30757,9 +30794,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "device_auth_confirm",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -30836,9 +30876,12 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "device_access_token",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -30934,9 +30977,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "group_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31057,9 +31103,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_spoof",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31158,9 +31207,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_local",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31236,9 +31288,12 @@ pub mod builder {
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_saml_begin",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31337,9 +31392,12 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "login_saml",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31386,9 +31444,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "logout",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31490,9 +31551,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31615,9 +31679,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -31686,9 +31753,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31786,9 +31856,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31857,9 +31930,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31930,9 +32006,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32034,9 +32113,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32157,9 +32239,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32303,9 +32388,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -32390,9 +32478,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32504,9 +32595,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32591,9 +32685,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -32729,9 +32826,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32890,9 +32990,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -32993,9 +33096,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33096,9 +33202,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -33286,9 +33395,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_metrics_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33473,9 +33585,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33634,9 +33749,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -33737,9 +33855,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33840,9 +33961,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "image_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -33979,9 +34103,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34142,9 +34269,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -34245,9 +34375,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34348,9 +34481,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -34502,9 +34638,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34680,9 +34819,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_attach",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -34810,9 +34952,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_detach",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -34915,9 +35060,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_external_ip_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35045,9 +35193,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_migrate",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35200,9 +35351,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35384,9 +35538,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -35504,9 +35661,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35655,9 +35815,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35773,9 +35936,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_network_interface_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -35876,9 +36042,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_reboot",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36035,9 +36204,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36146,9 +36318,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console_stream",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -36244,9 +36419,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_start",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36347,9 +36525,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_stop",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36436,9 +36617,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36554,9 +36738,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36693,9 +36880,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36856,9 +37046,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -36959,9 +37152,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37062,9 +37258,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "snapshot_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37200,9 +37399,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37361,9 +37563,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -37464,9 +37669,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37594,9 +37802,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37697,9 +37908,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37802,9 +38016,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_firewall_rules_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37941,9 +38158,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_firewall_rules_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38095,9 +38315,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38273,9 +38496,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -38391,9 +38617,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38536,9 +38765,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38654,9 +38886,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -38823,9 +39058,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39022,9 +39260,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -39155,9 +39396,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39321,9 +39565,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39454,9 +39701,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_router_route_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -39608,9 +39858,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39786,9 +40039,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -39904,9 +40160,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40049,9 +40308,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40167,9 +40429,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -40337,9 +40602,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "vpc_subnet_list_network_interfaces",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40436,9 +40704,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40515,9 +40786,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40603,9 +40877,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "role_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40716,9 +40993,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "role_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40765,9 +41045,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_me",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40869,9 +41152,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_me_groups",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41019,9 +41305,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41142,9 +41431,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41213,9 +41505,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41284,9 +41579,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "session_sshkey_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -41352,9 +41650,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41420,9 +41721,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41488,9 +41792,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_view_by_id",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41592,9 +41899,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41717,9 +42027,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41788,9 +42101,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41859,9 +42175,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "certificate_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -41963,9 +42282,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "physical_disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42113,9 +42435,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "rack_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42227,9 +42552,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "rack_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42331,9 +42659,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "sled_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42445,9 +42776,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "sled_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42567,9 +42901,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "sled_physical_disk_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42717,9 +43054,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42842,9 +43182,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -42910,9 +43253,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42978,9 +43324,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_image_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43082,9 +43431,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43205,9 +43557,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43273,9 +43628,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43371,9 +43729,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43439,9 +43800,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43545,9 +43909,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_range_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43676,9 +44043,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_range_add",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43763,9 +44133,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_range_remove",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43812,9 +44185,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43900,9 +44276,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_range_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44010,9 +44389,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_range_add",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -44075,9 +44457,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "ip_pool_service_range_remove",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -44233,9 +44618,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_metric",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44284,9 +44672,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44363,9 +44754,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44467,9 +44861,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saga_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44581,9 +44978,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saga_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44685,9 +45085,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44808,9 +45211,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -44876,9 +45282,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44944,9 +45353,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45068,9 +45480,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_identity_provider_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45214,9 +45629,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "local_idp_user_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45301,9 +45719,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "local_idp_user_delete",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45404,9 +45825,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "local_idp_user_set_password",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45512,9 +45936,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saml_identity_provider_create",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45601,9 +46028,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "saml_identity_provider_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45671,9 +46101,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_policy_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45771,9 +46204,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_policy_update",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45893,9 +46329,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_users_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46026,9 +46465,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "silo_user_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46130,9 +46572,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_user_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46244,9 +46689,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_user_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46333,9 +46781,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "timeseries_schema_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46482,9 +46933,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "user_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46667,9 +47121,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46829,9 +47286,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -46935,9 +47395,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47041,9 +47504,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "disk_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -47180,9 +47646,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47342,9 +47811,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -47448,9 +47920,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47554,9 +48029,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -47711,9 +48189,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47892,9 +48373,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_attach_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48025,9 +48509,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_disk_detach_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48158,9 +48645,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_migrate_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48264,9 +48754,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_reboot_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48426,9 +48919,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48541,9 +49037,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial_console_stream_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -48642,9 +49141,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_start_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48748,9 +49250,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_stop_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48852,9 +49357,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48977,9 +49485,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -49048,9 +49559,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49148,9 +49662,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49219,9 +49736,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -49292,9 +49812,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49396,9 +49919,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "organization_policy_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49519,9 +50045,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_list_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49664,9 +50193,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_create_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -49754,9 +50286,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49871,9 +50406,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49961,9 +50499,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_delete_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50053,9 +50594,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_view_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50174,9 +50718,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "project_policy_update_v1",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50279,9 +50826,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_component_version_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50431,9 +50981,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "update_deployments_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50547,9 +51100,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "update_deployment_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50596,9 +51152,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_refresh",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50677,9 +51236,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_start",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -50726,9 +51288,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_stop",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50830,9 +51395,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50944,9 +51512,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_view",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -51015,9 +51586,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_update_components_list",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -51066,9 +51640,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "system_version",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -25921,26 +25921,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "0.0.1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "0.0.1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 ///Virtual disks are used to store instance-local data which includes the
 /// operating system.
 pub trait ClientDisksExt {
@@ -29871,7 +29872,9 @@ impl ClientVpcsExt for Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`ClientDisksExt::disk_view_by_id`]
     ///
     ///[`ClientDisksExt::disk_view_by_id`]: super::ClientDisksExt::disk_view_by_id
@@ -29911,7 +29914,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -29923,7 +29926,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -29977,7 +29982,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -29989,7 +29994,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30043,7 +30050,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30055,7 +30062,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30112,7 +30121,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30124,7 +30133,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30178,7 +30189,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30190,7 +30201,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30244,7 +30257,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30256,7 +30269,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30310,7 +30325,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30322,7 +30337,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30376,7 +30393,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30388,7 +30405,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30442,7 +30461,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30454,7 +30473,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30508,7 +30529,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30520,7 +30541,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30574,7 +30597,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30586,7 +30609,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -30650,7 +30675,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30659,7 +30684,9 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -30717,7 +30744,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30730,7 +30757,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -30798,7 +30827,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30807,7 +30836,9 @@ pub mod builder {
                 .form_urlencoded(&body)?
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -30885,7 +30916,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -30903,7 +30934,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31011,7 +31044,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31024,7 +31057,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31114,7 +31149,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31123,7 +31158,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31195,11 +31232,13 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client.client.get(url).headers(header_map).build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31285,7 +31324,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31298,7 +31337,9 @@ pub mod builder {
                 .body(body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),
@@ -31333,7 +31374,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31345,7 +31386,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31429,7 +31472,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31447,7 +31490,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31557,7 +31602,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31570,7 +31615,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -31627,7 +31674,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31639,7 +31686,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31724,7 +31773,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31737,7 +31786,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31794,7 +31845,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31806,7 +31857,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -31865,7 +31918,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31877,7 +31930,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -31966,7 +32021,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -31979,7 +32034,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32082,7 +32139,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32100,7 +32157,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32231,7 +32290,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32244,7 +32303,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -32317,7 +32378,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32329,7 +32390,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32428,7 +32491,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32441,7 +32504,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32514,7 +32579,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32526,7 +32591,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -32644,7 +32711,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32662,7 +32729,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -32808,7 +32877,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32821,7 +32890,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -32910,7 +32981,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -32922,7 +32993,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33011,7 +33084,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33023,7 +33096,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -33189,7 +33264,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33211,7 +33286,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33378,7 +33455,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33396,7 +33473,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33542,7 +33621,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33555,7 +33634,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -33644,7 +33725,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33656,7 +33737,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -33745,7 +33828,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33757,7 +33840,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -33876,7 +33961,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -33894,7 +33979,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34042,7 +34129,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34055,7 +34142,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -34144,7 +34233,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34156,7 +34245,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34245,7 +34336,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34257,7 +34348,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -34391,7 +34484,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34409,7 +34502,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34572,7 +34667,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34585,7 +34680,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -34700,7 +34797,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34713,7 +34810,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -34804,7 +34903,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34816,7 +34915,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -34931,7 +35032,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -34944,7 +35045,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35079,7 +35182,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35097,7 +35200,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35266,7 +35371,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35279,7 +35384,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -35385,7 +35492,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35397,7 +35504,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35533,7 +35642,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35546,7 +35655,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -35650,7 +35761,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35662,7 +35773,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -35751,7 +35864,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35763,7 +35876,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -35899,7 +36014,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -35920,7 +36035,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36011,7 +36128,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36029,7 +36146,9 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -36113,7 +36232,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36125,7 +36244,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36214,7 +36335,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36226,7 +36347,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -36301,7 +36424,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36313,7 +36436,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36416,7 +36541,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36429,7 +36554,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36548,7 +36675,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36566,7 +36693,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36714,7 +36843,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36727,7 +36856,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -36816,7 +36947,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36828,7 +36959,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -36917,7 +37050,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -36929,7 +37062,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37047,7 +37182,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37065,7 +37200,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37211,7 +37348,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37224,7 +37361,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -37313,7 +37452,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37325,7 +37464,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37440,7 +37581,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37453,7 +37594,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37542,7 +37685,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37554,7 +37697,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -37645,7 +37790,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37657,7 +37802,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37781,7 +37928,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37794,7 +37941,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -37928,7 +38077,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -37946,7 +38095,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38109,7 +38260,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38122,7 +38273,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -38226,7 +38379,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38238,7 +38391,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38368,7 +38523,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38381,7 +38536,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38485,7 +38642,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38497,7 +38654,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -38646,7 +38805,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38664,7 +38823,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -38848,7 +39009,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38861,7 +39022,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -38980,7 +39143,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -38992,7 +39155,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39143,7 +39308,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39156,7 +39321,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39275,7 +39442,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39287,7 +39454,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -39421,7 +39590,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39439,7 +39608,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39602,7 +39773,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39615,7 +39786,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -39719,7 +39892,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39731,7 +39904,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39861,7 +40036,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39874,7 +40049,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -39978,7 +40155,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -39990,7 +40167,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -40140,7 +40319,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40158,7 +40337,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40243,7 +40424,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40255,7 +40436,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40319,7 +40502,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40332,7 +40515,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40401,7 +40586,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40418,7 +40603,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40517,7 +40704,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40529,7 +40716,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40564,7 +40753,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40576,7 +40765,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40660,7 +40851,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40678,7 +40869,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40808,7 +41001,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40826,7 +41019,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -40934,7 +41129,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -40947,7 +41142,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41004,7 +41201,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41016,7 +41213,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41073,7 +41272,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41085,7 +41284,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -41139,7 +41340,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41151,7 +41352,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41205,7 +41408,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41217,7 +41420,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41271,7 +41476,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41283,7 +41488,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41367,7 +41574,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41385,7 +41592,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41495,7 +41704,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41508,7 +41717,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -41565,7 +41776,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41577,7 +41788,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41634,7 +41847,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41646,7 +41859,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -41730,7 +41945,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41748,7 +41963,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41878,7 +42095,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -41896,7 +42113,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -41996,7 +42215,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42008,7 +42227,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42092,7 +42313,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42110,7 +42331,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42210,7 +42433,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42222,7 +42445,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42324,7 +42549,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42342,7 +42567,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42472,7 +42699,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42490,7 +42717,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42600,7 +42829,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42613,7 +42842,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -42667,7 +42898,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42679,7 +42910,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42733,7 +42966,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42745,7 +42978,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -42829,7 +43064,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42847,7 +43082,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -42955,7 +43192,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -42968,7 +43205,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43022,7 +43261,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43034,7 +43273,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43117,7 +43358,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43130,7 +43371,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43184,7 +43427,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43196,7 +43439,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43283,7 +43528,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43300,7 +43545,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43416,7 +43663,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43429,7 +43676,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43501,7 +43750,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43514,7 +43763,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43549,7 +43800,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43561,7 +43812,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43630,7 +43883,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43647,7 +43900,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -43742,7 +43997,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43755,7 +44010,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -43805,7 +44062,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43818,7 +44075,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -43951,7 +44210,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -43974,7 +44233,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44011,7 +44272,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44023,7 +44284,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44087,7 +44350,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44100,7 +44363,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44184,7 +44449,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44202,7 +44467,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44302,7 +44569,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44314,7 +44581,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44398,7 +44667,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44416,7 +44685,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44524,7 +44795,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44537,7 +44808,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -44591,7 +44864,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44603,7 +44876,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44657,7 +44932,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44669,7 +44944,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -44773,7 +45050,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44791,7 +45068,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -44922,7 +45201,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -44935,7 +45214,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45008,7 +45289,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45020,7 +45301,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45108,7 +45391,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45121,7 +45404,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -45214,7 +45499,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45227,7 +45512,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -45302,7 +45589,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45314,7 +45601,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45370,7 +45659,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45382,7 +45671,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45467,7 +45758,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45480,7 +45771,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45582,7 +45875,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45600,7 +45893,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45719,7 +46014,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45731,7 +46026,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45815,7 +46112,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45833,7 +46130,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -45933,7 +46232,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -45945,7 +46244,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46015,7 +46316,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46032,7 +46333,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46161,7 +46464,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46179,7 +46482,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46339,7 +46644,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46362,7 +46667,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46504,7 +46811,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46522,7 +46829,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -46609,7 +46918,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46626,7 +46935,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -46713,7 +47024,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46730,7 +47041,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -46844,7 +47157,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -46867,7 +47180,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47009,7 +47324,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47027,7 +47342,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -47114,7 +47431,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47131,7 +47448,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47218,7 +47537,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47235,7 +47554,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -47367,7 +47688,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47390,7 +47711,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47551,7 +47874,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47569,7 +47892,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -47682,7 +48007,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47700,7 +48025,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -47813,7 +48140,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47831,7 +48158,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -47918,7 +48247,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -47935,7 +48264,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48069,7 +48400,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48095,7 +48426,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48185,7 +48518,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48208,7 +48541,9 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -48290,7 +48625,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48307,7 +48642,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48394,7 +48731,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48411,7 +48748,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("project", &project))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -48495,7 +48834,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48513,7 +48852,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48623,7 +48964,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48636,7 +48977,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -48693,7 +49036,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48705,7 +49048,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48790,7 +49135,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48803,7 +49148,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -48860,7 +49207,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48872,7 +49219,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -48931,7 +49280,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -48943,7 +49292,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49032,7 +49383,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49045,7 +49396,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49144,7 +49497,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49166,7 +49519,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49292,7 +49647,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49309,7 +49664,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -49381,7 +49738,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49397,7 +49754,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49495,7 +49854,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49512,7 +49871,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49584,7 +49945,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49600,7 +49961,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -49674,7 +50037,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49690,7 +50053,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49792,7 +50157,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49809,7 +50174,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -49894,7 +50261,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -49912,7 +50279,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50044,7 +50413,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50062,7 +50431,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50164,7 +50535,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50176,7 +50547,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50211,7 +50584,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50223,7 +50596,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50289,7 +50664,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50302,7 +50677,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 202u16 => ResponseValue::from_response(response).await,
@@ -50337,7 +50714,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50349,7 +50726,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -50433,7 +50812,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50451,7 +50830,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50551,7 +50932,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50563,7 +50944,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50620,7 +51003,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50632,7 +51015,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -50669,7 +51054,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -50681,7 +51066,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -1,6 +1,6 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -14124,9 +14124,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14167,9 +14170,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "image_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14210,9 +14216,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14253,9 +14262,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_network_interface_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14298,9 +14310,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14343,9 +14358,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14386,9 +14404,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "snapshot_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14429,9 +14450,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_route_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14472,9 +14496,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14515,9 +14542,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_subnet_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14558,9 +14588,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14598,9 +14631,12 @@ impl Client {
             .form_urlencoded(&body)?
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "device_auth_request",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14637,9 +14673,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "device_auth_confirm",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -14676,9 +14715,12 @@ impl Client {
             .form_urlencoded(&body)?
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "device_access_token",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14723,9 +14765,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "group_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14800,9 +14845,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "login_spoof",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -14841,9 +14889,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "login_local",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14881,9 +14932,12 @@ impl Client {
         );
         #[allow(unused_mut)]
         let mut request = self.client.get(url).headers(header_map).build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "login_saml_begin",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14928,9 +14982,12 @@ impl Client {
             .body(body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "login_saml",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14962,9 +15019,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "logout",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -15017,9 +15077,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15101,9 +15164,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -15149,9 +15215,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15200,9 +15269,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15248,9 +15320,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -15296,9 +15371,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_policy_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15347,9 +15425,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_policy_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15408,9 +15489,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15503,9 +15587,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -15555,9 +15642,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15610,9 +15700,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15662,9 +15755,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -15727,9 +15823,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15832,9 +15931,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -15883,9 +15985,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15932,9 +16037,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -16008,9 +16116,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_metrics_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16143,9 +16254,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "image_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16251,9 +16365,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "image_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -16302,9 +16419,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "image_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16355,9 +16475,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "image_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -16418,9 +16541,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16524,9 +16650,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -16575,9 +16704,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16624,9 +16756,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -16693,9 +16828,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_disk_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16808,9 +16946,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_disk_attach",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -16861,9 +17002,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_disk_detach",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -16910,9 +17054,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_external_ip_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16963,9 +17110,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_migrate",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17030,9 +17180,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_network_interface_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17142,9 +17295,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_network_interface_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -17193,9 +17349,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_network_interface_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17246,9 +17405,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_network_interface_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17302,9 +17464,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_network_interface_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -17353,9 +17518,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_reboot",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -17432,9 +17600,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_serial_console",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17489,9 +17660,12 @@ impl Client {
                 ),
             )
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_serial_console_stream",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             101u16 => ResponseValue::upgrade(response).await,
@@ -17535,9 +17709,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_start",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -17586,9 +17763,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_stop",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -17638,9 +17818,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_policy_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17691,9 +17874,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_policy_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17754,9 +17940,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "snapshot_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17860,9 +18049,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "snapshot_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -17909,9 +18101,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "snapshot_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17958,9 +18153,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "snapshot_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -18021,9 +18219,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18124,9 +18325,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -18173,9 +18377,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18224,9 +18431,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18273,9 +18483,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -18322,9 +18535,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_firewall_rules_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18373,9 +18589,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_firewall_rules_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18440,9 +18659,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18552,9 +18774,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -18603,9 +18828,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18656,9 +18884,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18707,9 +18938,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -18779,9 +19013,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_route_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18900,9 +19137,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_route_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -18953,9 +19193,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_route_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19008,9 +19251,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_route_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19061,9 +19307,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_router_route_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -19128,9 +19377,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_subnet_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19240,9 +19492,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_subnet_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -19291,9 +19546,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_subnet_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19344,9 +19602,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_subnet_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19395,9 +19656,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_subnet_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -19465,9 +19729,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "vpc_subnet_list_network_interfaces",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19569,9 +19836,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "policy_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19609,9 +19879,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "policy_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19659,9 +19932,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "role_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19742,9 +20018,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "role_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19780,9 +20059,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "session_me",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19833,9 +20115,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "session_me_groups",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19927,9 +20212,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "session_sshkey_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20010,9 +20298,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "session_sshkey_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -20056,9 +20347,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "session_sshkey_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20102,9 +20396,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "session_sshkey_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -20145,9 +20442,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_image_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20188,9 +20488,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20231,9 +20534,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_view_by_id",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20288,9 +20594,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "certificate_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20375,9 +20684,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "certificate_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -20420,9 +20732,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "certificate_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20465,9 +20780,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "certificate_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -20518,9 +20836,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "physical_disk_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20611,9 +20932,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "rack_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20696,9 +21020,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "rack_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20749,9 +21076,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "sled_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20834,9 +21164,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "sled_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20893,9 +21226,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "sled_physical_disk_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20993,9 +21329,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_image_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21080,9 +21419,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_image_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -21125,9 +21467,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_image_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21172,9 +21517,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_image_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -21225,9 +21573,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21304,9 +21655,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -21347,9 +21701,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21392,9 +21749,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21435,9 +21795,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -21493,9 +21856,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_range_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21580,9 +21946,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_range_add",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -21625,9 +21994,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_range_remove",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -21663,9 +22035,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_service_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21715,9 +22090,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_service_range_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21795,9 +22173,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_service_range_add",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -21835,9 +22216,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "ip_pool_service_range_remove",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -21903,9 +22287,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_metric",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21941,9 +22328,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_policy_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21981,9 +22371,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_policy_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22034,9 +22427,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "saga_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22116,9 +22512,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "saga_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22171,9 +22570,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22252,9 +22654,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -22300,9 +22705,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22348,9 +22756,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -22407,9 +22818,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_identity_provider_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22504,9 +22918,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "local_idp_user_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -22554,9 +22971,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "local_idp_user_delete",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -22611,9 +23031,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "local_idp_user_set_password",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -22661,9 +23084,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "saml_identity_provider_create",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -22711,9 +23137,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "saml_identity_provider_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22757,9 +23186,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_policy_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22806,9 +23238,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_policy_update",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22865,9 +23300,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_users_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22955,9 +23393,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "silo_user_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23008,9 +23449,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_user_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23094,9 +23538,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_user_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23144,9 +23591,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "timeseries_schema_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23235,9 +23685,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "user_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23336,9 +23789,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_list_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23426,9 +23882,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_create_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -23476,9 +23935,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_view_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23526,9 +23988,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "disk_delete_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -23588,9 +24053,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_list_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23679,9 +24147,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_create_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -23729,9 +24200,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_view_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23779,9 +24253,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_delete_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -23847,9 +24324,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_disk_list_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23951,9 +24431,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_disk_attach_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -24003,9 +24486,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_disk_detach_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -24055,9 +24541,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_migrate_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24105,9 +24594,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_reboot_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -24183,9 +24675,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_serial_console_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24240,9 +24735,12 @@ impl Client {
                 ),
             )
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_serial_console_stream_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             101u16 => ResponseValue::upgrade(response).await,
@@ -24285,9 +24783,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_start_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -24335,9 +24836,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_stop_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -24388,9 +24892,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_list_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24468,9 +24975,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_create_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -24511,9 +25021,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_view_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24556,9 +25069,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_update_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24599,9 +25115,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_delete_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -24642,9 +25161,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_policy_view_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24687,9 +25209,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "organization_policy_update_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24746,9 +25271,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_list_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24832,9 +25360,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_create_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -24880,9 +25411,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_view_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24930,9 +25464,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_update_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24978,9 +25515,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_delete_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -25026,9 +25566,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_policy_view_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25076,9 +25619,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "project_policy_update_v1",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25129,9 +25675,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_component_version_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25222,9 +25771,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "update_deployments_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25305,9 +25857,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "update_deployment_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25343,9 +25898,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_update_refresh",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -25383,9 +25941,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_update_start",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -25423,9 +25984,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_update_stop",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -25476,9 +26040,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_update_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25559,9 +26126,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_update_view",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25603,9 +26173,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_update_components_list",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25641,9 +26214,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "system_version",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -1,8 +1,8 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -14071,26 +14071,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "0.0.1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "0.0.1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -14111,7 +14112,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14123,7 +14124,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14152,7 +14155,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14164,7 +14167,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14193,7 +14198,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14205,7 +14210,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14234,7 +14241,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14246,7 +14253,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14277,7 +14286,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14289,7 +14298,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14320,7 +14331,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14332,7 +14343,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14361,7 +14374,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14373,7 +14386,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14402,7 +14417,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14414,7 +14429,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14443,7 +14460,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14455,7 +14472,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14484,7 +14503,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14496,7 +14515,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14525,7 +14546,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14537,7 +14558,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14566,7 +14589,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14575,7 +14598,9 @@ impl Client {
             .form_urlencoded(&body)?
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14599,7 +14624,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14612,7 +14637,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -14640,7 +14667,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14649,7 +14676,9 @@ impl Client {
             .form_urlencoded(&body)?
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14676,7 +14705,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14694,7 +14723,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -14756,7 +14787,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14769,7 +14800,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -14799,7 +14832,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14808,7 +14841,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14842,11 +14877,13 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self.client.get(url).headers(header_map).build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14878,7 +14915,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14891,7 +14928,9 @@ impl Client {
             .body(body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),
@@ -14911,7 +14950,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14923,7 +14962,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -14958,7 +14999,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -14976,7 +15017,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15045,7 +15088,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15058,7 +15101,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -15092,7 +15137,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15104,7 +15149,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15140,7 +15187,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15153,7 +15200,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15187,7 +15236,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15199,7 +15248,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -15233,7 +15284,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15245,7 +15296,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15281,7 +15334,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15294,7 +15347,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15335,7 +15390,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15353,7 +15408,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15433,7 +15490,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15446,7 +15503,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -15484,7 +15543,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15496,7 +15555,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15536,7 +15597,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15549,7 +15610,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15587,7 +15650,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15599,7 +15662,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -15644,7 +15709,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15662,7 +15727,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15752,7 +15819,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15765,7 +15832,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -15802,7 +15871,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15814,7 +15883,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -15849,7 +15920,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15861,7 +15932,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -15913,7 +15986,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -15935,7 +16008,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16050,7 +16125,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16068,7 +16143,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16161,7 +16238,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16174,7 +16251,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -16211,7 +16290,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16223,7 +16302,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16262,7 +16343,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16274,7 +16355,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -16317,7 +16400,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16335,7 +16418,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16426,7 +16511,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16439,7 +16524,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -16476,7 +16563,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16488,7 +16575,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16523,7 +16612,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16535,7 +16624,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -16584,7 +16675,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16602,7 +16693,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16702,7 +16795,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16715,7 +16808,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -16753,7 +16848,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16766,7 +16861,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -16801,7 +16898,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16813,7 +16910,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16851,7 +16950,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16864,7 +16963,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -16911,7 +17012,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -16929,7 +17030,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17026,7 +17129,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17039,7 +17142,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -17076,7 +17181,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17088,7 +17193,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17126,7 +17233,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17139,7 +17246,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17181,7 +17290,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17193,7 +17302,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -17230,7 +17341,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17242,7 +17353,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -17298,7 +17411,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17319,7 +17432,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17356,7 +17471,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17374,7 +17489,9 @@ impl Client {
                 ),
             )
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             101u16 => ResponseValue::upgrade(response).await,
@@ -17406,7 +17523,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17418,7 +17535,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -17455,7 +17574,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17467,7 +17586,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -17505,7 +17626,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17517,7 +17638,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17555,7 +17678,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17568,7 +17691,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17611,7 +17736,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17629,7 +17754,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17720,7 +17847,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17733,7 +17860,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -17768,7 +17897,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17780,7 +17909,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17815,7 +17946,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17827,7 +17958,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -17870,7 +18003,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17888,7 +18021,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -17976,7 +18111,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -17989,7 +18124,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -18024,7 +18161,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18036,7 +18173,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18072,7 +18211,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18085,7 +18224,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18120,7 +18261,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18132,7 +18273,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -18167,7 +18310,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18179,7 +18322,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18215,7 +18360,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18228,7 +18373,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18275,7 +18422,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18293,7 +18440,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18390,7 +18539,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18403,7 +18552,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -18440,7 +18591,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18452,7 +18603,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18490,7 +18643,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18503,7 +18656,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18540,7 +18695,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18552,7 +18707,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -18604,7 +18761,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18622,7 +18779,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18728,7 +18887,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18741,7 +18900,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -18780,7 +18941,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18792,7 +18953,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18832,7 +18995,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18845,7 +19008,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -18884,7 +19049,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18896,7 +19061,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -18943,7 +19110,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -18961,7 +19128,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19058,7 +19227,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19071,7 +19240,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -19108,7 +19279,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19120,7 +19291,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19158,7 +19331,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19171,7 +19344,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19208,7 +19383,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19220,7 +19395,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -19270,7 +19447,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19288,7 +19465,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19378,7 +19557,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19390,7 +19569,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19415,7 +19596,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19428,7 +19609,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19459,7 +19642,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19476,7 +19659,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19545,7 +19730,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19557,7 +19742,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19581,7 +19768,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19593,7 +19780,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19626,7 +19815,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19644,7 +19833,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19718,7 +19909,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19736,7 +19927,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19804,7 +19997,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19817,7 +20010,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -19849,7 +20044,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19861,7 +20056,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19893,7 +20090,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19905,7 +20102,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -19934,7 +20133,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19946,7 +20145,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -19975,7 +20176,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -19987,7 +20188,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20016,7 +20219,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20028,7 +20231,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20065,7 +20270,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20083,7 +20288,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20155,7 +20362,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20168,7 +20375,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -20199,7 +20408,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20211,7 +20420,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20242,7 +20453,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20254,7 +20465,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -20287,7 +20500,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20305,7 +20518,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20378,7 +20593,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20396,7 +20611,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20467,7 +20684,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20479,7 +20696,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20512,7 +20731,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20530,7 +20749,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20601,7 +20822,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20613,7 +20834,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20652,7 +20875,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20670,7 +20893,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20750,7 +20975,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20768,7 +20993,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20840,7 +21067,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20853,7 +21080,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -20884,7 +21113,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20896,7 +21125,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -20929,7 +21160,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20941,7 +21172,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -20974,7 +21207,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -20992,7 +21225,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21056,7 +21291,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21069,7 +21304,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -21098,7 +21335,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21110,7 +21347,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21140,7 +21379,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21153,7 +21392,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21182,7 +21423,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21194,7 +21435,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -21233,7 +21476,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21250,7 +21493,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21322,7 +21567,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21335,7 +21580,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -21365,7 +21612,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21378,7 +21625,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -21402,7 +21651,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21414,7 +21663,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21447,7 +21698,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21464,7 +21715,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21529,7 +21782,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21542,7 +21795,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -21567,7 +21822,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21580,7 +21835,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -21623,7 +21880,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21646,7 +21903,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21670,7 +21929,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21682,7 +21941,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21707,7 +21968,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21720,7 +21981,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21753,7 +22016,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21771,7 +22034,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21839,7 +22104,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21851,7 +22116,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21886,7 +22153,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21904,7 +22171,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -21970,7 +22239,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -21983,7 +22252,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -22017,7 +22288,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22029,7 +22300,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22063,7 +22336,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22075,7 +22348,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -22114,7 +22389,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22132,7 +22407,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22214,7 +22491,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22227,7 +22504,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -22263,7 +22542,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22275,7 +22554,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -22317,7 +22598,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22330,7 +22611,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -22365,7 +22648,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22378,7 +22661,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -22414,7 +22699,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22426,7 +22711,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22458,7 +22745,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22470,7 +22757,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22504,7 +22793,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22517,7 +22806,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22556,7 +22847,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22574,7 +22865,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22650,7 +22943,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22662,7 +22955,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22695,7 +22990,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22713,7 +23008,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22785,7 +23082,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22797,7 +23094,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22828,7 +23127,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22845,7 +23144,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -22916,7 +23217,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -22934,7 +23235,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23010,7 +23313,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23033,7 +23336,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23103,7 +23408,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23121,7 +23426,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -23152,7 +23459,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23169,7 +23476,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23200,7 +23509,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23217,7 +23526,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -23254,7 +23565,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23277,7 +23588,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23348,7 +23661,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23366,7 +23679,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -23397,7 +23712,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23414,7 +23729,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23445,7 +23762,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23462,7 +23779,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -23505,7 +23824,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23528,7 +23847,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23612,7 +23933,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23630,7 +23951,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -23662,7 +23985,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23680,7 +24003,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -23712,7 +24037,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23730,7 +24055,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23761,7 +24088,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23778,7 +24105,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -23828,7 +24157,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23854,7 +24183,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -23886,7 +24217,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23909,7 +24240,9 @@ impl Client {
                 ),
             )
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             101u16 => ResponseValue::upgrade(response).await,
@@ -23935,7 +24268,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -23952,7 +24285,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -23983,7 +24318,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24000,7 +24335,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("project", &project))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -24033,7 +24370,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24051,7 +24388,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24116,7 +24455,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24129,7 +24468,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -24158,7 +24499,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24170,7 +24511,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24200,7 +24543,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24213,7 +24556,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24242,7 +24587,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24254,7 +24599,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -24283,7 +24630,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24295,7 +24642,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24325,7 +24674,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24338,7 +24687,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24373,7 +24724,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24395,7 +24746,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24462,7 +24815,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24479,7 +24832,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -24509,7 +24864,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24525,7 +24880,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24556,7 +24913,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24573,7 +24930,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24603,7 +24962,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24619,7 +24978,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -24649,7 +25010,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24665,7 +25026,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24696,7 +25059,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24713,7 +25076,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24746,7 +25111,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24764,7 +25129,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24837,7 +25204,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24855,7 +25222,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24924,7 +25293,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24936,7 +25305,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -24960,7 +25331,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -24972,7 +25343,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -24997,7 +25370,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -25010,7 +25383,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             202u16 => ResponseValue::from_response(response).await,
@@ -25036,7 +25411,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -25048,7 +25423,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -25081,7 +25458,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -25099,7 +25476,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25168,7 +25547,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -25180,7 +25559,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25210,7 +25591,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -25222,7 +25603,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -25246,7 +25629,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -25258,7 +25641,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -133,7 +133,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::key_get`]
     ///
@@ -260,9 +261,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("url", &url))
                 .headers(header_map)
                 .build()?;
-            _client.pre(&mut _request).await?;
-            let _result = _client.wrap(_client.exec(_request)).await;
-            _client.post(&_result).await?;
+            let info = OperationInfo {
+                operation_id: "key_get",
+            };
+            _client.pre(&mut _request, &info).await?;
+            let _result = _client.exec(_request, &info).await;
+            _client.post(&_result, &info).await?;
             let _response = _result?;
             match _response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(_response)),

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -78,26 +78,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "v1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "v1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Gets a key
     ///
@@ -131,7 +132,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::key_get`]
     ///
     ///[`Client::key_get`]: super::Client::key_get
@@ -244,7 +247,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(_client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut _request = _client
@@ -257,7 +260,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("url", &url))
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
+            _client.pre(&mut _request).await?;
+            let _result = _client.wrap(_client.exec(_request)).await;
+            _client.post(&_result).await?;
             let _response = _result?;
             match _response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(_response)),

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -133,7 +133,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::key_get`]
     ///
@@ -260,9 +261,12 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("url", &url))
                 .headers(header_map)
                 .build()?;
-            _client.pre(&mut _request).await?;
-            let _result = _client.wrap(_client.exec(_request)).await;
-            _client.post(&_result).await?;
+            let info = OperationInfo {
+                operation_id: "key_get",
+            };
+            _client.pre(&mut _request, &info).await?;
+            let _result = _client.exec(_request, &info).await;
+            _client.post(&_result, &info).await?;
             let _response = _result?;
             match _response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(_response)),

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -78,26 +78,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "v1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "v1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Gets a key
     ///
@@ -131,7 +132,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::key_get`]
     ///
     ///[`Client::key_get`]: super::Client::key_get
@@ -244,7 +247,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(_client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut _request = _client
@@ -257,7 +260,9 @@ pub mod builder {
                 .query(&progenitor_client::QueryParam::new("url", &url))
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
+            _client.pre(&mut _request).await?;
+            let _result = _client.wrap(_client.exec(_request)).await;
+            _client.post(&_result).await?;
             let _response = _result?;
             match _response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(_response)),

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -1,6 +1,6 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -140,9 +140,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("url", &url))
             .headers(header_map)
             .build()?;
-        self.pre(&mut _request).await?;
-        let _result = self.wrap(self.exec(_request)).await;
-        self.post(&_result).await?;
+        let info = OperationInfo {
+            operation_id: "key_get",
+        };
+        self.pre(&mut _request, &info).await?;
+        let _result = self.exec(_request, &info).await;
+        self.post(&_result, &info).await?;
         let _response = _result?;
         match _response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(_response)),

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -127,7 +127,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::key_get`]
     ///
@@ -195,9 +196,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "key_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -78,26 +78,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "v1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "v1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Gets a key
     ///
@@ -125,7 +126,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::key_get`]
     ///
     ///[`Client::key_get`]: super::Client::key_get
@@ -179,7 +182,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -192,7 +195,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -127,7 +127,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::key_get`]
     ///
@@ -195,9 +196,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "key_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -78,26 +78,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "v1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "v1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Gets a key
     ///
@@ -125,7 +126,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::key_get`]
     ///
     ///[`Client::key_get`]: super::Client::key_get
@@ -179,7 +182,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -192,7 +195,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -1,8 +1,8 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -79,26 +79,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "v1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "v1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -120,7 +121,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -133,7 +134,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -1,6 +1,6 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -134,9 +134,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "key_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -3135,7 +3135,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::instance_get`]
     ///
@@ -3171,9 +3172,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3254,9 +3258,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_ensure",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3341,9 +3348,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_issue_crucible_snapshot_request",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3428,9 +3438,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_migrate_status",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3485,9 +3498,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -3545,9 +3561,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_state_put",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -3632,9 +3651,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_state_monitor",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -3019,26 +3019,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "0.0.1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "0.0.1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/instance`
     ///
@@ -3133,7 +3134,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::instance_get`]
     ///
     ///[`Client::instance_get`]: super::Client::instance_get
@@ -3156,7 +3159,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3168,7 +3171,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3236,7 +3241,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3249,7 +3254,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3322,7 +3329,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3334,7 +3341,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3406,7 +3415,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3419,7 +3428,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3456,7 +3467,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3474,7 +3485,9 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -3519,7 +3532,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3532,7 +3545,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -3604,7 +3619,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3617,7 +3632,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -3090,7 +3090,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::instance_get`]
     ///
@@ -3126,9 +3127,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_get",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3209,9 +3213,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_ensure",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3296,9 +3303,12 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_issue_crucible_snapshot_request",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3383,9 +3393,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_migrate_status",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3440,9 +3453,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_serial",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -3500,9 +3516,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_state_put",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -3587,9 +3606,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "instance_state_monitor",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -2974,26 +2974,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "0.0.1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "0.0.1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/instance`
     ///
@@ -3088,7 +3089,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::instance_get`]
     ///
     ///[`Client::instance_get`]: super::Client::instance_get
@@ -3111,7 +3114,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3123,7 +3126,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3191,7 +3196,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3204,7 +3209,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 201u16 => ResponseValue::from_response(response).await,
@@ -3277,7 +3284,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3289,7 +3296,9 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3361,7 +3370,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3374,7 +3383,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
@@ -3411,7 +3422,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3429,7 +3440,9 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(response).await,
@@ -3474,7 +3487,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3487,7 +3500,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(response)),
@@ -3559,7 +3574,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -3572,7 +3587,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1,8 +1,8 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -1539,26 +1539,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "0.0.1"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "0.0.1"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -1570,7 +1571,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -1582,7 +1583,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1605,7 +1608,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -1618,7 +1621,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -1649,7 +1654,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -1661,7 +1666,9 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1684,7 +1691,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -1697,7 +1704,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1719,7 +1728,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -1737,7 +1746,9 @@ impl Client {
                 ),
             )
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             101u16 => ResponseValue::upgrade(response).await,
@@ -1755,7 +1766,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -1768,7 +1779,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -1791,7 +1804,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -1804,7 +1817,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1,6 +1,6 @@
 #![allow(elided_named_lifetimes)]
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -1583,9 +1583,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1621,9 +1624,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_ensure",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             201u16 => ResponseValue::from_response(response).await,
@@ -1666,9 +1672,12 @@ impl Client {
             )
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_issue_crucible_snapshot_request",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1704,9 +1713,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_migrate_status",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
@@ -1746,9 +1758,12 @@ impl Client {
                 ),
             )
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_serial",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             101u16 => ResponseValue::upgrade(response).await,
@@ -1779,9 +1794,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_state_put",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),
@@ -1817,9 +1835,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "instance_state_monitor",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -402,7 +402,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::default_params`]
     ///
@@ -462,9 +463,12 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "default_params",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -361,26 +361,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "9000.0.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "9000.0.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/`
     ///
@@ -400,7 +401,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::default_params`]
     ///
     ///[`Client::default_params`]: super::Client::default_params
@@ -450,7 +453,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -459,7 +462,9 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -225,9 +225,12 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "default_params",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -183,26 +183,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "9000.0.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "9000.0.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -215,7 +216,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -224,7 +225,9 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -152,9 +152,12 @@ impl Client {
         );
         #[allow(unused_mut)]
         let mut request = self.client.get(url).headers(header_map).build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "freeform_response",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -116,26 +116,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "9000.0.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "9000.0.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -147,11 +148,13 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self.client.get(url).headers(header_map).build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(ResponseValue::stream(response)),

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -175,9 +175,12 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("use", &use_))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "renamed_parameters",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -116,26 +116,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "9000.0.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "9000.0.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -159,7 +160,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -174,7 +175,9 @@ impl Client {
             .query(&progenitor_client::QueryParam::new("use", &use_))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             204u16 => Ok(ResponseValue::empty(response)),

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -317,26 +317,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "1.0.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "1.0.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/`
     ///
@@ -361,7 +362,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::paginated_u32s`]
     ///
     ///[`Client::paginated_u32s`]: super::Client::paginated_u32s
@@ -416,7 +419,7 @@ pub mod builder {
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
             #[allow(unused_mut)]
             let mut request = client
@@ -433,7 +436,9 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
+            client.pre(&mut request).await?;
+            let result = client.wrap(client.exec(request)).await;
+            client.post(&result).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -363,7 +363,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{
-        encode_path, ByteStream, ClientHooks, ClientInfo, Error, RequestBuilderExt, ResponseValue,
+        encode_path, ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
+        ResponseValue,
     };
     ///Builder for [`Client::paginated_u32s`]
     ///
@@ -436,9 +437,12 @@ pub mod builder {
                 ))
                 .headers(header_map)
                 .build()?;
-            client.pre(&mut request).await?;
-            let result = client.wrap(client.exec(request)).await;
-            client.post(&result).await?;
+            let info = OperationInfo {
+                operation_id: "paginated_u32s",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
 #[allow(unused_imports)]
-pub use progenitor_client::{ByteStream, Error, ResponseValue};
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 pub mod types {
@@ -164,26 +164,27 @@ impl Client {
             client,
         }
     }
+}
 
-    /// Get the base URL to which requests are made.
-    pub fn baseurl(&self) -> &String {
-        &self.baseurl
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "1.0.0"
     }
 
-    /// Get the internal `reqwest::Client` used to make requests.
-    pub fn client(&self) -> &reqwest::Client {
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+
+    fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    /// Get the version of this API.
-    ///
-    /// This string is pulled directly from the source OpenAPI
-    /// document and may be in any format the API selects.
-    pub fn api_version(&self) -> &'static str {
-        "1.0.0"
+    fn inner(&self) -> &() {
+        &()
     }
 }
 
+impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(elided_named_lifetimes)]
 impl Client {
@@ -202,7 +203,7 @@ impl Client {
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
-            ::reqwest::header::HeaderValue::from_static(self.api_version()),
+            ::reqwest::header::HeaderValue::from_static(Self::api_version()),
         );
         #[allow(unused_mut)]
         let mut request = self
@@ -219,7 +220,9 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
+        self.pre(&mut request).await?;
+        let result = self.wrap(self.exec(request)).await;
+        self.post(&result).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use progenitor_client::{encode_path, ClientHooks, RequestBuilderExt};
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
 #[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
@@ -220,9 +220,12 @@ impl Client {
             ))
             .headers(header_map)
             .build()?;
-        self.pre(&mut request).await?;
-        let result = self.wrap(self.exec(request)).await;
-        self.post(&result).await?;
+        let info = OperationInfo {
+            operation_id: "paginated_u32s",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,


### PR DESCRIPTION
So far we've allowed progenitor consumers to customize the generated code to calls to custom code before (pre-) and after (post-) the execution of all HTTP requests. This has been fine, but we've introduced now 4 variants with both overlap and significant limitation. In particular, when we wanted to include additional debugging output to our generated CLI, it turned out to be quite awkward and it wasn't clear how we could achieve our goals without also screwing up the SDK's interface.

This PR proposes a new trait that looks like this:

```rust
#[allow(async_fn_in_trait)]
pub trait ClientHooks<Inner = ()>
where
    Self: ClientInfo<Inner>,
{
    /// Implement to execute code prior to the execution of all requests.
    async fn pre<T>(&self, _request: &mut reqwest::Request) -> std::result::Result<(), Error<T>> {
        Ok(())
    }

    /// Implement to execute code after the execution of all requests.
    async fn post<T>(
        &self,
        _result: &reqwest::Result<reqwest::Response>,
    ) -> std::result::Result<(), Error<T>> {
        Ok(())
    }

    /// Implement to bracket the `execute` Future with your own code. Do not
    /// forget to `execute.await` at some point.
    async fn wrap(
        &self,
        execute: impl std::future::Future<Output = reqwest::Result<reqwest::Response>>,
    ) -> reqwest::Result<reqwest::Response> {
        execute.await
    }

    /// Implement to customize the execution of the given request.
    async fn exec(&self, request: reqwest::Request) -> reqwest::Result<reqwest::Response> {
        self.client().execute(request).await
    }
}
```

Generated code will implement this by default for `&Client`. Consumers who wish to customize things get to do so by simply `impl ClientHooks for Client { .. }` adjacent to the generated code. Today, hooks are specified in hard-to-debug `quote! { }` generated `TokenStream`s; with this change, we can effectively do the same thing--and more--in normal Rust code.

I'm not wed to aspects of the interface. For example, I thought that `wrap` would be useful, but now I'm not sure it is, so perhaps we remove it. I'm not sure of the appropriate return type for all of these methods--we may want to further modify the `progenitor_client::Error` type to adapt it to this new modality.

If this works out, I would **definitely** like to deprecate and/or remove the existing hooks as they're finicky, weird, poorly document, and hard **to** document.

You can see an example if this in action here: https://github.com/oxidecomputer/oxide.rs/pull/1081. It does seem a bit more reasonable than the current mechanism. 