### PR TITLE
fix: missing quote on end of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Currently, the generated code doesn't deal with request headers. To add default 
 ```rust
     let baseurl = std::env::var("API_URL").expect("$API_URL not set");
     
-    let access_token = std::env::var("API_ACCESS_TOKEN").expect("$API_ACCESS_TOKEN not set);
+    let access_token = std::env::var("API_ACCESS_TOKEN").expect("$API_ACCESS_TOKEN not set");
     let authorization_header = format!("Bearer {}", access_token);
 
     let mut headers = reqwest::header::HeaderMap::new();


### PR DESCRIPTION
This PR fixes a small typo in the README: a missing closing quotation mark at the end of a string.

While it's a minor issue, I thought it would be helpful to correct it for clarity and consistency. 

Thanks for maintaining this crate!