### PR TITLE
style(clippy): address some clippy warnings

### DIFF
--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -256,15 +256,13 @@ pub fn dependencies(builder: &Generator, include_client: bool) -> Vec<String> {
     ];
 
     let type_space = builder.get_type_space();
-    let mut needs_serde_json = false;
-
-    if include_client {
+    let needs_serde_json = if include_client {
         // code included from progenitor-client needs extra dependencies
         deps.push(format!(
             "percent-encoding = \"{}\"",
             DEPENDENCIES.percent_encoding
         ));
-        needs_serde_json = true;
+        true
     } else {
         let crate_version =
             if let (false, Some(value)) = (is_non_release(), option_env!("CARGO_PKG_VERSION")) {
@@ -274,7 +272,8 @@ pub fn dependencies(builder: &Generator, include_client: bool) -> Vec<String> {
             };
         let client_version_dep = format!("progenitor-client = \"{crate_version}\"");
         deps.push(client_version_dep);
-    }
+        false
+    };
 
     if type_space.uses_regress() {
         deps.push(format!("regress = \"{}\"", DEPENDENCIES.regress));

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -310,12 +310,11 @@ where
     P: AsRef<Path> + std::clone::Clone + std::fmt::Debug,
 {
     let mut f = File::open(p.clone())?;
-    let api = match serde_json::from_reader(f) {
-        Ok(json_value) => json_value,
-        _ => {
-            f = File::open(p)?;
-            serde_yaml::from_reader(f)?
-        }
+    let api = if let Ok(json_value) = serde_json::from_reader(f) {
+        json_value
+    } else {
+        f = File::open(p)?;
+        serde_yaml::from_reader(f)?
     };
     Ok(api)
 }

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -65,8 +65,8 @@ enum InterfaceArg {
 impl From<InterfaceArg> for InterfaceStyle {
     fn from(arg: InterfaceArg) -> Self {
         match arg {
-            InterfaceArg::Positional => InterfaceStyle::Positional,
-            InterfaceArg::Builder => InterfaceStyle::Builder,
+            InterfaceArg::Positional => Self::Positional,
+            InterfaceArg::Builder => Self::Builder,
         }
     }
 }
@@ -80,8 +80,8 @@ enum TagArg {
 impl From<TagArg> for TagStyle {
     fn from(arg: TagArg) -> Self {
         match arg {
-            TagArg::Merged => TagStyle::Merged,
-            TagArg::Separate => TagStyle::Separate,
+            TagArg::Merged => Self::Merged,
+            TagArg::Separate => Self::Separate,
         }
     }
 }

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -239,6 +239,7 @@ static DEPENDENCIES: Dependencies = Dependencies {
     uuid: "1.0",
 };
 
+#[must_use]
 pub fn dependencies(builder: Generator, include_client: bool) -> Vec<String> {
     let mut deps = vec![
         format!("bytes = \"{}\"", DEPENDENCIES.bytes),

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
                 version = \"{}\"\n\
                 edition = \"2024\"\n\
                 license = \"{}\"\n",
-                name, version, &args.license_name,
+                name, version, args.license_name,
             );
             if let Some(registry_name) = args.registry_name {
                 tomlout.extend(format!("publish = [\"{}\"]\n", registry_name).chars());

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -23,10 +23,10 @@ enum CargoCli {
     Progenitor(Args),
 }
 
-/// Generate a stand-alone crate from an OpenAPI document
+/// Generate a stand-alone crate from an `OpenAPI` document
 #[derive(Parser)]
 struct Args {
-    /// OpenAPI definition document (JSON or YAML)
+    /// `OpenAPI` definition document (JSON or YAML)
     #[clap(short = 'i', long)]
     input: String,
     /// Output directory for Rust crate

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -92,7 +92,7 @@ fn reformat_code(input: String) -> String {
         wrap_comments: Some(true),
         ..Default::default()
     };
-    space_out_items(rustfmt_wrapper::rustfmt_config(config, input).unwrap()).unwrap()
+    space_out_items(&rustfmt_wrapper::rustfmt_config(config, input).unwrap()).unwrap()
 }
 
 fn save<P>(p: P, data: &str) -> Result<()>
@@ -164,7 +164,7 @@ fn main() -> Result<()> {
                 [dependencies]\n\
                 {}\n\
                 \n",
-                    dependencies(builder, args.include_client).join("\n"),
+                    dependencies(&builder, args.include_client).join("\n"),
                 )
                 .chars(),
             );
@@ -240,7 +240,7 @@ static DEPENDENCIES: Dependencies = Dependencies {
 };
 
 #[must_use]
-pub fn dependencies(builder: Generator, include_client: bool) -> Vec<String> {
+pub fn dependencies(builder: &Generator, include_client: bool) -> Vec<String> {
     let mut deps = vec![
         format!("bytes = \"{}\"", DEPENDENCIES.bytes),
         format!("futures-core = \"{}\"", DEPENDENCIES.futures),

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -12,7 +12,7 @@ use openapiv3::OpenAPI;
 use progenitor::{GenerationSettings, Generator, InterfaceStyle, TagStyle};
 use progenitor_impl::space_out_items;
 
-fn is_non_release() -> bool {
+const fn is_non_release() -> bool {
     cfg!(debug_assertions)
 }
 

--- a/cargo-progenitor/src/main.rs
+++ b/cargo-progenitor/src/main.rs
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
             println!("-----------------------------------------------------");
             for (idx, type_entry) in type_space.iter_types().enumerate() {
                 let n = type_entry.describe();
-                println!("{:>4}  {}", idx, n);
+                println!("{idx:>4}  {n}");
             }
             println!("-----------------------------------------------------");
             println!();
@@ -156,7 +156,7 @@ fn main() -> Result<()> {
                 name, version, args.license_name,
             );
             if let Some(registry_name) = args.registry_name {
-                tomlout.extend(format!("publish = [\"{}\"]\n", registry_name).chars());
+                tomlout.extend(format!("publish = [\"{registry_name}\"]\n").chars());
             }
             tomlout.extend(
                 format!(
@@ -178,7 +178,7 @@ fn main() -> Result<()> {
 
             // Create the Rust source file containing the generated client:
             let lib_code = if args.include_client {
-                format!("mod progenitor_client;\n\n{}", api_code)
+                format!("mod progenitor_client;\n\n{api_code}")
             } else {
                 api_code.to_string()
             };
@@ -198,7 +198,7 @@ fn main() -> Result<()> {
         }
 
         Err(e) => {
-            println!("gen fail: {:?}", e);
+            println!("gen fail: {e:?}");
             bail!("generation experienced errors");
         }
     }
@@ -271,7 +271,7 @@ pub fn dependencies(builder: Generator, include_client: bool) -> Vec<String> {
             } else {
                 "*"
             };
-        let client_version_dep = format!("progenitor-client = \"{}\"", crate_version);
+        let client_version_dep = format!("progenitor-client = \"{crate_version}\"");
         deps.push(client_version_dep);
     }
 

--- a/cargo-progenitor/tests/data/test_help.stdout
+++ b/cargo-progenitor/tests/data/test_help.stdout
@@ -1,10 +1,10 @@
-Generate a stand-alone crate from an OpenAPI document
+Generate a stand-alone crate from an `OpenAPI` document
 
 Usage: cargo progenitor [OPTIONS] --input <INPUT> --output <OUTPUT> --name <NAME> --version <VERSION>
 
 Options:
   -i, --input <INPUT>
-          OpenAPI definition document (JSON or YAML)
+          `OpenAPI` definition document (JSON or YAML)
   -o, --output <OUTPUT>
           Output directory for Rust crate
   -n, --name <NAME>

--- a/example-build/build.rs
+++ b/example-build/build.rs
@@ -8,7 +8,7 @@ use std::{
 
 fn main() {
     let src = "../sample_openapi/keeper.json";
-    println!("cargo:rerun-if-changed={}", src);
+    println!("cargo:rerun-if-changed={src}");
     let file = File::open(src).unwrap();
     let spec = serde_json::from_reader(file).unwrap();
     let mut generator = progenitor::Generator::default();

--- a/example-build/src/main.rs
+++ b/example-build/src/main.rs
@@ -6,8 +6,8 @@ include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 fn main() {
     let client = Client::new("https://foo/bar");
     let body = types::EnrolBody {
-        host: "".to_string(),
-        key: "".to_string(),
+        host: String::new(),
+        key: String::new(),
     };
     let _future = client.enrol("auth-token", &body);
 }

--- a/example-build/src/main.rs
+++ b/example-build/src/main.rs
@@ -5,11 +5,9 @@ include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 
 fn main() {
     let client = Client::new("https://foo/bar");
-    let _ = client.enrol(
-        "auth-token",
-        &types::EnrolBody {
-            host: "".to_string(),
-            key: "".to_string(),
-        },
-    );
+    let body = types::EnrolBody {
+        host: "".to_string(),
+        key: "".to_string(),
+    };
+    let _future = client.enrol("auth-token", &body);
 }

--- a/example-macro/src/main.rs
+++ b/example-macro/src/main.rs
@@ -5,7 +5,7 @@ use progenitor::generate_api;
 generate_api!(
     spec = "../sample_openapi/keeper.json",
     pre_hook = (|request| {
-        println!("doing this {:?}", request);
+        println!("doing this {request:?}");
     }),
     pre_hook_async = crate::add_auth_headers,
     post_hook = crate::all_done,

--- a/example-macro/src/main.rs
+++ b/example-macro/src/main.rs
@@ -27,7 +27,7 @@ async fn add_auth_headers(
     Ok(())
 }
 
-fn all_done(_result: &reqwest::Result<reqwest::Response>) {}
+const fn all_done(_result: &reqwest::Result<reqwest::Response>) {}
 
 mod buildomat {
     use progenitor::generate_api;
@@ -35,4 +35,4 @@ mod buildomat {
     generate_api!("../sample_openapi/buildomat.json");
 }
 
-fn main() {}
+const fn main() {}

--- a/example-out-dir/build.rs
+++ b/example-out-dir/build.rs
@@ -9,7 +9,7 @@ fn main() {
     // complex build script might, for example, extract the OpenAPI document
     // from a non-file source, writing it out to OUT_DIR.
     let src = "../sample_openapi/keeper.json";
-    println!("cargo:rerun-if-changed={}", src);
+    println!("cargo:rerun-if-changed={src}");
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("keeper.json");

--- a/example-out-dir/src/main.rs
+++ b/example-out-dir/src/main.rs
@@ -12,8 +12,8 @@ generate_api!(
 fn main() {
     let client = Client::new("https://example.com");
     let body = types::EnrolBody {
-        host: "".to_string(),
-        key: "".to_string(),
+        host: String::new(),
+        key: String::new(),
     };
     let _future = client.enrol("auth-token", &body);
 }

--- a/example-out-dir/src/main.rs
+++ b/example-out-dir/src/main.rs
@@ -11,11 +11,9 @@ generate_api!(
 
 fn main() {
     let client = Client::new("https://example.com");
-    std::mem::drop(client.enrol(
-        "auth-token",
-        &types::EnrolBody {
-            host: "".to_string(),
-            key: "".to_string(),
-        },
-    ));
+    let body = types::EnrolBody {
+        host: "".to_string(),
+        key: "".to_string(),
+    };
+    let _future = client.enrol("auth-token", &body);
 }

--- a/example-wasm/build.rs
+++ b/example-wasm/build.rs
@@ -8,7 +8,7 @@ use std::{
 
 fn main() {
     let src = "../sample_openapi/keeper.json";
-    println!("cargo:rerun-if-changed={}", src);
+    println!("cargo:rerun-if-changed={src}");
     let file = File::open(src).unwrap();
     let spec = serde_json::from_reader(file).unwrap();
     let mut generator = progenitor::Generator::default();

--- a/example-wasm/src/main.rs
+++ b/example-wasm/src/main.rs
@@ -6,8 +6,8 @@ include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 fn main() {
     let client = Client::new("https://foo/bar");
     let body = types::EnrolBody {
-        host: "".to_string(),
-        key: "".to_string(),
+        host: String::new(),
+        key: String::new(),
     };
     let _future = client.enrol("auth-token", &body);
 }

--- a/example-wasm/src/main.rs
+++ b/example-wasm/src/main.rs
@@ -5,11 +5,9 @@ include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 
 fn main() {
     let client = Client::new("https://foo/bar");
-    let _ = client.enrol(
-        "auth-token",
-        &types::EnrolBody {
-            host: "".to_string(),
-            key: "".to_string(),
-        },
-    );
+    let body = types::EnrolBody {
+        host: "".to_string(),
+        key: "".to_string(),
+    };
+    let _future = client.enrol("auth-token", &body);
 }

--- a/example-wasm/tests/client.rs
+++ b/example-wasm/tests/client.rs
@@ -8,5 +8,5 @@ include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 #[wasm_bindgen_test::wasm_bindgen_test]
 fn test_client_new() {
     let client = Client::new("http://foo/bar");
-    assert!(client.baseurl == "http://foo/bar");
+    assert_eq!(client.baseurl, "http://foo/bar");
 }

--- a/progenitor-client/src/lib.rs
+++ b/progenitor-client/src/lib.rs
@@ -14,6 +14,6 @@ pub use crate::progenitor_client::*;
 // when generating the stand-alone crate.
 #[doc(hidden)]
 #[must_use]
-pub fn code() -> &'static str {
+pub const fn code() -> &'static str {
     include_str!("progenitor_client.rs")
 }

--- a/progenitor-client/src/lib.rs
+++ b/progenitor-client/src/lib.rs
@@ -13,6 +13,7 @@ pub use crate::progenitor_client::*;
 // need to determine the provenance of progenitor (crates.io, github, etc.)
 // when generating the stand-alone crate.
 #[doc(hidden)]
+#[must_use]
 pub fn code() -> &'static str {
     include_str!("progenitor_client.rs")
 }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -451,29 +451,29 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::InvalidRequest(s) => {
-                write!(f, "Invalid Request: {}", s)?;
+                write!(f, "Invalid Request: {s}")?;
             }
             Error::CommunicationError(e) => {
-                write!(f, "Communication Error: {}", e)?;
+                write!(f, "Communication Error: {e}")?;
             }
             Error::ErrorResponse(rve) => {
                 write!(f, "Error Response: ")?;
                 rve.fmt_info(f)?;
             }
             Error::InvalidUpgrade(e) => {
-                write!(f, "Invalid Response Upgrade: {}", e)?;
+                write!(f, "Invalid Response Upgrade: {e}")?;
             }
             Error::ResponseBodyError(e) => {
-                write!(f, "Invalid Response Body Bytes: {}", e)?;
+                write!(f, "Invalid Response Body Bytes: {e}")?;
             }
             Error::InvalidResponsePayload(b, e) => {
-                write!(f, "Invalid Response Payload ({:?}): {}", b, e)?;
+                write!(f, "Invalid Response Payload ({b:?}): {e}")?;
             }
             Error::UnexpectedResponse(r) => {
-                write!(f, "Unexpected Response: {:?}", r)?;
+                write!(f, "Unexpected Response: {r:?}")?;
             }
             Error::Custom(s) => {
-                write!(f, "Error: {}", s)?;
+                write!(f, "Error: {s}")?;
             }
         }
 

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -367,14 +367,12 @@ impl<E> Error<E> {
     /// Returns the status code, if the error was generated from a response.
     pub fn status(&self) -> Option<reqwest::StatusCode> {
         match self {
-            Error::InvalidRequest(_) | Error::Custom(_) | Error::InvalidResponsePayload(_, _) => {
-                None
+            Self::InvalidRequest(_) | Self::Custom(_) | Self::InvalidResponsePayload(_, _) => None,
+            Self::CommunicationError(e) | Self::InvalidUpgrade(e) | Self::ResponseBodyError(e) => {
+                e.status()
             }
-            Error::CommunicationError(e)
-            | Error::InvalidUpgrade(e)
-            | Error::ResponseBodyError(e) => e.status(),
-            Error::ErrorResponse(rv) => Some(rv.status()),
-            Error::UnexpectedResponse(r) => Some(r.status()),
+            Self::ErrorResponse(rv) => Some(rv.status()),
+            Self::UnexpectedResponse(r) => Some(r.status()),
         }
     }
 
@@ -390,10 +388,10 @@ impl<E> Error<E> {
     /// * 504 Gateway Timeout
     pub fn is_retryable(&self) -> bool {
         match self {
-            Error::CommunicationError(_) => true,
-            Error::ErrorResponse(rv) => is_retryable_status(rv.status()),
-            Error::UnexpectedResponse(r) => is_retryable_status(r.status()),
-            Error::InvalidUpgrade(e) | Error::ResponseBodyError(e) => {
+            Self::CommunicationError(_) => true,
+            Self::ErrorResponse(rv) => is_retryable_status(rv.status()),
+            Self::UnexpectedResponse(r) => is_retryable_status(r.status()),
+            Self::InvalidUpgrade(e) | Self::ResponseBodyError(e) => {
                 // We expect InvalidUpgrade and ResponseBodyError to be 2xx
                 // statuses.
                 //
@@ -404,9 +402,7 @@ impl<E> Error<E> {
                 //   it is appropriate to check for retryability.
                 e.status().is_some_and(is_retryable_status)
             }
-            Error::InvalidRequest(_) | Error::InvalidResponsePayload(_, _) | Error::Custom(_) => {
-                false
-            }
+            Self::InvalidRequest(_) | Self::InvalidResponsePayload(_, _) | Self::Custom(_) => false,
         }
     }
 
@@ -416,10 +412,10 @@ impl<E> Error<E> {
     /// various error response bodies.
     pub fn into_untyped(self) -> Error {
         match self {
-            Error::InvalidRequest(s) => Error::InvalidRequest(s),
-            Error::Custom(s) => Error::Custom(s),
-            Error::CommunicationError(e) => Error::CommunicationError(e),
-            Error::ErrorResponse(ResponseValue {
+            Self::InvalidRequest(s) => Error::InvalidRequest(s),
+            Self::Custom(s) => Error::Custom(s),
+            Self::CommunicationError(e) => Error::CommunicationError(e),
+            Self::ErrorResponse(ResponseValue {
                 inner: _,
                 status,
                 headers,
@@ -428,10 +424,10 @@ impl<E> Error<E> {
                 status,
                 headers,
             }),
-            Error::InvalidUpgrade(e) => Error::InvalidUpgrade(e),
-            Error::ResponseBodyError(e) => Error::ResponseBodyError(e),
-            Error::InvalidResponsePayload(b, e) => Error::InvalidResponsePayload(b, e),
-            Error::UnexpectedResponse(r) => Error::UnexpectedResponse(r),
+            Self::InvalidUpgrade(e) => Error::InvalidUpgrade(e),
+            Self::ResponseBodyError(e) => Error::ResponseBodyError(e),
+            Self::InvalidResponsePayload(b, e) => Error::InvalidResponsePayload(b, e),
+            Self::UnexpectedResponse(r) => Error::UnexpectedResponse(r),
         }
     }
 }
@@ -460,29 +456,29 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::InvalidRequest(s) => {
+            Self::InvalidRequest(s) => {
                 write!(f, "Invalid Request: {s}")?;
             }
-            Error::CommunicationError(e) => {
+            Self::CommunicationError(e) => {
                 write!(f, "Communication Error: {e}")?;
             }
-            Error::ErrorResponse(rve) => {
+            Self::ErrorResponse(rve) => {
                 write!(f, "Error Response: ")?;
                 rve.fmt_info(f)?;
             }
-            Error::InvalidUpgrade(e) => {
+            Self::InvalidUpgrade(e) => {
                 write!(f, "Invalid Response Upgrade: {e}")?;
             }
-            Error::ResponseBodyError(e) => {
+            Self::ResponseBodyError(e) => {
                 write!(f, "Invalid Response Body Bytes: {e}")?;
             }
-            Error::InvalidResponsePayload(b, e) => {
+            Self::InvalidResponsePayload(b, e) => {
                 write!(f, "Invalid Response Payload ({b:?}): {e}")?;
             }
-            Error::UnexpectedResponse(r) => {
+            Self::UnexpectedResponse(r) => {
                 write!(f, "Unexpected Response: {r:?}")?;
             }
-            Error::Custom(s) => {
+            Self::Custom(s) => {
                 write!(f, "Error: {s}")?;
             }
         }
@@ -541,10 +537,10 @@ where
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::CommunicationError(e)
-            | Error::InvalidUpgrade(e)
-            | Error::ResponseBodyError(e) => Some(e),
-            Error::InvalidResponsePayload(_b, e) => Some(e),
+            Self::CommunicationError(e) | Self::InvalidUpgrade(e) | Self::ResponseBodyError(e) => {
+                Some(e)
+            }
+            Self::InvalidResponsePayload(_b, e) => Some(e),
             _ => None,
         }
     }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -99,7 +99,7 @@ pub struct OperationInfo {
 /// implement this for `&Client`; to override the default behavior, implement
 /// some or all of the interfaces for the `Client` type (without the
 /// reference). This mechanism relies on so-called "auto-ref specialization".
-#[allow(async_fn_in_trait, unused)]
+#[allow(async_fn_in_trait, unused_variables)]
 pub trait ClientHooks<Inner = ()>
 where
     Self: ClientInfo<Inner>,

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -362,13 +362,13 @@ impl<E> Error<E> {
     /// Returns the status code, if the error was generated from a response.
     pub fn status(&self) -> Option<reqwest::StatusCode> {
         match self {
-            Error::InvalidRequest(_) => None,
-            Error::Custom(_) => None,
-            Error::CommunicationError(e) => e.status(),
+            Error::InvalidRequest(_) | Error::Custom(_) | Error::InvalidResponsePayload(_, _) => {
+                None
+            }
+            Error::CommunicationError(e)
+            | Error::InvalidUpgrade(e)
+            | Error::ResponseBodyError(e) => e.status(),
             Error::ErrorResponse(rv) => Some(rv.status()),
-            Error::InvalidUpgrade(e) => e.status(),
-            Error::ResponseBodyError(e) => e.status(),
-            Error::InvalidResponsePayload(_, _) => None,
             Error::UnexpectedResponse(r) => Some(r.status()),
         }
     }
@@ -399,9 +399,9 @@ impl<E> Error<E> {
                 //   it is appropriate to check for retryability.
                 e.status().is_some_and(is_retryable_status)
             }
-            Error::InvalidRequest(_) => false,
-            Error::InvalidResponsePayload(_, _) => false,
-            Error::Custom(_) => false,
+            Error::InvalidRequest(_) | Error::InvalidResponsePayload(_, _) | Error::Custom(_) => {
+                false
+            }
         }
     }
 
@@ -536,9 +536,9 @@ where
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::CommunicationError(e) => Some(e),
-            Error::InvalidUpgrade(e) => Some(e),
-            Error::ResponseBodyError(e) => Some(e),
+            Error::CommunicationError(e)
+            | Error::InvalidUpgrade(e)
+            | Error::ResponseBodyError(e) => Some(e),
             Error::InvalidResponsePayload(_b, e) => Some(e),
             _ => None,
         }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -26,11 +26,13 @@ impl ByteStream {
     /// Creates a new [`ByteStream`].
     ///
     /// Useful for generating test fixtures.
+    #[must_use]
     pub fn new(inner: InnerByteStream) -> Self {
         Self(inner)
     }
 
     /// Consumes the [`ByteStream`] and return its inner [`Stream`].
+    #[must_use]
     pub fn into_inner(self) -> InnerByteStream {
         self.0
     }
@@ -205,6 +207,7 @@ impl ResponseValue<reqwest::Upgraded> {
 
 impl ResponseValue<ByteStream> {
     #[doc(hidden)]
+    #[must_use]
     pub fn stream(response: reqwest::Response) -> Self {
         let status = response.status();
         let headers = response.headers().clone();
@@ -218,6 +221,7 @@ impl ResponseValue<ByteStream> {
 
 impl ResponseValue<()> {
     #[doc(hidden)]
+    #[must_use]
     pub fn empty(response: reqwest::Response) -> Self {
         let status = response.status();
         let headers = response.headers().clone();
@@ -290,6 +294,7 @@ impl<T> ResponseValue<T> {
 
 impl ResponseValue<ByteStream> {
     /// Consumes the `ResponseValue`, returning the wrapped [`Stream`].
+    #[must_use]
     pub fn into_inner_stream(self) -> InnerByteStream {
         self.into_inner().into_inner()
     }
@@ -568,6 +573,7 @@ const PATH_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
 
 #[doc(hidden)]
 /// Percent encode input string.
+#[must_use]
 pub fn encode_path(pc: &str) -> String {
     percent_encoding::utf8_percent_encode(pc, PATH_SET).to_string()
 }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -240,7 +240,11 @@ impl<T> ResponseValue<T> {
     /// Creates a [`ResponseValue`] from the inner type, status, and headers.
     ///
     /// Useful for generating test fixtures.
-    pub fn new(inner: T, status: reqwest::StatusCode, headers: reqwest::header::HeaderMap) -> Self {
+    pub const fn new(
+        inner: T,
+        status: reqwest::StatusCode,
+        headers: reqwest::header::HeaderMap,
+    ) -> Self {
         Self {
             inner,
             status,
@@ -254,12 +258,12 @@ impl<T> ResponseValue<T> {
     }
 
     /// Gets the status from this response.
-    pub fn status(&self) -> reqwest::StatusCode {
+    pub const fn status(&self) -> reqwest::StatusCode {
         self.status
     }
 
     /// Gets the headers from this response.
-    pub fn headers(&self) -> &reqwest::header::HeaderMap {
+    pub const fn headers(&self) -> &reqwest::header::HeaderMap {
         &self.headers
     }
 
@@ -606,7 +610,7 @@ pub struct QueryParam<'a, T> {
 
 impl<'a, T> QueryParam<'a, T> {
     #[doc(hidden)]
-    pub fn new(name: &'a str, value: &'a T) -> Self {
+    pub const fn new(name: &'a str, value: &'a T) -> Self {
         Self { name, value }
     }
 }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -630,7 +630,7 @@ where
     }
 }
 
-pub(crate) struct QuerySerializer<'a, S> {
+struct QuerySerializer<'a, S> {
     inner: S,
     name: &'a str,
 }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -23,7 +23,7 @@ type InnerByteStream = std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes
 pub struct ByteStream(InnerByteStream);
 
 impl ByteStream {
-    /// Creates a new ByteStream
+    /// Creates a new [`ByteStream`].
     ///
     /// Useful for generating test fixtures.
     pub fn new(inner: InnerByteStream) -> Self {
@@ -54,7 +54,7 @@ impl DerefMut for ByteStream {
 pub trait ClientInfo<Inner> {
     /// Get the version of this API.
     ///
-    /// This string is pulled directly from the source OpenAPI document and may
+    /// This string is pulled directly from the source `OpenAPI` document and may
     /// be in any format the API selects.
     fn api_version() -> &'static str;
 
@@ -91,7 +91,7 @@ where
 
 /// Information about an operation, consumed by hook implementations.
 pub struct OperationInfo {
-    /// The corresponding operationId from the source OpenAPI document.
+    /// The corresponding operationId from the source `OpenAPI` document.
     pub operation_id: &'static str,
 }
 
@@ -243,7 +243,7 @@ impl<T> ResponseValue<T> {
         }
     }
 
-    /// Consumes the ResponseValue, returning the wrapped value.
+    /// Consumes the [`ResponseValue`], returning the wrapped value.
     pub fn into_inner(self) -> T {
         self.inner
     }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -222,7 +222,7 @@ impl ResponseValue<ByteStream> {
 impl ResponseValue<()> {
     #[doc(hidden)]
     #[must_use]
-    pub fn empty(response: reqwest::Response) -> Self {
+    pub fn empty(response: &reqwest::Response) -> Self {
         let status = response.status();
         let headers = response.headers().clone();
         // TODO is there anything we want to do to confirm that there is no

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -97,9 +97,10 @@ pub struct OperationInfo {
     pub operation_id: &'static str,
 }
 
-/// Interface for changing the behavior of generated clients. All clients
-/// implement this for `&Client`; to override the default behavior, implement
-/// some or all of the interfaces for the `Client` type (without the
+/// Interface for changing the behavior of generated clients.
+///
+/// All clients implement this for `&Client`; to override the default behavior,
+/// implement some or all of the interfaces for the `Client` type (without the
 /// reference). This mechanism relies on so-called "auto-ref specialization".
 #[allow(async_fn_in_trait, unused_variables)]
 pub trait ClientHooks<Inner = ()>

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Oxide Computer Company
 
 #![allow(dead_code)]
+// `Error` is public API. Boxing its large variants would be a breaking change.
+#![allow(clippy::result_large_err)]
 
 //! Support code for generated clients.
 

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -169,6 +169,13 @@ pub struct ResponseValue<T> {
 
 impl<T: DeserializeOwned> ResponseValue<T> {
     #[doc(hidden)]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        allow(
+            clippy::future_not_send,
+            reason = "reqwest response futures use browser-local state on wasm"
+        )
+    )]
     pub async fn from_response<E>(response: reqwest::Response) -> Result<Self, Error<E>> {
         let status = response.status();
         let headers = response.headers().clone();

--- a/progenitor-client/tests/client_test.rs
+++ b/progenitor-client/tests/client_test.rs
@@ -171,6 +171,18 @@ fn test_query_enum_untagged() {
         Object { a: u64, b: u64 },
         Array(Vec<u64>),
     }
+
+    #[derive(Serialize)]
+    #[serde(transparent)]
+    struct Name(String);
+
+    #[derive(Serialize)]
+    #[serde(untagged)]
+    enum NameOrId {
+        Name(Name),
+        Id(uuid::Uuid),
+    }
+
     let value = Value::Simple;
     let result = encode_query_param("ignored", &value).unwrap();
     assert_eq!(result, "");
@@ -190,15 +202,6 @@ fn test_query_enum_untagged() {
     let result = encode_query_param("paramName", &value).unwrap();
     assert_eq!(result, "paramName=1&paramName=2&paramName=3&paramName=4");
 
-    #[derive(Serialize)]
-    #[serde(transparent)]
-    struct Name(String);
-    #[derive(Serialize)]
-    #[serde(untagged)]
-    enum NameOrId {
-        Name(Name),
-        Id(uuid::Uuid),
-    }
     let value = Some(NameOrId::Name(Name("xyz".to_string())));
     let result = encode_query_param("paramName", &value).unwrap();
     assert_eq!(result, "paramName=xyz");

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -24,6 +24,11 @@ struct CliOperation {
 
 impl Generator {
     /// Generate a `clap`-based CLI.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `OpenAPI` document is invalid or its types
+    /// cannot be converted into CLI arguments.
     pub fn cli(&mut self, spec: &OpenAPI, crate_name: &str) -> Result<TokenStream> {
         validate_openapi(spec)?;
 

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -610,11 +610,7 @@ impl Generator {
                 None
             };
 
-        let prop_type = if let Some(inner_type) = maybe_inner_type {
-            inner_type
-        } else {
-            prop_type
-        };
+        let prop_type = maybe_inner_type.unwrap_or(prop_type);
 
         let scalar = prop_type.has_impl(TypeSpaceImpl::FromStr);
 
@@ -716,16 +712,14 @@ fn clap_arg(
         None
     };
 
-    let value_parser = if let Some(enum_parser) = maybe_enum_parser {
-        enum_parser
-    } else {
+    let value_parser = maybe_enum_parser.unwrap_or_else(|| {
         // Let clap pick a value parser for us. This has the benefit of
         // allowing for override implementations. A generated client may
         // implement ValueParserFactory for a type to create a custom parser.
         quote! {
             ::clap::value_parser!(#arg_type_name)
         }
-    };
+    });
 
     let required = match volitionality {
         Volitionality::Optional => quote! { .required(false) },

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -202,6 +202,10 @@ impl Generator {
     }
 
     #[allow(clippy::too_many_lines, reason = "mirrors the generated CLI method")]
+    #[allow(
+        clippy::single_match_else,
+        reason = "the match documents both request execution modes"
+    )]
     fn cli_method(&mut self, method: &crate::method::OperationMethod) -> CliOperation {
         let CliArg {
             parser: parser_args,

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -206,7 +206,7 @@ impl Generator {
         clippy::single_match_else,
         reason = "the match documents both request execution modes"
     )]
-    fn cli_method(&mut self, method: &crate::method::OperationMethod) -> CliOperation {
+    fn cli_method(&self, method: &crate::method::OperationMethod) -> CliOperation {
         let CliArg {
             parser: parser_args,
             consumer: consumer_args,

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -29,6 +29,11 @@ impl Generator {
     ///
     /// Returns an error if the `OpenAPI` document is invalid or its types
     /// cannot be converted into CLI arguments.
+    ///
+    /// # Panics
+    ///
+    /// Panics if validated component references violate an internal generator
+    /// invariant.
     pub fn cli(&mut self, spec: &OpenAPI, crate_name: &str) -> Result<TokenStream> {
         validate_openapi(spec)?;
 

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -690,7 +690,7 @@ fn clap_arg(
         let maybe_var_names = e
             .variants()
             .map(|(var_name, var_details)| {
-                if let TypeEnumVariant::Simple = var_details {
+                if matches!(var_details, TypeEnumVariant::Simple) {
                     Some(format_ident!("{}", var_name))
                 } else {
                     None

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -404,8 +404,8 @@ impl Generator {
                 OperationParameterKind::Body(_) => continue,
 
                 OperationParameterKind::Path => true,
-                OperationParameterKind::Query(required) => *required,
-                OperationParameterKind::Header(required) => *required,
+                OperationParameterKind::Query(required)
+                | OperationParameterKind::Header(required) => *required,
             };
 
             // For paginated endpoints, we don't generate 'page_token' args.

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -255,9 +255,9 @@ impl Generator {
         let op_name = format_ident!("{}", &method.operation_id);
 
         let (_, success_kind) =
-            self.extract_responses(method, OperationResponseStatus::is_success_or_default);
+            Self::extract_responses(method, OperationResponseStatus::is_success_or_default);
         let (_, error_kind) =
-            self.extract_responses(method, OperationResponseStatus::is_error_or_default);
+            Self::extract_responses(method, OperationResponseStatus::is_error_or_default);
 
         let execute_and_output = match method.dropshot_paginated {
             // Normal, one-shot API calls.

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -34,6 +34,7 @@ impl Generator {
     ///
     /// Panics if validated component references violate an internal generator
     /// invariant.
+    #[allow(clippy::too_many_lines, reason = "keeps generation stages together")]
     pub fn cli(&mut self, spec: &OpenAPI, crate_name: &str) -> Result<TokenStream> {
         validate_openapi(spec)?;
 
@@ -200,6 +201,7 @@ impl Generator {
         Ok(code)
     }
 
+    #[allow(clippy::too_many_lines, reason = "mirrors the generated CLI method")]
     fn cli_method(&mut self, method: &crate::method::OperationMethod) -> CliOperation {
         let CliArg {
             parser: parser_args,
@@ -406,6 +408,7 @@ impl Generator {
         }
     }
 
+    #[allow(clippy::too_many_lines, reason = "keeps argument generation cohesive")]
     fn cli_method_args(&self, method: &crate::method::OperationMethod) -> CliArg {
         let mut args = CliOperationArgs::default();
 

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -637,6 +637,7 @@ impl Generator {
     }
 }
 
+#[derive(Clone, Copy)]
 enum Volitionality {
     Optional,
     Required,

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -413,8 +413,8 @@ impl Generator {
                 continue;
             }
 
-            let first_page_required = first_page_required_set
-                .map_or(false, |required| required.contains(&param.api_name));
+            let first_page_required =
+                first_page_required_set.is_some_and(|required| required.contains(&param.api_name));
 
             let volitionality = if innately_required || first_page_required {
                 Volitionality::Required

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -48,7 +48,13 @@ impl Generator {
                 })
             })
             .map(|(path, method, operation, path_parameters)| {
-                self.process_operation(operation, &spec.components, path, method, path_parameters)
+                self.process_operation(
+                    operation,
+                    spec.components.as_ref(),
+                    path,
+                    method,
+                    path_parameters,
+                )
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -432,7 +438,12 @@ impl Generator {
             // There should be no conflicting path or query parameters.
             assert!(!args.has_arg(&arg_name));
 
-            let parser = clap_arg(&arg_name, volitionality, &param.description, &arg_type);
+            let parser = clap_arg(
+                &arg_name,
+                volitionality,
+                param.description.as_ref(),
+                &arg_type,
+            );
 
             let arg_fn_name = sanitize(&param.name, Case::Snake);
             let arg_fn = format_ident!("{}", arg_fn_name);
@@ -600,7 +611,7 @@ impl Generator {
             let parser = clap_arg(
                 &prop_name,
                 volitionality,
-                &description.map(str::to_string),
+                description.map(str::to_string).as_ref(),
                 &prop_type,
             );
 
@@ -647,10 +658,10 @@ enum Volitionality {
 fn clap_arg(
     arg_name: &str,
     volitionality: Volitionality,
-    description: &Option<String>,
+    description: Option<&String>,
     arg_type: &Type,
 ) -> TokenStream {
-    let help = description.as_ref().map(|description| {
+    let help = description.map(|description| {
         quote! {
             .help(#description)
         }

--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -476,7 +476,7 @@ impl Generator {
                 }
             };
 
-            args.add_arg(arg_name, CliArg { parser, consumer })
+            args.add_arg(arg_name, CliArg { parser, consumer });
         }
 
         let maybe_body_type_id = method
@@ -500,14 +500,14 @@ impl Generator {
             match details {
                 typify::TypeDetails::Struct(struct_info) => {
                     for prop_info in struct_info.properties_info() {
-                        self.cli_method_body_arg(&mut args, prop_info)
+                        self.cli_method_body_arg(&mut args, prop_info);
                     }
                 }
 
                 _ => {
                     // If the body is not a struct, we don't know what's
                     // required or how to generate it
-                    args.body_required()
+                    args.body_required();
                 }
             }
         }
@@ -643,9 +643,9 @@ impl Generator {
                     })
                 }
             };
-            args.add_arg(prop_name, CliArg { parser, consumer })
+            args.add_arg(prop_name, CliArg { parser, consumer });
         } else if required {
-            args.body_required()
+            args.body_required();
         }
 
         // Cases

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -75,7 +75,7 @@ impl Generator {
         let crate_path = syn::TypePath {
             qself: None,
             path: syn::parse_str(crate_path)
-                .unwrap_or_else(|_| panic!("{} is not a valid identifier", crate_path)),
+                .unwrap_or_else(|_| panic!("{crate_path} is not a valid identifier")),
         };
 
         let code = quote! {

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -30,6 +30,11 @@ impl Generator {
     /// The `crate_path` parameter should be a valid Rust path corresponding to
     /// the SDK. This can include `::` and instances of `-` in the crate name
     /// should be converted to `_`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `OpenAPI` document or crate path is invalid, or
+    /// if its types cannot be converted into mock definitions.
     pub fn httpmock(&mut self, spec: &OpenAPI, crate_path: &str) -> Result<TokenStream> {
         validate_openapi(spec)?;
 

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -143,6 +143,7 @@ impl Generator {
         Ok(code)
     }
 
+    #[allow(clippy::too_many_lines, reason = "mirrors the generated mock method")]
     fn httpmock_method(&mut self, method: &crate::method::OperationMethod) -> MockOp {
         let when_name = sanitize(&format!("{}-when", method.operation_id), Case::Pascal);
         let when = format_ident!("{}", when_name).to_token_stream();

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -144,7 +144,7 @@ impl Generator {
     }
 
     #[allow(clippy::too_many_lines, reason = "mirrors the generated mock method")]
-    fn httpmock_method(&mut self, method: &crate::method::OperationMethod) -> MockOp {
+    fn httpmock_method(&self, method: &crate::method::OperationMethod) -> MockOp {
         let when_name = sanitize(&format!("{}-when", method.operation_id), Case::Pascal);
         let when = format_ident!("{}", when_name).to_token_stream();
         let then_name = sanitize(&format!("{}-then", method.operation_id), Case::Pascal);

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -35,6 +35,11 @@ impl Generator {
     ///
     /// Returns an error if the `OpenAPI` document or crate path is invalid, or
     /// if its types cannot be converted into mock definitions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if validated component references violate an internal generator
+    /// invariant.
     pub fn httpmock(&mut self, spec: &OpenAPI, crate_path: &str) -> Result<TokenStream> {
         validate_openapi(spec)?;
 

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -54,7 +54,13 @@ impl Generator {
                 })
             })
             .map(|(path, method, operation, path_parameters)| {
-                self.process_operation(operation, &spec.components, path, method, path_parameters)
+                self.process_operation(
+                    operation,
+                    spec.components.as_ref(),
+                    path,
+                    method,
+                    path_parameters,
+                )
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -328,7 +328,8 @@ impl Generator {
                             },
                         )
                     }
-                    crate::method::OperationResponseKind::None => Default::default(),
+                    crate::method::OperationResponseKind::None
+                    | crate::method::OperationResponseKind::Upgrade => Default::default(),
                     crate::method::OperationResponseKind::Raw => (
                         quote! {
                             value: ::serde_json::Value,
@@ -338,7 +339,6 @@ impl Generator {
                             .json_body(value)
                         },
                     ),
-                    crate::method::OperationResponseKind::Upgrade => Default::default(),
                 };
 
                 match status_code {

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -85,33 +85,23 @@ struct CrateSpec {
 }
 
 /// Style of generated client.
-#[derive(Clone, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, PartialEq, Eq, Default)]
 pub enum InterfaceStyle {
     /// Use positional style.
+    #[default]
     Positional,
     /// Use builder style.
     Builder,
 }
 
-impl Default for InterfaceStyle {
-    fn default() -> Self {
-        Self::Positional
-    }
-}
-
 /// Style for using the OpenAPI tags when generating names in the client.
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Default)]
 pub enum TagStyle {
     /// Merge tags to create names in the generated client.
+    #[default]
     Merged,
     /// Use each tag name to create separate names in the generated client.
     Separate,
-}
-
-impl Default for TagStyle {
-    fn default() -> Self {
-        Self::Merged
-    }
 }
 
 impl GenerationSettings {

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -252,7 +252,7 @@ impl Default for Generator {
     fn default() -> Self {
         Self {
             type_space: TypeSpace::new(TypeSpaceSettings::default().with_type_mod("types")),
-            settings: Default::default(),
+            settings: GenerationSettings::default(),
             uses_futures: Default::default(),
             uses_websockets: Default::default(),
         }
@@ -430,6 +430,10 @@ impl Generator {
 
             /// Types used as operation parameters and responses.
             #[allow(clippy::all)]
+            #[allow(
+                clippy::default_trait_access,
+                reason = "default expressions are emitted by typify"
+            )]
             pub mod types {
                 #types
             }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -117,13 +117,13 @@ impl GenerationSettings {
     }
 
     /// Set the [`InterfaceStyle`].
-    pub fn with_interface(&mut self, interface: InterfaceStyle) -> &mut Self {
+    pub const fn with_interface(&mut self, interface: InterfaceStyle) -> &mut Self {
         self.interface = interface;
         self
     }
 
     /// Set the [`TagStyle`].
-    pub fn with_tag(&mut self, tag: TagStyle) -> &mut Self {
+    pub const fn with_tag(&mut self, tag: TagStyle) -> &mut Self {
         self.tag = tag;
         self
     }
@@ -209,7 +209,7 @@ impl GenerationSettings {
     /// Policy regarding crates referenced by the schema extension
     /// `x-rust-type` not explicitly specified via [`Self::with_crate`].
     /// See [`typify::TypeSpaceSettings::with_unknown_crates`].
-    pub fn with_unknown_crates(&mut self, policy: UnknownPolicy) -> &mut Self {
+    pub const fn with_unknown_crates(&mut self, policy: UnknownPolicy) -> &mut Self {
         self.unknown_crates = policy;
         self
     }
@@ -247,7 +247,7 @@ impl GenerationSettings {
     }
 
     /// Set the underlying reqwest client's timeout
-    pub fn with_timeout(&mut self, timeout: u64) -> &mut Self {
+    pub const fn with_timeout(&mut self, timeout: u64) -> &mut Self {
         self.timeout = Some(timeout);
         self
     }
@@ -705,21 +705,21 @@ impl Generator {
 
     /// Get the [`TypeSpace`] for schemas present in the `OpenAPI` specification.
     #[must_use]
-    pub fn get_type_space(&self) -> &TypeSpace {
+    pub const fn get_type_space(&self) -> &TypeSpace {
         &self.type_space
     }
 
     /// Whether the generated client needs to use additional crates to support
     /// futures.
     #[must_use]
-    pub fn uses_futures(&self) -> bool {
+    pub const fn uses_futures(&self) -> bool {
         self.uses_futures
     }
 
     /// Whether the generated client needs to use additional crates to support
     /// websockets.
     #[must_use]
-    pub fn uses_websockets(&self) -> bool {
+    pub const fn uses_websockets(&self) -> bool {
         self.uses_websockets
     }
 }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -408,7 +408,7 @@ impl Generator {
                 s.push_str(ss);
             }
 
-            s.push_str(&format!("\n\nVersion: {}", &spec.info.version));
+            s.push_str(&format!("\n\nVersion: {}", spec.info.version));
 
             s
         };

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -4,7 +4,10 @@
 
 #![deny(missing_docs)]
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Write as _,
+};
 
 use openapiv3::OpenAPI;
 use proc_macro2::TokenStream;
@@ -400,7 +403,7 @@ impl Generator {
                 s.push_str(ss);
             }
 
-            s.push_str(&format!("\n\nVersion: {}", spec.info.version));
+            write!(&mut s, "\n\nVersion: {}", spec.info.version).unwrap();
 
             s
         };

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -288,13 +288,13 @@ impl Generator {
             .replace
             .iter()
             .for_each(|(type_name, (replace_name, impls))| {
-                type_settings.with_replacement(type_name, replace_name, impls.iter().cloned());
+                type_settings.with_replacement(type_name, replace_name, impls.iter().copied());
             });
         settings
             .convert
             .iter()
             .for_each(|(schema, type_name, impls)| {
-                type_settings.with_conversion(schema.clone(), type_name, impls.iter().cloned());
+                type_settings.with_conversion(schema.clone(), type_name, impls.iter().copied());
             });
 
         // Set the map type if specified.

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -534,6 +534,10 @@ impl Generator {
                 clippy::result_large_err,
                 reason = "generated methods preserve the public Error representation"
             )]
+            #[allow(
+                clippy::match_same_arms,
+                reason = "generated status ranges remain explicit"
+            )]
             impl Client {
                 #(#methods)*
             }
@@ -572,6 +576,10 @@ impl Generator {
             #[allow(
                 clippy::result_large_err,
                 reason = "generated methods preserve the public Error representation"
+            )]
+            #[allow(
+                clippy::match_same_arms,
+                reason = "generated status ranges remain explicit"
             )]
             pub mod builder {
                 use super::types;
@@ -624,6 +632,10 @@ impl Generator {
             #[allow(
                 clippy::result_large_err,
                 reason = "generated methods preserve the public Error representation"
+            )]
+            #[allow(
+                clippy::match_same_arms,
+                reason = "generated status ranges remain explicit"
             )]
             pub mod builder {
                 use super::types;

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -106,6 +106,7 @@ pub enum TagStyle {
 
 impl GenerationSettings {
     /// Create new generator settings with default values.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -260,6 +261,7 @@ impl Default for Generator {
 
 impl Generator {
     /// Create a new generator with default values.
+    #[must_use]
     pub fn new(settings: &GenerationSettings) -> Self {
         let mut type_settings = TypeSpaceSettings::default();
         type_settings
@@ -446,6 +448,7 @@ impl Generator {
                 /// `baseurl` is the base URL provided to the internal
                 /// `reqwest::Client`, and should include a scheme and hostname,
                 /// as well as port and a path stem if applicable.
+                #[must_use]
                 pub fn new(
                     baseurl: &str,
                     #inner_parameter
@@ -471,6 +474,7 @@ impl Generator {
                 /// `baseurl` is the base URL provided to the internal
                 /// `reqwest::Client`, and should include a scheme and hostname,
                 /// as well as port and a path stem if applicable.
+                #[must_use]
                 pub fn new_with_client(
                     baseurl: &str,
                     client: reqwest::Client,
@@ -651,18 +655,21 @@ impl Generator {
     }
 
     /// Get the [`TypeSpace`] for schemas present in the `OpenAPI` specification.
+    #[must_use]
     pub fn get_type_space(&self) -> &TypeSpace {
         &self.type_space
     }
 
     /// Whether the generated client needs to use additional crates to support
     /// futures.
+    #[must_use]
     pub fn uses_futures(&self) -> bool {
         self.uses_futures
     }
 
     /// Whether the generated client needs to use additional crates to support
     /// websockets.
+    #[must_use]
     pub fn uses_websockets(&self) -> bool {
         self.uses_websockets
     }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -456,6 +456,10 @@ impl Generator {
             /// Types used as operation parameters and responses.
             #[allow(clippy::all)]
             #[allow(
+                clippy::struct_field_names,
+                reason = "type definitions are emitted by typify"
+            )]
+            #[allow(
                 clippy::default_trait_access,
                 reason = "default expressions are emitted by typify"
             )]

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -575,6 +575,13 @@ impl Generator {
                 clippy::result_large_err,
                 reason = "generated methods preserve the public Error representation"
             )]
+            #[cfg_attr(
+                target_arch = "wasm32",
+                allow(
+                    clippy::future_not_send,
+                    reason = "reqwest futures use browser-local state on wasm"
+                )
+            )]
             #[allow(
                 clippy::match_same_arms,
                 reason = "generated status ranges remain explicit"
@@ -617,6 +624,13 @@ impl Generator {
             #[allow(
                 clippy::result_large_err,
                 reason = "generated methods preserve the public Error representation"
+            )]
+            #[cfg_attr(
+                target_arch = "wasm32",
+                allow(
+                    clippy::future_not_send,
+                    reason = "reqwest futures use browser-local state on wasm"
+                )
             )]
             #[allow(
                 clippy::match_same_arms,
@@ -673,6 +687,13 @@ impl Generator {
             #[allow(
                 clippy::result_large_err,
                 reason = "generated methods preserve the public Error representation"
+            )]
+            #[cfg_attr(
+                target_arch = "wasm32",
+                allow(
+                    clippy::future_not_send,
+                    reason = "reqwest futures use browser-local state on wasm"
+                )
             )]
             #[allow(
                 clippy::match_same_arms,

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -321,6 +321,11 @@ impl Generator {
     ///
     /// Returns an error if the `OpenAPI` document is invalid or its schemas
     /// cannot be converted into Rust types.
+    ///
+    /// # Panics
+    ///
+    /// Panics if validated component references violate an internal generator
+    /// invariant.
     pub fn generate_tokens(&mut self, spec: &OpenAPI) -> Result<TokenStream> {
         validate_openapi(spec)?;
 
@@ -468,6 +473,10 @@ impl Generator {
                 /// `baseurl` is the base URL provided to the internal
                 /// `reqwest::Client`, and should include a scheme and hostname,
                 /// as well as port and a path stem if applicable.
+                ///
+                /// # Panics
+                ///
+                /// Panics if the default `reqwest::Client` cannot be built.
                 #[must_use]
                 pub fn new(
                     baseurl: &str,
@@ -712,6 +721,10 @@ impl Generator {
 /// # Errors
 ///
 /// This function currently always returns `Ok`.
+///
+/// # Panics
+///
+/// Panics if one of the built-in regular expressions is invalid.
 pub fn space_out_items(content: &str) -> Result<String> {
     Ok(if cfg!(not(windows)) {
         let regex = regex::Regex::new(r"(\n\s*})(\n\s{0,8}[^} ])").unwrap();

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -721,7 +721,7 @@ pub fn validate_openapi(spec: &OpenAPI) -> Result<()> {
     spec.paths.paths.iter().try_for_each(|p| {
         match p.1 {
             openapiv3::ReferenceOr::Reference { reference: _ } => Err(Error::UnexpectedFormat(
-                format!("path {} uses reference, unsupported", p.0,),
+                format!("path {} uses reference, unsupported", p.0),
             )),
             openapiv3::ReferenceOr::Item(item) => {
                 // Make sure every operation has an operation ID, and that each

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -568,6 +568,10 @@ impl Generator {
         let out = quote! {
             #[allow(clippy::all)]
             #[allow(
+                clippy::too_many_arguments,
+                reason = "generated parameters mirror the OpenAPI operation"
+            )]
+            #[allow(
                 clippy::result_large_err,
                 reason = "generated methods preserve the public Error representation"
             )]

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -326,6 +326,10 @@ impl Generator {
     ///
     /// Panics if validated component references violate an internal generator
     /// invariant.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "keeps top-level generation stages together"
+    )]
     pub fn generate_tokens(&mut self, spec: &OpenAPI) -> Result<TokenStream> {
         validate_openapi(spec)?;
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -391,10 +391,10 @@ impl Generator {
 
         let types = self.type_space.to_stream();
 
-        let (inner_type, inner_fn_value) = match self.settings.inner_type.as_ref() {
-            Some(inner_type) => (inner_type.clone(), quote! { &self.inner }),
-            None => (quote! { () }, quote! { &() }),
-        };
+        let (inner_type, inner_fn_value) = self.settings.inner_type.as_ref().map_or_else(
+            || (quote! { () }, quote! { &() }),
+            |inner_type| (inner_type.clone(), quote! { &self.inner }),
+        );
 
         let inner_property = self.settings.inner_type.as_ref().map(|inner| {
             quote! {

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -690,10 +690,10 @@ impl Generator {
 /// Add newlines after end-braces at <= two levels of indentation.
 pub fn space_out_items(content: String) -> Result<String> {
     Ok(if cfg!(not(windows)) {
-        let regex = regex::Regex::new(r#"(\n\s*})(\n\s{0,8}[^} ])"#).unwrap();
+        let regex = regex::Regex::new(r"(\n\s*})(\n\s{0,8}[^} ])").unwrap();
         regex.replace_all(&content, "$1\n$2").to_string()
     } else {
-        let regex = regex::Regex::new(r#"(\n\s*})(\r\n\s{0,8}[^} ])"#).unwrap();
+        let regex = regex::Regex::new(r"(\n\s*})(\r\n\s{0,8}[^} ])").unwrap();
         regex.replace_all(&content, "$1\r\n$2").to_string()
     })
 }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -316,6 +316,11 @@ impl Generator {
     }
 
     /// Emit a [`TokenStream`] containing the generated client code.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `OpenAPI` document is invalid or its schemas
+    /// cannot be converted into Rust types.
     pub fn generate_tokens(&mut self, spec: &OpenAPI) -> Result<TokenStream> {
         validate_openapi(spec)?;
 
@@ -703,6 +708,10 @@ impl Generator {
 }
 
 /// Add newlines after end-braces at <= two levels of indentation.
+///
+/// # Errors
+///
+/// This function currently always returns `Ok`.
 pub fn space_out_items(content: &str) -> Result<String> {
     Ok(if cfg!(not(windows)) {
         let regex = regex::Regex::new(r"(\n\s*})(\n\s{0,8}[^} ])").unwrap();
@@ -725,6 +734,11 @@ fn validate_openapi_spec_version(spec_version: &str) -> Result<()> {
 }
 
 /// Do some very basic checks of the `OpenAPI` documents.
+///
+/// # Errors
+///
+/// Returns an error if the document uses an unsupported version, contains
+/// unresolved path references, or repeats an operation ID.
 pub fn validate_openapi(spec: &OpenAPI) -> Result<()> {
     validate_openapi_spec_version(spec.openapi.as_str())?;
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -685,8 +685,7 @@ fn validate_openapi_spec_version(spec_version: &str) -> Result<()> {
         Ok(())
     } else {
         Err(Error::UnexpectedFormat(format!(
-            "invalid version: {}",
-            spec_version
+            "invalid version: {spec_version}"
         )))
     }
 }
@@ -708,8 +707,7 @@ pub fn validate_openapi(spec: &OpenAPI) -> Result<()> {
                     if let Some(oid) = o.operation_id.as_ref() {
                         if !opids.insert(oid.to_string()) {
                             return Err(Error::UnexpectedFormat(format!(
-                                "duplicate operation ID: {}",
-                                oid,
+                                "duplicate operation ID: {oid}",
                             )));
                         }
                     } else {

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Oxide Computer Company
 
-//! Core implementation for the progenitor OpenAPI client generator.
+//! Core implementation for the progenitor `OpenAPI` client generator.
 
 #![deny(missing_docs)]
 
@@ -47,7 +47,7 @@ pub enum Error {
 #[allow(missing_docs)]
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// OpenAPI generator.
+/// `OpenAPI` generator.
 pub struct Generator {
     type_space: TypeSpace,
     settings: GenerationSettings,
@@ -94,7 +94,7 @@ pub enum InterfaceStyle {
     Builder,
 }
 
-/// Style for using the OpenAPI tags when generating names in the client.
+/// Style for using the `OpenAPI` tags when generating names in the client.
 #[derive(Clone, Deserialize, Default)]
 pub enum TagStyle {
     /// Merge tags to create names in the generated client.
@@ -110,13 +110,13 @@ impl GenerationSettings {
         Self::default()
     }
 
-    /// Set the [InterfaceStyle].
+    /// Set the [`InterfaceStyle`].
     pub fn with_interface(&mut self, interface: InterfaceStyle) -> &mut Self {
         self.interface = interface;
         self
     }
 
-    /// Set the [TagStyle].
+    /// Set the [`TagStyle`].
     pub fn with_tag(&mut self, tag: TagStyle) -> &mut Self {
         self.tag = tag;
         self
@@ -165,7 +165,7 @@ impl GenerationSettings {
     }
 
     /// Modify a type with the given name.
-    /// See [typify::TypeSpaceSettings::with_patch].
+    /// See [`typify::TypeSpaceSettings::with_patch`].
     pub fn with_patch<S: AsRef<str>>(&mut self, type_name: S, patch: &TypePatch) -> &mut Self {
         self.patch
             .insert(type_name.as_ref().to_string(), patch.clone());
@@ -173,7 +173,7 @@ impl GenerationSettings {
     }
 
     /// Replace a referenced type with a named type.
-    /// See [typify::TypeSpaceSettings::with_replacement].
+    /// See [`typify::TypeSpaceSettings::with_replacement`].
     pub fn with_replacement<TS: ToString, RS: ToString, I: Iterator<Item = TypeImpl>>(
         &mut self,
         type_name: TS,
@@ -188,7 +188,7 @@ impl GenerationSettings {
     }
 
     /// Replace a given schema with a named type.
-    /// See [typify::TypeSpaceSettings::with_conversion].
+    /// See [`typify::TypeSpaceSettings::with_conversion`].
     pub fn with_conversion<S: ToString, I: Iterator<Item = TypeImpl>>(
         &mut self,
         schema: schemars::schema::SchemaObject,
@@ -201,8 +201,8 @@ impl GenerationSettings {
     }
 
     /// Policy regarding crates referenced by the schema extension
-    /// `x-rust-type` not explicitly specified via [Self::with_crate].
-    /// See [typify::TypeSpaceSettings::with_unknown_crates].
+    /// `x-rust-type` not explicitly specified via [`Self::with_crate`].
+    /// See [`typify::TypeSpaceSettings::with_unknown_crates`].
     pub fn with_unknown_crates(&mut self, policy: UnknownPolicy) -> &mut Self {
         self.unknown_crates = policy;
         self
@@ -211,7 +211,7 @@ impl GenerationSettings {
     /// Explicitly named crates whose types may be used during generation
     /// rather than generating new types based on their schemas (base on the
     /// presence of the x-rust-type extension).
-    /// See [typify::TypeSpaceSettings::with_crate].
+    /// See [`typify::TypeSpaceSettings::with_crate`].
     pub fn with_crate<S1: ToString>(
         &mut self,
         crate_name: S1,
@@ -234,7 +234,7 @@ impl GenerationSettings {
     /// - [`indexmap::IndexMap`]
     ///
     /// The requiremnets for a map type can be found in the
-    /// [typify::TypeSpaceSettings::with_map_type] documentation.
+    /// [`typify::TypeSpaceSettings::with_map_type`] documentation.
     pub fn with_map_type<MT: ToString>(&mut self, map_type: MT) -> &mut Self {
         self.map_type = Some(map_type.to_string());
         self
@@ -308,7 +308,7 @@ impl Generator {
         }
     }
 
-    /// Emit a [TokenStream] containing the generated client code.
+    /// Emit a [`TokenStream`] containing the generated client code.
     pub fn generate_tokens(&mut self, spec: &OpenAPI) -> Result<TokenStream> {
         validate_openapi(spec)?;
 
@@ -387,7 +387,7 @@ impl Generator {
         let client_timeout = self.settings.timeout.unwrap_or(15);
 
         let client_docstring = {
-            let mut s = format!("Client for {}", spec.info.title);
+            let mut s = format!("Client for `{}`", spec.info.title);
 
             if let Some(ss) = &spec.info.description {
                 s.push_str("\n\n");
@@ -650,7 +650,7 @@ impl Generator {
         Ok(out)
     }
 
-    /// Get the [TypeSpace] for schemas present in the OpenAPI specification.
+    /// Get the [`TypeSpace`] for schemas present in the `OpenAPI` specification.
     pub fn get_type_space(&self) -> &TypeSpace {
         &self.type_space
     }
@@ -690,7 +690,7 @@ fn validate_openapi_spec_version(spec_version: &str) -> Result<()> {
     }
 }
 
-/// Do some very basic checks of the OpenAPI documents.
+/// Do some very basic checks of the `OpenAPI` documents.
 pub fn validate_openapi(spec: &OpenAPI) -> Result<()> {
     validate_openapi_spec_version(spec.openapi.as_str())?;
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -340,7 +340,13 @@ impl Generator {
                 })
             })
             .map(|(path, method, operation, path_parameters)| {
-                self.process_operation(operation, &spec.components, path, method, path_parameters)
+                self.process_operation(
+                    operation,
+                    spec.components.as_ref(),
+                    path,
+                    method,
+                    path_parameters,
+                )
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -536,6 +536,10 @@ impl Generator {
 
         let out = quote! {
             #[allow(clippy::all)]
+            #[allow(
+                clippy::result_large_err,
+                reason = "generated methods preserve the public Error representation"
+            )]
             impl Client {
                 #(#methods)*
             }
@@ -571,6 +575,10 @@ impl Generator {
 
             /// Types for composing operation parameters.
             #[allow(clippy::all)]
+            #[allow(
+                clippy::result_large_err,
+                reason = "generated methods preserve the public Error representation"
+            )]
             pub mod builder {
                 use super::types;
                 #[allow(unused_imports)]
@@ -619,6 +627,10 @@ impl Generator {
 
             /// Types for composing operation parameters.
             #[allow(clippy::all)]
+            #[allow(
+                clippy::result_large_err,
+                reason = "generated methods preserve the public Error representation"
+            )]
             pub mod builder {
                 use super::types;
                 #[allow(unused_imports)]

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -107,6 +107,8 @@ pub enum TagStyle {
     Separate,
 }
 
+// These public builder methods intentionally accept owned or borrowed values.
+#[allow(clippy::needless_pass_by_value)]
 impl GenerationSettings {
     /// Create new generator settings with default values.
     #[must_use]
@@ -361,7 +363,7 @@ impl Generator {
                     .collect::<BTreeMap<_, _>>();
                 self.generate_tokens_builder_separate(
                     &raw_methods,
-                    tag_info,
+                    &tag_info,
                     self.settings.inner_type.is_some(),
                 )
             }
@@ -617,7 +619,7 @@ impl Generator {
     fn generate_tokens_builder_separate(
         &mut self,
         input_methods: &[method::OperationMethod],
-        tag_info: BTreeMap<&String, &openapiv3::Tag>,
+        tag_info: &BTreeMap<&String, &openapiv3::Tag>,
         has_inner: bool,
     ) -> Result<TokenStream> {
         let builder_struct = input_methods
@@ -625,7 +627,7 @@ impl Generator {
             .map(|method| self.builder_struct(method, TagStyle::Separate, has_inner))
             .collect::<Result<Vec<_>>>()?;
 
-        let (traits_and_impls, trait_preludes) = self.builder_tags(input_methods, &tag_info);
+        let (traits_and_impls, trait_preludes) = self.builder_tags(input_methods, tag_info);
 
         // The allow(unused_imports) on the `pub use` is necessary with Rust
         // 1.76+, in case the generated file is not at the top level of the
@@ -695,13 +697,13 @@ impl Generator {
 }
 
 /// Add newlines after end-braces at <= two levels of indentation.
-pub fn space_out_items(content: String) -> Result<String> {
+pub fn space_out_items(content: &str) -> Result<String> {
     Ok(if cfg!(not(windows)) {
         let regex = regex::Regex::new(r"(\n\s*})(\n\s{0,8}[^} ])").unwrap();
-        regex.replace_all(&content, "$1\n$2").to_string()
+        regex.replace_all(content, "$1\n$2").to_string()
     } else {
         let regex = regex::Regex::new(r"(\n\s*})(\r\n\s{0,8}[^} ])").unwrap();
-        regex.replace_all(&content, "$1\r\n$2").to_string()
+        regex.replace_all(content, "$1\r\n$2").to_string()
     })
 }
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -365,11 +365,11 @@ impl Generator {
             .collect::<Result<Vec<_>>>()?;
 
         let operation_code = match (&self.settings.interface, &self.settings.tag) {
-            (InterfaceStyle::Positional, TagStyle::Merged) => self
+            (InterfaceStyle::Positional, TagStyle::Merged) => Ok(self
                 .generate_tokens_positional_merged(
                     &raw_methods,
                     self.settings.inner_type.is_some(),
-                ),
+                )),
             (InterfaceStyle::Positional, TagStyle::Separate) => {
                 unimplemented!("positional arguments with separate tags are currently unsupported")
             }
@@ -551,11 +551,11 @@ impl Generator {
         &mut self,
         input_methods: &[method::OperationMethod],
         has_inner: bool,
-    ) -> Result<TokenStream> {
+    ) -> TokenStream {
         let methods = input_methods
             .iter()
             .map(|method| self.positional_method(method, has_inner))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Vec<_>>();
 
         // The allow(unused_imports) on the `pub use` is necessary with Rust
         // 1.76+, in case the generated file is not at the top level of the
@@ -581,7 +581,7 @@ impl Generator {
                 pub use super::Client;
             }
         };
-        Ok(out)
+        out
     }
 
     fn generate_tokens_builder_merged(

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -728,7 +728,7 @@ pub fn validate_openapi(spec: &OpenAPI) -> Result<()> {
                 // operation ID is only used once in the document.
                 item.iter().try_for_each(|(_, o)| {
                     if let Some(oid) = o.operation_id.as_ref() {
-                        if !opids.insert(oid.to_string()) {
+                        if !opids.insert(oid.clone()) {
                             return Err(Error::UnexpectedFormat(format!(
                                 "duplicate operation ID: {oid}",
                             )));

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -596,7 +596,7 @@ impl Generator {
 
         let builder_methods = input_methods
             .iter()
-            .map(|method| self.builder_impl(method))
+            .map(Self::builder_impl)
             .collect::<Vec<_>>();
 
         let out = quote! {
@@ -651,7 +651,7 @@ impl Generator {
             .map(|method| self.builder_struct(method, TagStyle::Separate, has_inner))
             .collect::<Result<Vec<_>>>()?;
 
-        let (traits_and_impls, trait_preludes) = self.builder_tags(input_methods, tag_info);
+        let (traits_and_impls, trait_preludes) = Self::builder_tags(input_methods, tag_info);
 
         // The allow(unused_imports) on the `pub use` is necessary with Rust
         // 1.76+, in case the generated file is not at the top level of the

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1290,9 +1290,8 @@ impl Generator {
         };
 
         let typ = self.type_space.get_type(success_response).ok()?;
-        let details = match typ.details() {
-            typify::TypeDetails::Struct(details) => details,
-            _ => return None,
+        let typify::TypeDetails::Struct(details) = typ.details() else {
+            return None;
         };
 
         let properties = details.properties().collect::<BTreeMap<_, _>>();

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1376,7 +1376,7 @@ impl Generator {
     /// }
     /// ```
     ///
-    /// The Client's operation_id method simply invokes the builder's new
+    /// The client's `operation_id` method simply invokes the builder's new
     /// method, which assigns an error value to mandatory field and a
     /// `Ok(None)` value to optional ones:
     /// ```ignore
@@ -1920,7 +1920,7 @@ impl Generator {
         BuilderImpl { doc, sig, body }
     }
 
-    /// Generates a pair of TokenStreams.
+    /// Generates a pair of `TokenStream`s.
     ///
     /// The first includes all the operation code; impl Client for operations
     /// with no tags and code of this form for each tag:

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1178,10 +1178,10 @@ impl Generator {
     /// result is a `Vec<OperationResponse>` that enumerates the cases matching
     /// the filter, and a `TokenStream` that represents the generated type for
     /// those cases.
-    pub(crate) fn extract_responses<'a>(
-        method: &'a OperationMethod,
+    pub(crate) fn extract_responses(
+        method: &OperationMethod,
         filter: fn(&OperationResponseStatus) -> bool,
-    ) -> (Vec<&'a OperationResponse>, OperationResponseKind) {
+    ) -> (Vec<&OperationResponse>, OperationResponseKind) {
         let mut response_items = method
             .responses
             .iter()

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -614,7 +614,7 @@ impl Generator {
             success: success_type,
             error: error_type,
             body,
-        } = self.method_sig_body(method, quote! { Self }, quote! { self }, has_inner)?;
+        } = self.method_sig_body(method, &quote! { Self }, &quote! { self }, has_inner)?;
 
         let method_impl = quote! {
             #[doc = #doc_comment]
@@ -771,8 +771,8 @@ impl Generator {
     fn method_sig_body(
         &self,
         method: &OperationMethod,
-        client_type: TokenStream,
-        client_value: TokenStream,
+        client_type: &TokenStream,
+        client_value: &TokenStream,
         has_inner: bool,
     ) -> Result<MethodSigBody> {
         let param_names = method
@@ -876,7 +876,7 @@ impl Generator {
             })
             .collect();
 
-        let url_path = method.path.compile(url_renames, client_value.clone());
+        let url_path = method.path.compile(&url_renames, client_value);
         let url_path = quote! {
             let #url_ident = #url_path;
         };
@@ -951,7 +951,7 @@ impl Generator {
                 }
                 OperationResponseKind::None => {
                     quote! {
-                        Ok(ResponseValue::empty(#response_ident))
+                        Ok(ResponseValue::empty(&#response_ident))
                     }
                 }
                 OperationResponseKind::Raw => {
@@ -1001,7 +1001,7 @@ impl Generator {
                 OperationResponseKind::None => {
                     quote! {
                         Err(Error::ErrorResponse(
-                            ResponseValue::empty(#response_ident)
+                            ResponseValue::empty(&#response_ident)
                         ))
                     }
                 }
@@ -1658,8 +1658,8 @@ impl Generator {
             body,
         } = self.method_sig_body(
             method,
-            quote! { super::Client },
-            quote! { #client_ident },
+            &quote! { super::Client },
+            &quote! { #client_ident },
             has_inner,
         )?;
 

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1059,9 +1059,10 @@ impl Generator {
             }
         };
 
-        let inner = match has_inner {
-            true => quote! { &#client_value.inner, },
-            false => quote! {},
+        let inner = if has_inner {
+            quote! { &#client_value.inner, }
+        } else {
+            quote! {}
         };
         let pre_hook = self.settings.pre_hook.as_ref().map(|hook| {
             quote! {

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1664,7 +1664,9 @@ impl Generator {
         )?;
 
         let send_doc = format!(
-            "Sends a `{}` request to `{}`",
+            "Sends a `{}` request to `{}`\n\n\
+             # Errors\n\n\
+             Returns an error if request construction, transport, or response decoding fails.",
             method.method.as_str().to_ascii_uppercase(),
             method.path,
         );
@@ -2197,6 +2199,10 @@ fn make_doc_comment(method: &OperationMethod) -> String {
             buf.push('\n');
         }
     }
+
+    buf.push_str(
+        "\n# Errors\n\nReturns an error if request construction, transport, or response decoding fails.\n",
+    );
 
     buf
 }

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1951,7 +1951,7 @@ impl Generator {
         let mut base = Vec::new();
         let mut ext = BTreeMap::new();
 
-        methods.iter().for_each(|method| {
+        for method in methods {
             let BuilderImpl { doc, sig, body } = self.builder_helper(method);
 
             if method.tags.is_empty() {
@@ -1973,13 +1973,13 @@ impl Generator {
                         #body
                     }
                 };
-                method.tags.iter().for_each(|tag| {
+                for tag in &method.tags {
                     ext.entry(tag.clone())
                         .or_insert_with(Vec::new)
                         .push((trait_sig.clone(), impl_body.clone()));
-                });
+                }
             }
-        });
+        }
 
         let base_impl = (!base.is_empty()).then(|| {
             quote! {

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -559,7 +559,7 @@ impl Generator {
         &mut self,
         method: &OperationMethod,
         has_inner: bool,
-    ) -> Result<TokenStream> {
+    ) -> TokenStream {
         let operation_id = format_ident!("{}", method.operation_id);
 
         // Render each parameter as it will appear in the method signature.
@@ -616,7 +616,7 @@ impl Generator {
             success: success_type,
             error: error_type,
             body,
-        } = self.method_sig_body(method, &quote! { Self }, &quote! { self }, has_inner)?;
+        } = self.method_sig_body(method, &quote! { Self }, &quote! { self }, has_inner);
 
         let method_impl = quote! {
             #[doc = #doc_comment]
@@ -764,7 +764,7 @@ impl Generator {
             #stream_impl
         };
 
-        Ok(all)
+        all
     }
 
     /// Common code generation between positional and builder interface-styles.
@@ -777,7 +777,7 @@ impl Generator {
         client_type: &TokenStream,
         client_value: &TokenStream,
         has_inner: bool,
-    ) -> Result<MethodSigBody> {
+    ) -> MethodSigBody {
         let param_names = method
             .params
             .iter()
@@ -1167,11 +1167,11 @@ impl Generator {
             }
         };
 
-        Ok(MethodSigBody {
+        MethodSigBody {
             success: response_type.into_tokens(&self.type_space),
             error: error_type.into_tokens(&self.type_space),
             body: body_impl,
-        })
+        }
     }
 
     /// Extract responses that match criteria specified by the `filter`. The
@@ -1665,7 +1665,7 @@ impl Generator {
             &quote! { super::Client },
             &quote! { #client_ident },
             has_inner,
-        )?;
+        );
 
         let send_doc = format!(
             "Sends a `{}` request to `{}`\n\n\

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -696,6 +696,10 @@ impl Generator {
 
             quote! {
                 #[doc = #doc_comment]
+                #[allow(
+                    clippy::elidable_lifetime_names,
+                    reason = "the lifetime also binds borrowed stream parameters"
+                )]
                 pub fn #stream_id #bounds (
                     &'a self,
                     #(#stream_params),*

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -64,14 +64,14 @@ impl std::str::FromStr for HttpMethod {
 impl HttpMethod {
     const fn as_str(&self) -> &'static str {
         match self {
-            HttpMethod::Get => "get",
-            HttpMethod::Put => "put",
-            HttpMethod::Post => "post",
-            HttpMethod::Delete => "delete",
-            HttpMethod::Options => "options",
-            HttpMethod::Head => "head",
-            HttpMethod::Patch => "patch",
-            HttpMethod::Trace => "trace",
+            Self::Get => "get",
+            Self::Put => "put",
+            Self::Post => "post",
+            Self::Delete => "delete",
+            Self::Options => "options",
+            Self::Head => "head",
+            Self::Patch => "patch",
+            Self::Trace => "trace",
         }
     }
 }
@@ -121,11 +121,9 @@ pub enum OperationParameterKind {
 impl OperationParameterKind {
     const fn is_required(&self) -> bool {
         match self {
-            OperationParameterKind::Query(required) | OperationParameterKind::Header(required) => {
-                *required
-            }
+            Self::Query(required) | Self::Header(required) => *required,
             // TODO may be optional
-            OperationParameterKind::Path | OperationParameterKind::Body(_) => true,
+            Self::Path | Self::Body(_) => true,
         }
     }
     const fn is_optional(&self) -> bool {
@@ -206,38 +204,34 @@ pub enum OperationResponseStatus {
 impl OperationResponseStatus {
     fn to_value(&self) -> u16 {
         match self {
-            OperationResponseStatus::Code(code) => {
+            Self::Code(code) => {
                 assert!(*code < 1000);
                 *code
             }
-            OperationResponseStatus::Range(range) => {
+            Self::Range(range) => {
                 assert!(*range < 10);
                 *range * 100
             }
-            OperationResponseStatus::Default => 1000,
+            Self::Default => 1000,
         }
     }
 
     pub const fn is_success_or_default(&self) -> bool {
         matches!(
             self,
-            OperationResponseStatus::Default
-                | OperationResponseStatus::Code(101 | 200..=299)
-                | OperationResponseStatus::Range(2)
+            Self::Default | Self::Code(101 | 200..=299) | Self::Range(2)
         )
     }
 
     pub const fn is_error_or_default(&self) -> bool {
         matches!(
             self,
-            OperationResponseStatus::Default
-                | OperationResponseStatus::Code(400..=599)
-                | OperationResponseStatus::Range(4..=5)
+            Self::Default | Self::Code(400..=599) | Self::Range(4..=5)
         )
     }
 
     pub const fn is_default(&self) -> bool {
-        matches!(self, OperationResponseStatus::Default)
+        matches!(self, Self::Default)
     }
 }
 
@@ -264,17 +258,17 @@ pub enum OperationResponseKind {
 impl OperationResponseKind {
     pub fn into_tokens(self, type_space: &TypeSpace) -> TokenStream {
         match self {
-            OperationResponseKind::Type(ref type_id) => {
+            Self::Type(ref type_id) => {
                 let type_name = type_space.get_type(type_id).unwrap().ident();
                 quote! { #type_name }
             }
-            OperationResponseKind::None => {
+            Self::None => {
                 quote! { () }
             }
-            OperationResponseKind::Raw => {
+            Self::Raw => {
                 quote! { ByteStream }
             }
-            OperationResponseKind::Upgrade => {
+            Self::Upgrade => {
                 quote! { reqwest::Upgraded }
             }
         }

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1431,6 +1431,11 @@ impl Generator {
             .collect::<Vec<_>>();
 
         let client_ident = unique_ident_from("client", &param_names);
+        let client_init = if client_ident == format_ident!("client") {
+            quote! { client }
+        } else {
+            quote! { #client_ident: client }
+        };
 
         let mut cloneable = true;
 
@@ -1876,7 +1881,7 @@ impl Generator {
                 )]
                 pub fn new(client: &'a super::Client) -> Self {
                     Self {
-                        #client_ident: client,
+                        #client_init,
                         #( #param_names: #param_values, )*
                     }
                 }

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -282,6 +282,7 @@ impl OperationResponseKind {
 }
 
 impl Generator {
+    #[allow(clippy::too_many_lines, reason = "keeps operation analysis cohesive")]
     pub(crate) fn process_operation(
         &mut self,
         operation: &openapiv3::Operation,
@@ -553,6 +554,7 @@ impl Generator {
         })
     }
 
+    #[allow(clippy::too_many_lines, reason = "mirrors the generated method")]
     pub(crate) fn positional_method(
         &mut self,
         method: &OperationMethod,
@@ -768,6 +770,7 @@ impl Generator {
     /// Common code generation between positional and builder interface-styles.
     /// Returns a struct with the success and error types and the core body
     /// implementation that marshals arguments and executes the request.
+    #[allow(clippy::too_many_lines, reason = "mirrors the generated request body")]
     fn method_sig_body(
         &self,
         method: &OperationMethod,
@@ -1414,6 +1417,7 @@ impl Generator {
     /// Finally, paginated interfaces have a `stream()` method which uses the
     /// `send()` method above to fetch each page of results to assemble the
     /// items into a single `impl Stream`.
+    #[allow(clippy::too_many_lines, reason = "mirrors the generated builder")]
     pub(crate) fn builder_struct(
         &mut self,
         method: &OperationMethod,

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1194,8 +1194,8 @@ impl Generator {
         // since it will never be hit. Note that this is a no-op for error
         // responses.
         let len = response_items.len();
-        if len >= 2 {
-            if let (
+        if len >= 2
+            && let (
                 OperationResponse {
                     status_code: OperationResponseStatus::Range(2),
                     ..
@@ -1205,9 +1205,8 @@ impl Generator {
                     ..
                 },
             ) = (&response_items[len - 2], &response_items[len - 1])
-            {
-                response_items.pop();
-            }
+        {
+            response_items.pop();
         }
 
         let response_types = response_items

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -936,7 +936,7 @@ impl Generator {
         assert!(body_func.clone().count() <= 1);
 
         let (success_response_items, response_type) =
-            self.extract_responses(method, OperationResponseStatus::is_success_or_default);
+            Self::extract_responses(method, OperationResponseStatus::is_success_or_default);
 
         let success_response_matches = success_response_items.iter().map(|response| {
             let pat = match &response.status_code {
@@ -974,7 +974,7 @@ impl Generator {
 
         // Errors...
         let (error_response_items, error_type) =
-            self.extract_responses(method, OperationResponseStatus::is_error_or_default);
+            Self::extract_responses(method, OperationResponseStatus::is_error_or_default);
 
         let error_response_matches = error_response_items.iter().map(|response| {
             let pat = match &response.status_code {
@@ -1179,7 +1179,6 @@ impl Generator {
     /// the filter, and a `TokenStream` that represents the generated type for
     /// those cases.
     pub(crate) fn extract_responses<'a>(
-        &self,
         method: &'a OperationMethod,
         filter: fn(&OperationResponseStatus) -> bool,
     ) -> (Vec<&'a OperationResponse>, OperationResponseKind) {
@@ -1888,7 +1887,7 @@ impl Generator {
         })
     }
 
-    fn builder_helper(&self, method: &OperationMethod) -> BuilderImpl {
+    fn builder_helper(method: &OperationMethod) -> BuilderImpl {
         let operation_id = format_ident!("{}", method.operation_id);
         let struct_name = sanitize(&method.operation_id, Case::Pascal);
         let struct_ident = format_ident!("{}", struct_name);
@@ -1944,7 +1943,6 @@ impl Generator {
     /// pub use super::ClientTagExt;
     /// ```
     pub(crate) fn builder_tags(
-        &self,
         methods: &[OperationMethod],
         tag_info: &BTreeMap<&String, &openapiv3::Tag>,
     ) -> (TokenStream, TokenStream) {
@@ -1952,7 +1950,7 @@ impl Generator {
         let mut ext = BTreeMap::new();
 
         for method in methods {
-            let BuilderImpl { doc, sig, body } = self.builder_helper(method);
+            let BuilderImpl { doc, sig, body } = Self::builder_helper(method);
 
             if method.tags.is_empty() {
                 let impl_body = quote! {
@@ -2027,8 +2025,8 @@ impl Generator {
         )
     }
 
-    pub(crate) fn builder_impl(&self, method: &OperationMethod) -> TokenStream {
-        let BuilderImpl { doc, sig, body } = self.builder_helper(method);
+    pub(crate) fn builder_impl(method: &OperationMethod) -> TokenStream {
+        let BuilderImpl { doc, sig, body } = Self::builder_helper(method);
 
         let impl_body = quote! {
             #[doc = #doc]

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -120,11 +120,11 @@ pub enum OperationParameterKind {
 impl OperationParameterKind {
     fn is_required(&self) -> bool {
         match self {
-            OperationParameterKind::Path => true,
-            OperationParameterKind::Query(required) => *required,
-            OperationParameterKind::Header(required) => *required,
+            OperationParameterKind::Query(required) | OperationParameterKind::Header(required) => {
+                *required
+            }
             // TODO may be optional
-            OperationParameterKind::Body(_) => true,
+            OperationParameterKind::Path | OperationParameterKind::Body(_) => true,
         }
     }
     fn is_optional(&self) -> bool {
@@ -2270,43 +2270,37 @@ fn sort_params(raw_params: &mut [OperationParameter], names: &[String]) {
                         .unwrap_or_else(|| panic!("{b_name} missing from path"));
                     a_index.cmp(&b_index)
                 }
-                (OperationParameterKind::Path, OperationParameterKind::Query(_)) => Ordering::Less,
-                (OperationParameterKind::Path, OperationParameterKind::Body(_)) => Ordering::Less,
-                (OperationParameterKind::Path, OperationParameterKind::Header(_)) => Ordering::Less,
+                (
+                    OperationParameterKind::Path,
+                    OperationParameterKind::Query(_)
+                    | OperationParameterKind::Body(_)
+                    | OperationParameterKind::Header(_),
+                )
+                | (
+                    OperationParameterKind::Query(_),
+                    OperationParameterKind::Body(_) | OperationParameterKind::Header(_),
+                ) => Ordering::Less,
 
                 // Query params are in lexicographic order.
-                (OperationParameterKind::Query(_), OperationParameterKind::Body(_)) => {
-                    Ordering::Less
-                }
-                (OperationParameterKind::Query(_), OperationParameterKind::Query(_)) => {
+                (OperationParameterKind::Query(_), OperationParameterKind::Query(_))
+                | (OperationParameterKind::Header(_), OperationParameterKind::Header(_)) => {
                     a_name.cmp(b_name)
-                }
-                (OperationParameterKind::Query(_), OperationParameterKind::Path) => {
-                    Ordering::Greater
-                }
-                (OperationParameterKind::Query(_), OperationParameterKind::Header(_)) => {
-                    Ordering::Less
                 }
 
                 // Body params are last and should be singular.
-                (OperationParameterKind::Body(_), OperationParameterKind::Path) => {
-                    Ordering::Greater
-                }
-                (OperationParameterKind::Body(_), OperationParameterKind::Query(_)) => {
-                    Ordering::Greater
-                }
-                (OperationParameterKind::Body(_), OperationParameterKind::Header(_)) => {
-                    Ordering::Greater
-                }
                 (OperationParameterKind::Body(_), OperationParameterKind::Body(_)) => {
                     panic!("should only be one body")
                 }
 
-                // Header params are in lexicographic order.
-                (OperationParameterKind::Header(_), OperationParameterKind::Header(_)) => {
-                    a_name.cmp(b_name)
-                }
-                (OperationParameterKind::Header(_), _) => Ordering::Greater,
+                (OperationParameterKind::Query(_), OperationParameterKind::Path)
+                | (
+                    OperationParameterKind::Body(_),
+                    OperationParameterKind::Path
+                    | OperationParameterKind::Query(_)
+                    | OperationParameterKind::Header(_),
+                )
+                // Header params sort after every other parameter kind.
+                | (OperationParameterKind::Header(_), _) => Ordering::Greater,
             }
         },
     );

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1014,12 +1014,12 @@ impl Generator {
                 OperationResponseKind::Upgrade => {
                     if response.status_code == OperationResponseStatus::Default {
                         return quote! {}; // catch-all handled below
-                    } else {
-                        todo!(
-                            "non-default error response handling for \
-                                upgrade requests is not yet implemented"
-                        );
                     }
+
+                    todo!(
+                        "non-default error response handling for \
+                                upgrade requests is not yet implemented"
+                    );
                 }
             };
 

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -20,7 +20,7 @@ use crate::{
 use crate::{to_schema::ToSchema, util::ReferenceOrExt};
 
 /// The intermediate representation of an operation that will become a method.
-pub(crate) struct OperationMethod {
+pub struct OperationMethod {
     pub operation_id: String,
     pub tags: Vec<String>,
     pub method: HttpMethod,
@@ -170,7 +170,7 @@ impl std::fmt::Display for BodyContentType {
 }
 
 #[derive(Debug)]
-pub(crate) struct OperationResponse {
+pub struct OperationResponse {
     pub status_code: OperationResponseStatus,
     pub typ: OperationResponseKind,
     // TODO this isn't currently used because dropshot doesn't give us a
@@ -197,7 +197,7 @@ impl PartialOrd for OperationResponse {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) enum OperationResponseStatus {
+pub enum OperationResponseStatus {
     Code(u16),
     Range(u16),
     Default,
@@ -254,7 +254,7 @@ impl PartialOrd for OperationResponseStatus {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub(crate) enum OperationResponseKind {
+pub enum OperationResponseKind {
     Type(TypeId),
     None,
     Raw,

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -315,7 +315,7 @@ impl Generator {
                         let schema = parameter_data.schema()?.to_schema();
 
                         let name = sanitize(
-                            &format!("{}-{}", operation_id, &parameter_data.name),
+                            &format!("{}-{}", operation_id, parameter_data.name),
                             Case::Pascal,
                         );
                         let typ = self.type_space.add_type_with_name(&schema, Some(name))?;
@@ -339,7 +339,7 @@ impl Generator {
                             &format!(
                                 "{}-{}",
                                 operation.operation_id.as_ref().unwrap(),
-                                &parameter_data.name,
+                                parameter_data.name,
                             ),
                             Case::Pascal,
                         );
@@ -376,7 +376,7 @@ impl Generator {
                             &format!(
                                 "{}-{}",
                                 operation.operation_id.as_ref().unwrap(),
-                                &parameter_data.name,
+                                parameter_data.name,
                             ),
                             Case::Pascal,
                         );

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -390,13 +390,13 @@ impl Generator {
                         })
                     }
                     openapiv3::Parameter::Path { style, .. } => Err(Error::UnexpectedFormat(
-                        format!("unsupported style of path parameter {style:#?}",),
+                        format!("unsupported style of path parameter {style:#?}"),
                     )),
                     openapiv3::Parameter::Query { style, .. } => Err(Error::UnexpectedFormat(
-                        format!("unsupported style of query parameter {style:#?}",),
+                        format!("unsupported style of query parameter {style:#?}"),
                     )),
                     cookie @ openapiv3::Parameter::Cookie { .. } => Err(Error::UnexpectedFormat(
-                        format!("cookie parameters are not supported {cookie:#?}",),
+                        format!("cookie parameters are not supported {cookie:#?}"),
                     )),
                 }
             })
@@ -467,7 +467,7 @@ impl Generator {
                         let typ = if let Some(schema) = &mt.schema {
                             let schema = schema.to_schema();
                             let name = sanitize(
-                                &format!("{}-response", operation.operation_id.as_ref().unwrap(),),
+                                &format!("{}-response", operation.operation_id.as_ref().unwrap()),
                                 Case::Pascal,
                             );
                             self.type_space.add_type_with_name(&schema, Some(name))?
@@ -1617,7 +1617,7 @@ impl Generator {
                     OperationParameterType::RawBody => match param.kind {
                         OperationParameterKind::Body(BodyContentType::OctetStream) => {
                             let err_msg =
-                                format!("conversion to `reqwest::Body` for {} failed", param.name,);
+                                format!("conversion to `reqwest::Body` for {} failed", param.name);
 
                             Ok(quote! {
                                 pub fn #param_name<B>(mut self, value: B) -> Self
@@ -1631,7 +1631,7 @@ impl Generator {
                         }
                         OperationParameterKind::Body(BodyContentType::Text(_)) => {
                             let err_msg =
-                                format!("conversion to `String` for {} failed", param.name,);
+                                format!("conversion to `String` for {} failed", param.name);
 
                             Ok(quote! {
                                 pub fn #param_name<V>(mut self, value: V) -> Self
@@ -1815,7 +1815,7 @@ impl Generator {
         let struct_doc = match (tag_style, method.tags.len(), method.tags.first()) {
             (TagStyle::Merged, _, _) | (TagStyle::Separate, 0, _) => {
                 let ty = format!("Client::{}", method.operation_id);
-                format!("Builder for [`{ty}`]\n\n[`{ty}`]: super::{ty}",)
+                format!("Builder for [`{ty}`]\n\n[`{ty}`]: super::{ty}")
             }
             (TagStyle::Separate, 1, Some(tag)) => {
                 let ty = format!(
@@ -1823,7 +1823,7 @@ impl Generator {
                     sanitize(tag, Case::Pascal),
                     method.operation_id
                 );
-                format!("Builder for [`{ty}`]\n\n[`{ty}`]: super::{ty}",)
+                format!("Builder for [`{ty}`]\n\n[`{ty}`]: super::{ty}")
             }
             (TagStyle::Separate, _, _) => {
                 format!(
@@ -2139,7 +2139,7 @@ impl Generator {
                     todo!("media type encoding not empty: {:#?}", media_type);
                 }
                 let name = sanitize(
-                    &format!("{}-body", operation.operation_id.as_ref().unwrap(),),
+                    &format!("{}-body", operation.operation_id.as_ref().unwrap()),
                     Case::Pascal,
                 );
                 let typ = self

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -62,7 +62,7 @@ impl std::str::FromStr for HttpMethod {
     }
 }
 impl HttpMethod {
-    fn as_str(&self) -> &'static str {
+    const fn as_str(&self) -> &'static str {
         match self {
             HttpMethod::Get => "get",
             HttpMethod::Put => "put",
@@ -119,7 +119,7 @@ pub enum OperationParameterKind {
 }
 
 impl OperationParameterKind {
-    fn is_required(&self) -> bool {
+    const fn is_required(&self) -> bool {
         match self {
             OperationParameterKind::Query(required) | OperationParameterKind::Header(required) => {
                 *required
@@ -128,7 +128,7 @@ impl OperationParameterKind {
             OperationParameterKind::Path | OperationParameterKind::Body(_) => true,
         }
     }
-    fn is_optional(&self) -> bool {
+    const fn is_optional(&self) -> bool {
         !self.is_required()
     }
 }
@@ -218,7 +218,7 @@ impl OperationResponseStatus {
         }
     }
 
-    pub fn is_success_or_default(&self) -> bool {
+    pub const fn is_success_or_default(&self) -> bool {
         matches!(
             self,
             OperationResponseStatus::Default
@@ -227,7 +227,7 @@ impl OperationResponseStatus {
         )
     }
 
-    pub fn is_error_or_default(&self) -> bool {
+    pub const fn is_error_or_default(&self) -> bool {
         matches!(
             self,
             OperationResponseStatus::Default
@@ -236,7 +236,7 @@ impl OperationResponseStatus {
         )
     }
 
-    pub fn is_default(&self) -> bool {
+    pub const fn is_default(&self) -> bool {
         matches!(self, OperationResponseStatus::Default)
     }
 }
@@ -1877,6 +1877,10 @@ impl Generator {
             }
 
             impl<'a> #struct_ident<'a> {
+                #[allow(
+                    clippy::missing_const_for_fn,
+                    reason = "operation parameter defaults may require non-const initialization"
+                )]
                 pub fn new(client: &'a super::Client) -> Self {
                     Self {
                         #client_ident: client,

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -56,7 +56,7 @@ impl std::str::FromStr for HttpMethod {
             "head" => Ok(Self::Head),
             "patch" => Ok(Self::Patch),
             "trace" => Ok(Self::Trace),
-            _ => Err(Error::InternalError(format!("bad method: {}", s))),
+            _ => Err(Error::InternalError(format!("bad method: {s}"))),
         }
     }
 }
@@ -151,8 +151,7 @@ impl FromStr for BodyContentType {
             "application/x-www-form-urlencoded" => Ok(Self::FormUrlencoded),
             "text/plain" | "text/x-markdown" => Ok(Self::Text(String::from(&s[..offset]))),
             _ => Err(Error::UnexpectedFormat(format!(
-                "unexpected content type: {}",
-                s
+                "unexpected content type: {s}"
             ))),
         }
     }
@@ -392,13 +391,13 @@ impl Generator {
                         })
                     }
                     openapiv3::Parameter::Path { style, .. } => Err(Error::UnexpectedFormat(
-                        format!("unsupported style of path parameter {:#?}", style,),
+                        format!("unsupported style of path parameter {style:#?}",),
                     )),
                     openapiv3::Parameter::Query { style, .. } => Err(Error::UnexpectedFormat(
-                        format!("unsupported style of query parameter {:#?}", style,),
+                        format!("unsupported style of query parameter {style:#?}",),
                     )),
                     cookie @ openapiv3::Parameter::Cookie { .. } => Err(Error::UnexpectedFormat(
-                        format!("cookie parameters are not supported {:#?}", cookie,),
+                        format!("cookie parameters are not supported {cookie:#?}",),
                     )),
                 }
             })
@@ -527,8 +526,7 @@ impl Generator {
 
         if dropshot_websocket && dropshot_paginated.is_some() {
             return Err(Error::InvalidExtension(format!(
-                "conflicting extensions in {:?}",
-                operation_id
+                "conflicting extensions in {operation_id:?}"
             )));
         }
         if dropshot_websocket
@@ -538,8 +536,7 @@ impl Generator {
                 .is_none()
         {
             return Err(Error::InvalidExtension(format!(
-                "websocket endpoint {:?} must include an explicit 101 response code",
-                operation_id
+                "websocket endpoint {operation_id:?} must include an explicit 101 response code"
             )));
         }
 
@@ -1821,7 +1818,7 @@ impl Generator {
         let struct_doc = match (tag_style, method.tags.len(), method.tags.first()) {
             (TagStyle::Merged, _, _) | (TagStyle::Separate, 0, _) => {
                 let ty = format!("Client::{}", method.operation_id);
-                format!("Builder for [`{}`]\n\n[`{}`]: super::{}", ty, ty, ty,)
+                format!("Builder for [`{ty}`]\n\n[`{ty}`]: super::{ty}",)
             }
             (TagStyle::Separate, 1, Some(tag)) => {
                 let ty = format!(
@@ -1829,7 +1826,7 @@ impl Generator {
                     sanitize(tag, Case::Pascal),
                     method.operation_id
                 );
-                format!("Builder for [`{}`]\n\n[`{}`]: super::{}", ty, ty, ty,)
+                format!("Builder for [`{ty}`]\n\n[`{ty}`]: super::{ty}",)
             }
             (TagStyle::Separate, _, _) => {
                 format!(
@@ -1856,7 +1853,7 @@ impl Generator {
                                 sanitize(tag, Case::Pascal),
                                 method.operation_id,
                             );
-                            format!("[`{}`]: super::{}", ty, ty)
+                            format!("[`{ty}`]: super::{ty}")
                         })
                         .collect::<Vec<_>>()
                         .join("\n"),
@@ -2099,8 +2096,7 @@ impl Generator {
                             )),
                     } if enumeration.is_empty() => Ok(()),
                     _ => Err(Error::UnexpectedFormat(format!(
-                        "invalid schema for application/octet-stream: {:?}",
-                        schema
+                        "invalid schema for application/octet-stream: {schema:?}"
                     ))),
                 }?;
                 OperationParameterType::RawBody
@@ -2133,8 +2129,7 @@ impl Generator {
                             )),
                     } if enumeration.is_empty() => Ok(()),
                     _ => Err(Error::UnexpectedFormat(format!(
-                        "invalid schema for {}: {:?}",
-                        content_type, schema
+                        "invalid schema for {content_type}: {schema:?}"
                     ))),
                 }?;
                 OperationParameterType::RawBody
@@ -2268,11 +2263,11 @@ fn sort_params(raw_params: &mut [OperationParameter], names: &[String]) {
                     let a_index = names
                         .iter()
                         .position(|x| x == a_name)
-                        .unwrap_or_else(|| panic!("{} missing from path", a_name));
+                        .unwrap_or_else(|| panic!("{a_name} missing from path"));
                     let b_index = names
                         .iter()
                         .position(|x| x == b_name)
-                        .unwrap_or_else(|| panic!("{} missing from path", b_name));
+                        .unwrap_or_else(|| panic!("{b_name} missing from path"));
                     a_index.cmp(&b_index)
                 }
                 (OperationParameterKind::Path, OperationParameterKind::Query(_)) => Ordering::Less,
@@ -2326,7 +2321,7 @@ impl ParameterDataExt for openapiv3::ParameterData {
         match &self.format {
             openapiv3::ParameterSchemaOrContent::Schema(s) => Ok(s),
             openapiv3::ParameterSchemaOrContent::Content(c) => Err(Error::UnexpectedFormat(
-                format!("unexpected content {:#?}", c),
+                format!("unexpected content {c:#?}"),
             )),
         }
     }

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1671,7 +1671,7 @@ impl Generator {
         let send_doc = format!(
             "Sends a `{}` request to `{}`",
             method.method.as_str().to_ascii_uppercase(),
-            method.path.to_string(),
+            method.path,
         );
         let send_impl = quote! {
             #[doc = #send_doc]
@@ -1732,7 +1732,7 @@ impl Generator {
             let stream_doc = format!(
                 "Streams `{}` requests to `{}`",
                 method.method.as_str().to_ascii_uppercase(),
-                method.path.to_string(),
+                method.path,
             );
 
             quote! {
@@ -2182,7 +2182,7 @@ fn make_doc_comment(method: &OperationMethod) -> String {
     buf.push_str(&format!(
         "Sends a `{}` request to `{}`\n\n",
         method.method.as_str().to_ascii_uppercase(),
-        method.path.to_string(),
+        method.path,
     ));
 
     if method
@@ -2221,7 +2221,7 @@ fn make_stream_doc_comment(method: &OperationMethod) -> String {
     buf.push_str(&format!(
         "Sends repeated `{}` requests to `{}` until there are no more results.\n\n",
         method.method.as_str().to_ascii_uppercase(),
-        method.path.to_string(),
+        method.path,
     ));
 
     if method

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1892,11 +1892,10 @@ impl Generator {
         let struct_name = sanitize(&method.operation_id, Case::Pascal);
         let struct_ident = format_ident!("{}", struct_name);
 
-        let params = method
-            .params
-            .iter()
-            .map(|param| format!("\n    .{}({})", param.name, param.name))
-            .collect::<String>();
+        let mut params = String::new();
+        for param in &method.params {
+            write!(&mut params, "\n    .{}({})", param.name, param.name).unwrap();
+        }
 
         let eg = format!(
             "\

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -3,6 +3,7 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
+    fmt::Write as _,
     str::FromStr,
 };
 
@@ -2171,11 +2172,13 @@ fn make_doc_comment(method: &OperationMethod) -> String {
         buf.push_str("\n\n");
     }
 
-    buf.push_str(&format!(
+    write!(
+        &mut buf,
         "Sends a `{}` request to `{}`\n\n",
         method.method.as_str().to_ascii_uppercase(),
         method.path,
-    ));
+    )
+    .unwrap();
 
     if method
         .params
@@ -2186,7 +2189,7 @@ fn make_doc_comment(method: &OperationMethod) -> String {
     {
         buf.push_str("Arguments:\n");
         for param in &method.params {
-            buf.push_str(&format!("- `{}`", param.name));
+            write!(&mut buf, "- `{}`", param.name).unwrap();
             if let Some(description) = &param.description {
                 buf.push_str(": ");
                 buf.push_str(description);
@@ -2210,11 +2213,13 @@ fn make_stream_doc_comment(method: &OperationMethod) -> String {
         buf.push_str("\n\n");
     }
 
-    buf.push_str(&format!(
+    write!(
+        &mut buf,
         "Sends repeated `{}` requests to `{}` until there are no more results.\n\n",
         method.method.as_str().to_ascii_uppercase(),
         method.path,
-    ));
+    )
+    .unwrap();
 
     if method
         .params
@@ -2230,7 +2235,7 @@ fn make_stream_doc_comment(method: &OperationMethod) -> String {
                 continue;
             }
 
-            buf.push_str(&format!("- `{}`", param.name));
+            write!(&mut buf, "- `{}`", param.name).unwrap();
             if let Some(description) = &param.description {
                 buf.push_str(": ");
                 buf.push_str(description);

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -285,7 +285,7 @@ impl Generator {
     pub(crate) fn process_operation(
         &mut self,
         operation: &openapiv3::Operation,
-        components: &Option<Components>,
+        components: Option<&Components>,
         path: &str,
         method: &str,
         path_parameters: &[ReferenceOr<Parameter>],
@@ -2038,7 +2038,7 @@ impl Generator {
     fn get_body_param(
         &mut self,
         operation: &openapiv3::Operation,
-        components: &Option<Components>,
+        components: Option<&Components>,
     ) -> Result<Option<OperationParameter>> {
         let body = match &operation.request_body {
             Some(body) => body.item(components)?,

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1897,8 +1897,7 @@ impl Generator {
             .params
             .iter()
             .map(|param| format!("\n    .{}({})", param.name, param.name))
-            .collect::<Vec<_>>()
-            .join("");
+            .collect::<String>();
 
         let eg = format!(
             "\

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -524,10 +524,9 @@ impl Generator {
             )));
         }
         if dropshot_websocket
-            && responses
+            && !responses
                 .iter()
-                .find(|r| r.status_code == OperationResponseStatus::Code(101))
-                .is_none()
+                .any(|r| r.status_code == OperationResponseStatus::Code(101))
         {
             return Err(Error::InvalidExtension(format!(
                 "websocket endpoint {operation_id:?} must include an explicit 101 response code"

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -221,8 +221,7 @@ impl OperationResponseStatus {
         matches!(
             self,
             OperationResponseStatus::Default
-                | OperationResponseStatus::Code(101)
-                | OperationResponseStatus::Code(200..=299)
+                | OperationResponseStatus::Code(101 | 200..=299)
                 | OperationResponseStatus::Range(2)
         )
     }
@@ -489,8 +488,7 @@ impl Generator {
                     if matches!(
                         status_code,
                         OperationResponseStatus::Default
-                            | OperationResponseStatus::Code(101)
-                            | OperationResponseStatus::Code(200..=299)
+                            | OperationResponseStatus::Code(101 | 200..=299)
                             | OperationResponseStatus::Range(2)
                     ) {
                         success = true;
@@ -1238,8 +1236,7 @@ impl Generator {
             .filter(|param| {
                 matches!(
                     (param.api_name.as_str(), &param.kind),
-                    ("page_token", OperationParameterKind::Query(false))
-                        | ("limit", OperationParameterKind::Query(false))
+                    ("page_token" | "limit", OperationParameterKind::Query(false))
                 )
             })
             .count()

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -158,15 +158,16 @@ pub fn parse(t: &str) -> Result<PathTemplate> {
     Ok(PathTemplate { components })
 }
 
-impl ToString for PathTemplate {
-    fn to_string(&self) -> std::string::String {
-        self.components
-            .iter()
-            .map(|component| match component {
-                Component::Constant(s) => s.clone(),
-                Component::Parameter(s) => format!("{{{}}}", s),
-            })
-            .fold(String::new(), |a, b| a + &b)
+impl std::fmt::Display for PathTemplate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for component in &self.components {
+            match component {
+                Component::Constant(s) => f.write_str(s)?,
+                Component::Parameter(s) => write!(f, "{{{}}}", s)?,
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -35,7 +35,7 @@ impl PathTemplate {
                     "{}",
                     rename
                         .get(&n)
-                        .unwrap_or_else(|| panic!("missing path name mapping {}", n)),
+                        .unwrap_or_else(|| panic!("missing path name mapping {n}")),
                 );
                 Some(quote! {
                     encode_path(&#param.to_string())
@@ -69,7 +69,7 @@ impl PathTemplate {
                 Component::Parameter(_) => "[^/]*".to_string(),
             })
             .collect::<String>();
-        format!("^{}$", inner)
+        format!("^{inner}$")
     }
 
     pub fn as_wildcard_param(&self, param: &str) -> String {
@@ -82,7 +82,7 @@ impl PathTemplate {
                 Component::Parameter(_) => ".*".to_string(),
             })
             .collect::<String>();
-        format!("^{}$", inner)
+        format!("^{inner}$")
     }
 }
 
@@ -133,10 +133,7 @@ pub fn parse(t: &str) -> Result<PathTemplate> {
             State::Parameter => {
                 if c == '}' {
                     if a.contains('/') || a.contains('{') {
-                        return Err(Error::InvalidPath(format!(
-                            "invalid parameter name {:?}",
-                            a,
-                        )));
+                        return Err(Error::InvalidPath(format!("invalid parameter name {a:?}",)));
                     }
                     components.push(Component::Parameter(a));
                     a = String::new();
@@ -163,7 +160,7 @@ impl std::fmt::Display for PathTemplate {
         for component in &self.components {
             match component {
                 Component::Constant(s) => f.write_str(s)?,
-                Component::Parameter(s) => write!(f, "{{{}}}", s)?,
+                Component::Parameter(s) => write!(f, "{{{s}}}")?,
             }
         }
 
@@ -265,7 +262,7 @@ mod tests {
                     assert_eq!(&t, want);
                     assert_eq!(t.to_string().as_str(), *expect_string);
                 }
-                Err(e) => panic!("path {} {}", path, e),
+                Err(e) => panic!("path {path} {e}"),
             }
         }
     }
@@ -284,7 +281,7 @@ mod tests {
         for (path, want) in trials.iter() {
             match parse(path) {
                 Ok(t) => assert_eq!(&t.names(), want),
-                Err(e) => panic!("path {} {}", path, e),
+                Err(e) => panic!("path {path} {e}"),
             }
         }
     }

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -22,7 +22,7 @@ impl PathTemplate {
     pub fn compile(&self, rename: &HashMap<&String, &String>, client: &TokenStream) -> TokenStream {
         let mut fmt = String::new();
         fmt.push_str("{}");
-        for c in self.components.iter() {
+        for c in &self.components {
             match c {
                 Component::Constant(n) => fmt.push_str(n),
                 Component::Parameter(_) => fmt.push_str("{}"),
@@ -256,7 +256,7 @@ mod tests {
             ),
         ];
 
-        for (path, expect_string, want) in trials.iter() {
+        for (path, expect_string, want) in &trials {
             match parse(path) {
                 Ok(t) => {
                     assert_eq!(&t, want);
@@ -278,7 +278,7 @@ mod tests {
             ),
         ];
 
-        for (path, want) in trials.iter() {
+        for (path, want) in &trials {
             match parse(path) {
                 Ok(t) => assert_eq!(&t.names(), want),
                 Err(e) => panic!("path {path} {e}"),

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -19,7 +19,7 @@ pub struct PathTemplate {
 }
 
 impl PathTemplate {
-    pub fn compile(&self, rename: HashMap<&String, &String>, client: TokenStream) -> TokenStream {
+    pub fn compile(&self, rename: &HashMap<&String, &String>, client: &TokenStream) -> TokenStream {
         let mut fmt = String::new();
         fmt.push_str("{}");
         for c in self.components.iter() {
@@ -292,7 +292,7 @@ mod tests {
         let number = "number".to_string();
         rename.insert(&number, &number);
         let t = parse("/measure/{number}").unwrap();
-        let out = t.compile(rename, quote::quote! { self });
+        let out = t.compile(&rename, &quote::quote! { self });
         let want = quote::quote! {
             format!("{}/measure/{}",
                 self.baseurl,
@@ -312,7 +312,7 @@ mod tests {
         rename.insert(&two, &two);
         rename.insert(&three, &three);
         let t = parse("/abc/def:{one}:jkl/{two}/a:{three}").unwrap();
-        let out = t.compile(rename, quote::quote! { self });
+        let out = t.compile(&rename, &quote::quote! { self });
         let want = quote::quote! {
             format!("{}/abc/def:{}:jkl/{}/a:{}",
                 self.baseurl,

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -54,7 +54,7 @@ impl PathTemplate {
         self.components
             .iter()
             .filter_map(|c| match c {
-                Component::Parameter(name) => Some(name.to_string()),
+                Component::Parameter(name) => Some(name.clone()),
                 Component::Constant(_) => None,
             })
             .collect()

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -35,7 +35,7 @@ impl PathTemplate {
                     "{}",
                     rename
                         .get(&n)
-                        .expect(&format!("missing path name mapping {}", n)),
+                        .unwrap_or_else(|| panic!("missing path name mapping {}", n)),
                 );
                 Some(quote! {
                     encode_path(&#param.to_string())

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -291,6 +291,10 @@ mod tests {
         let mut rename = HashMap::new();
         let number = "number".to_string();
         rename.insert(&number, &number);
+        #[allow(
+            clippy::literal_string_with_formatting_args,
+            reason = "braces delimit path template parameters"
+        )]
         let t = parse("/measure/{number}").unwrap();
         let out = t.compile(&rename, &quote::quote! { self });
         let want = quote::quote! {
@@ -311,6 +315,10 @@ mod tests {
         rename.insert(&one, &one);
         rename.insert(&two, &two);
         rename.insert(&three, &three);
+        #[allow(
+            clippy::literal_string_with_formatting_args,
+            reason = "braces delimit path template parameters"
+        )]
         let t = parse("/abc/def:{one}:jkl/{two}/a:{three}").unwrap();
         let out = t.compile(&rename, &quote::quote! { self });
         let want = quote::quote! {

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -46,7 +46,7 @@ impl PathTemplate {
         });
 
         quote! {
-            format!(#fmt, #client.baseurl, #(#components,)*)
+            format!(#fmt, #client.baseurl #(, #components)*)
         }
     }
 
@@ -133,7 +133,7 @@ pub fn parse(t: &str) -> Result<PathTemplate> {
             State::Parameter => {
                 if c == '}' {
                     if a.contains('/') || a.contains('{') {
-                        return Err(Error::InvalidPath(format!("invalid parameter name {a:?}",)));
+                        return Err(Error::InvalidPath(format!("invalid parameter name {a:?}")));
                     }
                     components.push(Component::Parameter(a));
                     a = String::new();

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn basic() {
-        let trials = vec![
+        let trials = [
             (
                 "/info",
                 "/info",
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn names() {
-        let trials = vec![
+        let trials = [
             ("/info", vec![]),
             ("/measure/{number}", vec!["number".to_string()]),
             (

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -608,7 +608,7 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                             (None, _) => None,
                         };
                     }
-                };
+                }
 
                 // If we have exactly one type, and it's null, and we have
                 // subschemas that means that we must have had a bunch of

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -452,10 +452,12 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                     so.string().pattern = Some(pattern.clone());
                 }
                 if let Some(min_length) = min_length {
-                    so.string().min_length = Some(*min_length as u32);
+                    so.string().min_length =
+                        Some(u32::try_from(*min_length).expect("minimum length exceeds u32"));
                 }
                 if let Some(max_length) = max_length {
-                    so.string().max_length = Some(*max_length as u32);
+                    so.string().max_length =
+                        Some(u32::try_from(*max_length).expect("maximum length exceeds u32"));
                 }
 
                 // Number
@@ -498,10 +500,14 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                     so.object().additional_properties = additional_properties.convert();
                 }
                 if let Some(min_properties) = min_properties {
-                    so.object().min_properties = Some(*min_properties as u32);
+                    so.object().min_properties = Some(
+                        u32::try_from(*min_properties).expect("minimum property count exceeds u32"),
+                    );
                 }
                 if let Some(max_properties) = max_properties {
-                    so.object().max_properties = Some(*max_properties as u32);
+                    so.object().max_properties = Some(
+                        u32::try_from(*max_properties).expect("maximum property count exceeds u32"),
+                    );
                 }
 
                 // Array
@@ -509,10 +515,12 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                     so.array().items = items.convert().clone().map(SingleOrVec::Single);
                 }
                 if let Some(min_items) = min_items {
-                    so.array().min_items = Some(*min_items as u32);
+                    so.array().min_items =
+                        Some(u32::try_from(*min_items).expect("minimum item count exceeds u32"));
                 }
                 if let Some(max_items) = max_items {
-                    so.array().max_items = Some(*max_items as u32);
+                    so.array().max_items =
+                        Some(u32::try_from(*max_items).expect("maximum item count exceeds u32"));
                 }
                 if let Some(unique_items) = unique_items {
                     so.array().unique_items = Some(*unique_items);
@@ -748,7 +756,7 @@ fn oneof_nullable_wrapper(
 
 impl Convert<Option<u32>> for Option<usize> {
     fn convert(&self) -> Option<u32> {
-        (*self).map(|m| m as u32)
+        (*self).map(|m| u32::try_from(m).expect("schema bound exceeds u32"))
     }
 }
 

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -717,35 +717,29 @@ impl Convert<String> for openapiv3::IntegerFormat {
 
 impl Convert<Value> for Option<String> {
     fn convert(&self) -> Value {
-        match self {
-            Some(value) => Value::String(value.clone()),
-            None => Value::Null,
-        }
+        self.as_ref()
+            .map_or(Value::Null, |value| Value::String(value.clone()))
     }
 }
 
 impl Convert<Value> for Option<f64> {
     fn convert(&self) -> Value {
-        match self {
-            Some(value) => Value::Number(serde_json::Number::from_f64(*value).unwrap()),
-            None => Value::Null,
-        }
+        self.as_ref().map_or(Value::Null, |value| {
+            Value::Number(serde_json::Number::from_f64(*value).unwrap())
+        })
     }
 }
 impl Convert<Value> for Option<i64> {
     fn convert(&self) -> Value {
-        match self {
-            Some(value) => Value::Number(serde_json::Number::from(*value)),
-            None => Value::Null,
-        }
+        self.as_ref().map_or(Value::Null, |value| {
+            Value::Number(serde_json::Number::from(*value))
+        })
     }
 }
 impl Convert<Value> for Option<bool> {
     fn convert(&self) -> Value {
-        match self {
-            Some(value) => Value::Bool(*value),
-            None => Value::Null,
-        }
+        self.as_ref()
+            .map_or(Value::Null, |value| Value::Bool(*value))
     }
 }
 

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -52,10 +52,10 @@ where
 impl Convert<schemars::schema::Schema> for openapiv3::ReferenceOr<openapiv3::Schema> {
     fn convert(&self) -> schemars::schema::Schema {
         match self {
-            openapiv3::ReferenceOr::Reference { reference } => {
+            Self::Reference { reference } => {
                 schemars::schema::SchemaObject::new_ref(reference.clone()).into()
             }
-            openapiv3::ReferenceOr::Item(schema) => schema.convert(),
+            Self::Item(schema) => schema.convert(),
         }
     }
 }
@@ -675,9 +675,9 @@ where
 {
     fn convert(&self) -> Option<String> {
         match self {
-            openapiv3::VariantOrUnknownOrEmpty::Item(i) => Some(i.convert()),
-            openapiv3::VariantOrUnknownOrEmpty::Unknown(s) => Some(s.clone()),
-            openapiv3::VariantOrUnknownOrEmpty::Empty => None,
+            Self::Item(i) => Some(i.convert()),
+            Self::Unknown(s) => Some(s.clone()),
+            Self::Empty => None,
         }
     }
 }
@@ -685,11 +685,11 @@ where
 impl Convert<String> for openapiv3::StringFormat {
     fn convert(&self) -> String {
         match self {
-            openapiv3::StringFormat::Date => "date",
-            openapiv3::StringFormat::DateTime => "date-time",
-            openapiv3::StringFormat::Password => "password",
-            openapiv3::StringFormat::Byte => "byte",
-            openapiv3::StringFormat::Binary => "binary",
+            Self::Date => "date",
+            Self::DateTime => "date-time",
+            Self::Password => "password",
+            Self::Byte => "byte",
+            Self::Binary => "binary",
         }
         .to_string()
     }
@@ -698,8 +698,8 @@ impl Convert<String> for openapiv3::StringFormat {
 impl Convert<String> for openapiv3::NumberFormat {
     fn convert(&self) -> String {
         match self {
-            openapiv3::NumberFormat::Float => "float",
-            openapiv3::NumberFormat::Double => "double",
+            Self::Float => "float",
+            Self::Double => "double",
         }
         .to_string()
     }
@@ -708,8 +708,8 @@ impl Convert<String> for openapiv3::NumberFormat {
 impl Convert<String> for openapiv3::IntegerFormat {
     fn convert(&self) -> String {
         match self {
-            openapiv3::IntegerFormat::Int32 => "int32",
-            openapiv3::IntegerFormat::Int64 => "int64",
+            Self::Int32 => "int32",
+            Self::Int64 => "int64",
         }
         .to_string()
     }
@@ -798,8 +798,8 @@ impl Convert<Option<u32>> for Option<usize> {
     }
 }
 
-impl Convert<Option<f64>> for Option<f64> {
-    fn convert(&self) -> Option<f64> {
+impl Convert<Self> for Option<f64> {
+    fn convert(&self) -> Self {
         *self
     }
 }
@@ -839,8 +839,8 @@ where
 impl Convert<schemars::schema::Schema> for openapiv3::AdditionalProperties {
     fn convert(&self) -> schemars::schema::Schema {
         match self {
-            openapiv3::AdditionalProperties::Any(b) => schemars::schema::Schema::Bool(*b),
-            openapiv3::AdditionalProperties::Schema(schema) => schema.convert(),
+            Self::Any(b) => schemars::schema::Schema::Bool(*b),
+            Self::Schema(schema) => schema.convert(),
         }
     }
 }

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -139,7 +139,10 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                 max_length,
             })) => schemars::schema::SchemaObject {
                 metadata,
-                instance_type: instance_type(schemars::schema::InstanceType::String, nullable),
+                instance_type: Some(instance_type(
+                    schemars::schema::InstanceType::String,
+                    nullable,
+                )),
                 format: format.convert(),
                 enum_values: enumeration.convert(),
                 string: Some(Box::new(schemars::schema::StringValidation {
@@ -170,7 +173,10 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                 };
                 schemars::schema::SchemaObject {
                     metadata,
-                    instance_type: instance_type(schemars::schema::InstanceType::Number, nullable),
+                    instance_type: Some(instance_type(
+                        schemars::schema::InstanceType::Number,
+                        nullable,
+                    )),
                     format: format.convert(),
                     enum_values: enumeration.convert(),
                     number: Some(Box::new(schemars::schema::NumberValidation {
@@ -207,7 +213,10 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                 };
                 schemars::schema::SchemaObject {
                     metadata,
-                    instance_type: instance_type(schemars::schema::InstanceType::Integer, nullable),
+                    instance_type: Some(instance_type(
+                        schemars::schema::InstanceType::Integer,
+                        nullable,
+                    )),
                     format: format.convert(),
                     enum_values: enumeration.convert(),
                     number: Some(Box::new(schemars::schema::NumberValidation {
@@ -231,7 +240,10 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                 max_properties,
             })) => schemars::schema::SchemaObject {
                 metadata,
-                instance_type: instance_type(schemars::schema::InstanceType::Object, nullable),
+                instance_type: Some(instance_type(
+                    schemars::schema::InstanceType::Object,
+                    nullable,
+                )),
                 object: Some(Box::new(schemars::schema::ObjectValidation {
                     max_properties: max_properties.convert(),
                     min_properties: min_properties.convert(),
@@ -253,7 +265,10 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                 unique_items,
             })) => schemars::schema::SchemaObject {
                 metadata,
-                instance_type: instance_type(schemars::schema::InstanceType::Array, nullable),
+                instance_type: Some(instance_type(
+                    schemars::schema::InstanceType::Array,
+                    nullable,
+                )),
                 array: Some(Box::new(schemars::schema::ArrayValidation {
                     items: items.as_ref().map(|items| {
                         schemars::schema::SingleOrVec::Single(Box::new(items.convert()))
@@ -273,7 +288,10 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                 enumeration,
             })) => schemars::schema::SchemaObject {
                 metadata,
-                instance_type: instance_type(schemars::schema::InstanceType::Boolean, nullable),
+                instance_type: Some(instance_type(
+                    schemars::schema::InstanceType::Boolean,
+                    nullable,
+                )),
                 enum_values: enumeration.convert(),
                 extensions,
                 ..Default::default()
@@ -551,28 +569,40 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
                 // We do this last so we can infer types if none are specified.
                 match (typ.as_deref(), nullable) {
                     (Some("boolean"), _) => {
-                        so.instance_type =
-                            instance_type(schemars::schema::InstanceType::Boolean, nullable);
+                        so.instance_type = Some(instance_type(
+                            schemars::schema::InstanceType::Boolean,
+                            nullable,
+                        ));
                     }
                     (Some("object"), _) => {
-                        so.instance_type =
-                            instance_type(schemars::schema::InstanceType::Object, nullable);
+                        so.instance_type = Some(instance_type(
+                            schemars::schema::InstanceType::Object,
+                            nullable,
+                        ));
                     }
                     (Some("array"), _) => {
-                        so.instance_type =
-                            instance_type(schemars::schema::InstanceType::Array, nullable);
+                        so.instance_type = Some(instance_type(
+                            schemars::schema::InstanceType::Array,
+                            nullable,
+                        ));
                     }
                     (Some("number"), _) => {
-                        so.instance_type =
-                            instance_type(schemars::schema::InstanceType::Number, nullable);
+                        so.instance_type = Some(instance_type(
+                            schemars::schema::InstanceType::Number,
+                            nullable,
+                        ));
                     }
                     (Some("string"), _) => {
-                        so.instance_type =
-                            instance_type(schemars::schema::InstanceType::String, nullable);
+                        so.instance_type = Some(instance_type(
+                            schemars::schema::InstanceType::String,
+                            nullable,
+                        ));
                     }
                     (Some("integer"), _) => {
-                        so.instance_type =
-                            instance_type(schemars::schema::InstanceType::Integer, nullable);
+                        so.instance_type = Some(instance_type(
+                            schemars::schema::InstanceType::Integer,
+                            nullable,
+                        ));
                     }
 
                     (Some(typ), _) => todo!("invalid type: {}", typ),
@@ -722,11 +752,11 @@ impl Convert<Value> for Option<bool> {
 fn instance_type(
     instance_type: schemars::schema::InstanceType,
     nullable: bool,
-) -> Option<schemars::schema::SingleOrVec<schemars::schema::InstanceType>> {
+) -> schemars::schema::SingleOrVec<schemars::schema::InstanceType> {
     if nullable {
-        Some(vec![instance_type, schemars::schema::InstanceType::Null].into())
+        vec![instance_type, schemars::schema::InstanceType::Null].into()
     } else {
-        Some(instance_type.into())
+        instance_type.into()
     }
 }
 

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -75,6 +75,10 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
         clippy::too_many_lines,
         reason = "covers the complete schema conversion"
     )]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "OpenAPI represents numeric constraints as f64"
+    )]
     fn convert(&self) -> schemars::schema::Schema {
         // TODO the discriminator field is used in a way that seems both
         // important and unfortunately redundant. It corresponds to the same

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -538,7 +538,7 @@ impl Convert<schemars::schema::Schema> for openapiv3::Schema {
 
                 // Array
                 if items.is_some() {
-                    so.array().items = items.convert().clone().map(SingleOrVec::Single);
+                    so.array().items = items.convert().map(SingleOrVec::Single);
                 }
                 if let Some(min_items) = min_items {
                     so.array().min_items =

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -71,6 +71,10 @@ where
 }
 
 impl Convert<schemars::schema::Schema> for openapiv3::Schema {
+    #[allow(
+        clippy::too_many_lines,
+        reason = "covers the complete schema conversion"
+    )]
     fn convert(&self) -> schemars::schema::Schema {
         // TODO the discriminator field is used in a way that seems both
         // important and unfortunately redundant. It corresponds to the same

--- a/progenitor-impl/src/to_schema.rs
+++ b/progenitor-impl/src/to_schema.rs
@@ -1,5 +1,7 @@
 // Copyright 2024 Oxide Computer Company
 
+use std::collections::BTreeMap;
+
 use indexmap::IndexMap;
 use openapiv3::AnySchema;
 use schemars::schema::SingleOrVec;
@@ -721,7 +723,7 @@ fn oneof_nullable_wrapper(
         let extensions = schema.extensions;
 
         schema.metadata = None;
-        schema.extensions = Default::default();
+        schema.extensions = BTreeMap::default();
 
         schemars::schema::SchemaObject {
             metadata,

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -126,6 +126,6 @@ pub(crate) fn unique_ident_from(
             return ident;
         }
 
-        name.insert_str(0, "_");
+        name.insert(0, '_');
     }
 }

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -8,10 +8,10 @@ use unicode_ident::{is_xid_continue, is_xid_start};
 
 use crate::Result;
 
-pub(crate) trait ReferenceOrExt<T: ComponentLookup> {
+pub trait ReferenceOrExt<T: ComponentLookup> {
     fn item<'a>(&'a self, components: Option<&'a Components>) -> Result<&'a T>;
 }
-pub(crate) trait ComponentLookup: Sized {
+pub trait ComponentLookup: Sized {
     fn get_components(components: &Components) -> &IndexMap<String, ReferenceOr<Self>>;
 }
 
@@ -32,7 +32,7 @@ impl<T: ComponentLookup> ReferenceOrExt<T> for openapiv3::ReferenceOr<T> {
     }
 }
 
-pub(crate) fn items<'a, T>(
+pub fn items<'a, T>(
     refs: &'a [ReferenceOr<T>],
     components: Option<&'a Components>,
 ) -> impl Iterator<Item = Result<&'a T>>
@@ -42,7 +42,7 @@ where
     refs.iter().map(move |r| r.item(components))
 }
 
-pub(crate) fn parameter_map<'a>(
+pub fn parameter_map<'a>(
     refs: &'a [ReferenceOr<Parameter>],
     components: Option<&'a Components>,
 ) -> Result<BTreeMap<&'a String, &'a Parameter>> {
@@ -76,12 +76,12 @@ impl ComponentLookup for Schema {
 }
 
 #[derive(Clone, Copy)]
-pub(crate) enum Case {
+pub enum Case {
     Pascal,
     Snake,
 }
 
-pub(crate) fn sanitize(input: &str, case: Case) -> String {
+pub fn sanitize(input: &str, case: Case) -> String {
     use heck::{ToPascalCase, ToSnakeCase};
     let to_case = match case {
         Case::Pascal => str::to_pascal_case,
@@ -114,10 +114,7 @@ pub(crate) fn sanitize(input: &str, case: Case) -> String {
 
 /// Given a desired name and a slice of `proc_macro2::Ident`, generate a new
 /// Ident that is unique from the slice.
-pub(crate) fn unique_ident_from(
-    name: &str,
-    identities: &[proc_macro2::Ident],
-) -> proc_macro2::Ident {
+pub fn unique_ident_from(name: &str, identities: &[proc_macro2::Ident]) -> proc_macro2::Ident {
     let mut name = name.to_string();
 
     loop {

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -9,20 +9,20 @@ use unicode_ident::{is_xid_continue, is_xid_start};
 use crate::Result;
 
 pub(crate) trait ReferenceOrExt<T: ComponentLookup> {
-    fn item<'a>(&'a self, components: &'a Option<Components>) -> Result<&'a T>;
+    fn item<'a>(&'a self, components: Option<&'a Components>) -> Result<&'a T>;
 }
 pub(crate) trait ComponentLookup: Sized {
     fn get_components(components: &Components) -> &IndexMap<String, ReferenceOr<Self>>;
 }
 
 impl<T: ComponentLookup> ReferenceOrExt<T> for openapiv3::ReferenceOr<T> {
-    fn item<'a>(&'a self, components: &'a Option<Components>) -> Result<&'a T> {
+    fn item<'a>(&'a self, components: Option<&'a Components>) -> Result<&'a T> {
         match self {
             ReferenceOr::Item(item) => Ok(item),
             ReferenceOr::Reference { reference } => {
                 let idx = reference.rfind('/').unwrap();
                 let key = &reference[idx + 1..];
-                let parameters = T::get_components(components.as_ref().unwrap());
+                let parameters = T::get_components(components.unwrap());
                 parameters
                     .get(key)
                     .unwrap_or_else(|| panic!("key {key} is missing"))
@@ -34,17 +34,17 @@ impl<T: ComponentLookup> ReferenceOrExt<T> for openapiv3::ReferenceOr<T> {
 
 pub(crate) fn items<'a, T>(
     refs: &'a [ReferenceOr<T>],
-    components: &'a Option<Components>,
+    components: Option<&'a Components>,
 ) -> impl Iterator<Item = Result<&'a T>>
 where
     T: ComponentLookup,
 {
-    refs.iter().map(|r| r.item(components))
+    refs.iter().map(move |r| r.item(components))
 }
 
 pub(crate) fn parameter_map<'a>(
     refs: &'a [ReferenceOr<Parameter>],
-    components: &'a Option<Components>,
+    components: Option<&'a Components>,
 ) -> Result<BTreeMap<&'a String, &'a Parameter>> {
     items(refs, components)
         .map(|res| res.map(|param| (&param.parameter_data_ref().name, param)))

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -75,6 +75,7 @@ impl ComponentLookup for Schema {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) enum Case {
     Pascal,
     Snake,

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -18,8 +18,8 @@ pub trait ComponentLookup: Sized {
 impl<T: ComponentLookup> ReferenceOrExt<T> for openapiv3::ReferenceOr<T> {
     fn item<'a>(&'a self, components: Option<&'a Components>) -> Result<&'a T> {
         match self {
-            ReferenceOr::Item(item) => Ok(item),
-            ReferenceOr::Reference { reference } => {
+            Self::Item(item) => Ok(item),
+            Self::Reference { reference } => {
                 let idx = reference.rfind('/').unwrap();
                 let key = &reference[idx + 1..];
                 let parameters = T::get_components(components.unwrap());

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -111,7 +111,7 @@ pub(crate) fn sanitize(input: &str, case: Case) -> String {
     }
 }
 
-/// Given a desired name and a slice of proc_macro2::Ident, generate a new
+/// Given a desired name and a slice of `proc_macro2::Ident`, generate a new
 /// Ident that is unique from the slice.
 pub(crate) fn unique_ident_from(
     name: &str,

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -25,7 +25,7 @@ impl<T: ComponentLookup> ReferenceOrExt<T> for openapiv3::ReferenceOr<T> {
                 let parameters = T::get_components(components.as_ref().unwrap());
                 parameters
                     .get(key)
-                    .unwrap_or_else(|| panic!("key {} is missing", key))
+                    .unwrap_or_else(|| panic!("key {key} is missing"))
                     .item(components)
             }
         }
@@ -100,14 +100,14 @@ pub(crate) fn sanitize(input: &str, case: Case) -> String {
     let out = match out.chars().next() {
         None => to_case("x"),
         Some(c) if is_xid_start(c) => out,
-        Some(_) => format!("_{}", out),
+        Some(_) => format!("_{out}"),
     };
 
     // Make sure the string is a valid Rust identifier.
     if typify::accept_as_ident(&out) {
         out
     } else {
-        format!("{}_", out)
+        format!("{out}_")
     }
 }
 

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2347,7 +2347,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Buildomat
+///Client for `Buildomat`
 ///
 ///Version: 1.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2810,7 +2810,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
@@ -2865,7 +2865,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
@@ -2914,7 +2914,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2986,7 +2986,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
@@ -3043,7 +3043,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3127,7 +3127,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -3221,7 +3221,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -3298,7 +3298,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -3381,7 +3381,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3462,7 +3462,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
@@ -3519,7 +3519,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -3591,7 +3591,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3672,7 +3672,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
@@ -3730,7 +3730,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -3828,7 +3828,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -3920,7 +3920,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -4018,7 +4018,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -4111,7 +4111,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/workers`
@@ -4166,7 +4166,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
@@ -4215,7 +4215,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Ok(None),
             }
         }
@@ -4287,7 +4287,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 accept_language: Ok(None),
             }
         }

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2761,7 +2761,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3357,7 +3357,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3566,7 +3566,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
+                201u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3738,7 +3738,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3825,7 +3825,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
+                201u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3909,7 +3909,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -4031,8 +4031,8 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::empty(response))),
+                200..=299 => Ok(ResponseValue::empty(&response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::empty(&response))),
             }
         }
     }

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2662,6 +2662,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2668,6 +2668,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2785,6 +2785,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2416,7 +2416,12 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.control_hold()
     ///    .send()
     ///    .await;
@@ -2427,7 +2432,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/control/resume`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.control_resume()
     ///    .send()
     ///    .await;
@@ -2438,7 +2448,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/task/{Task}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_get()
     ///    .task(task)
     ///    .send()
@@ -2450,7 +2465,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.tasks_get()
     ///    .send()
     ///    .await;
@@ -2461,7 +2481,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/tasks`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_submit()
     ///    .body(body)
     ///    .send()
@@ -2473,7 +2498,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks/{task}/events`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_events_get()
     ///    .task(task)
     ///    .minseq(minseq)
@@ -2486,7 +2516,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_outputs_get()
     ///    .task(task)
     ///    .send()
@@ -2498,7 +2533,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_output_download()
     ///    .task(task)
     ///    .output(output)
@@ -2511,7 +2551,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/users`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.user_create()
     ///    .body(body)
     ///    .send()
@@ -2523,7 +2568,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/whoami`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.whoami()
     ///    .send()
     ///    .await;
@@ -2534,7 +2584,12 @@ impl Client {
 
     ///Sends a `PUT` request to `/v1/whoami/name`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.whoami_put_name()
     ///    .body(body)
     ///    .send()
@@ -2546,7 +2601,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/bootstrap`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_bootstrap()
     ///    .body(body)
     ///    .send()
@@ -2558,7 +2618,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/worker/ping`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_ping()
     ///    .send()
     ///    .await;
@@ -2569,7 +2634,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/append`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_append()
     ///    .task(task)
     ///    .body(body)
@@ -2582,7 +2652,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_upload_chunk()
     ///    .task(task)
     ///    .body(body)
@@ -2595,7 +2670,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_complete()
     ///    .task(task)
     ///    .body(body)
@@ -2608,7 +2688,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/output`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_add_output()
     ///    .task(task)
     ///    .body(body)
@@ -2621,7 +2706,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/workers`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.workers_list()
     ///    .send()
     ///    .await;
@@ -2632,7 +2722,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/workers/recycle`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.workers_recycle()
     ///    .send()
     ///    .await;
@@ -2643,7 +2738,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/things`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.get_thing_or_things()
     ///    .id(id)
     ///    .send()
@@ -2655,7 +2755,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/header-arg`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.header_arg()
     ///    .accept_language(accept_language)
     ///    .send()
@@ -2697,6 +2802,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl);
@@ -2743,6 +2853,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl);
@@ -2795,6 +2910,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/task/{Task}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -2846,6 +2966,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl);
@@ -2916,6 +3041,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/tasks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body
@@ -2993,6 +3123,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<::std::vec::Vec<types::TaskEvent>>, Error<()>> {
@@ -3066,6 +3201,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<::std::vec::Vec<types::TaskOutput>>, Error<()>> {
@@ -3145,6 +3285,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
                 client,
@@ -3218,6 +3363,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/users`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body
@@ -3268,6 +3418,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/whoami`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl);
@@ -3329,6 +3484,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/whoami/name`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -3401,6 +3561,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body
@@ -3451,6 +3616,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl);
@@ -3535,6 +3705,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3612,6 +3787,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3707,6 +3887,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3794,6 +3979,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3845,6 +4035,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/workers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl);
@@ -3891,6 +4086,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl);
@@ -3944,6 +4144,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/things`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<::std::string::String>, Error<()>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -4006,6 +4211,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/header-arg`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2365,6 +2365,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2361,6 +2361,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -2380,6 +2381,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2805,6 +2805,10 @@ pub mod builder {
     }
 
     impl<'a> ControlHold<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -2856,6 +2860,10 @@ pub mod builder {
     }
 
     impl<'a> ControlResume<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -2900,6 +2908,10 @@ pub mod builder {
     }
 
     impl<'a> TaskGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -2969,6 +2981,10 @@ pub mod builder {
     }
 
     impl<'a> TasksGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3021,6 +3037,10 @@ pub mod builder {
     }
 
     impl<'a> TaskSubmit<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3101,6 +3121,10 @@ pub mod builder {
     }
 
     impl<'a> TaskEventsGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3191,6 +3215,10 @@ pub mod builder {
     }
 
     impl<'a> TaskOutputsGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3264,6 +3292,10 @@ pub mod builder {
     }
 
     impl<'a> TaskOutputDownload<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3343,6 +3375,10 @@ pub mod builder {
     }
 
     impl<'a> UserCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3421,6 +3457,10 @@ pub mod builder {
     }
 
     impl<'a> Whoami<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3473,6 +3513,10 @@ pub mod builder {
     }
 
     impl<'a> WhoamiPutName<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3541,6 +3585,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerBootstrap<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3619,6 +3667,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerPing<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3672,6 +3724,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskAppend<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3766,6 +3822,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskUploadChunk<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3854,6 +3914,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskComplete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3948,6 +4012,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskAddOutput<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -4038,6 +4106,10 @@ pub mod builder {
     }
 
     impl<'a> WorkersList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -4089,6 +4161,10 @@ pub mod builder {
     }
 
     impl<'a> WorkersRecycle<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -4133,6 +4209,10 @@ pub mod builder {
     }
 
     impl<'a> GetThingOrThings<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -4201,6 +4281,10 @@ pub mod builder {
     }
 
     impl<'a> HeaderArg<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2699,7 +2699,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/hold", client.baseurl,);
+            let url = format!("{}/v1/control/hold", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -2745,7 +2745,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/resume", client.baseurl,);
+            let url = format!("{}/v1/control/resume", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -2801,7 +2801,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/task/{}",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -2848,7 +2848,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/tasks", client.baseurl,);
+            let url = format!("{}/v1/tasks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -2921,7 +2921,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/tasks", client.baseurl,);
+            let url = format!("{}/v1/tasks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3006,7 +3006,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/tasks/{}/events",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3074,7 +3074,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/tasks/{}/outputs",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3157,7 +3157,7 @@ pub mod builder {
                 "{}/v1/tasks/{}/outputs/{}",
                 client.baseurl,
                 encode_path(&task.to_string()),
-                encode_path(&output.to_string()),
+                encode_path(&output.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3223,7 +3223,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/users", client.baseurl,);
+            let url = format!("{}/v1/users", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3270,7 +3270,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/whoami", client.baseurl,);
+            let url = format!("{}/v1/whoami", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3332,7 +3332,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/whoami/name", client.baseurl,);
+            let url = format!("{}/v1/whoami/name", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3406,7 +3406,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let url = format!("{}/v1/worker/bootstrap", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3453,7 +3453,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/worker/ping", client.baseurl,);
+            let url = format!("{}/v1/worker/ping", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3544,7 +3544,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/append",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3619,7 +3619,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/chunk",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3716,7 +3716,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/complete",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3803,7 +3803,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/output",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3847,7 +3847,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers", client.baseurl,);
+            let url = format!("{}/v1/workers", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3893,7 +3893,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let url = format!("{}/v1/workers/recycle", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3947,7 +3947,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<::std::string::String>, Error<()>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/things", client.baseurl,);
+            let url = format!("{}/v1/things", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -4012,7 +4012,7 @@ pub mod builder {
                 accept_language,
             } = self;
             let accept_language = accept_language.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/header-arg", client.baseurl,);
+            let url = format!("{}/v1/header-arg", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2718,7 +2718,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3314,7 +3314,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3523,7 +3523,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
+                201u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3695,7 +3695,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3782,7 +3782,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
+                201u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3866,7 +3866,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }
@@ -3988,8 +3988,8 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::empty(response))),
+                200..=299 => Ok(ResponseValue::empty(&response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::empty(&response))),
             }
         }
     }

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2767,7 +2767,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
@@ -2822,7 +2822,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
@@ -2871,7 +2871,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2943,7 +2943,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
@@ -3000,7 +3000,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3084,7 +3084,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -3178,7 +3178,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -3255,7 +3255,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -3338,7 +3338,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3419,7 +3419,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
@@ -3476,7 +3476,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -3548,7 +3548,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3629,7 +3629,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
@@ -3687,7 +3687,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -3785,7 +3785,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -3877,7 +3877,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -3975,7 +3975,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -4068,7 +4068,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/workers`
@@ -4123,7 +4123,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
@@ -4172,7 +4172,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Ok(None),
             }
         }
@@ -4244,7 +4244,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 accept_language: Ok(None),
             }
         }

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2304,7 +2304,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Buildomat
+///Client for `Buildomat`
 ///
 ///Version: 1.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2322,6 +2322,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2762,6 +2762,10 @@ pub mod builder {
     }
 
     impl<'a> ControlHold<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -2813,6 +2817,10 @@ pub mod builder {
     }
 
     impl<'a> ControlResume<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -2857,6 +2865,10 @@ pub mod builder {
     }
 
     impl<'a> TaskGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -2926,6 +2938,10 @@ pub mod builder {
     }
 
     impl<'a> TasksGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -2978,6 +2994,10 @@ pub mod builder {
     }
 
     impl<'a> TaskSubmit<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3058,6 +3078,10 @@ pub mod builder {
     }
 
     impl<'a> TaskEventsGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3148,6 +3172,10 @@ pub mod builder {
     }
 
     impl<'a> TaskOutputsGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3221,6 +3249,10 @@ pub mod builder {
     }
 
     impl<'a> TaskOutputDownload<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3300,6 +3332,10 @@ pub mod builder {
     }
 
     impl<'a> UserCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3378,6 +3414,10 @@ pub mod builder {
     }
 
     impl<'a> Whoami<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3430,6 +3470,10 @@ pub mod builder {
     }
 
     impl<'a> WhoamiPutName<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3498,6 +3542,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerBootstrap<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3576,6 +3624,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerPing<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3629,6 +3681,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskAppend<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3723,6 +3779,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskUploadChunk<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3811,6 +3871,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskComplete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3905,6 +3969,10 @@ pub mod builder {
     }
 
     impl<'a> WorkerTaskAddOutput<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3995,6 +4063,10 @@ pub mod builder {
     }
 
     impl<'a> WorkersList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -4046,6 +4118,10 @@ pub mod builder {
     }
 
     impl<'a> WorkersRecycle<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -4090,6 +4166,10 @@ pub mod builder {
     }
 
     impl<'a> GetThingOrThings<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -4158,6 +4238,10 @@ pub mod builder {
     }
 
     impl<'a> HeaderArg<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2625,6 +2625,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2619,6 +2619,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2318,6 +2318,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -2337,6 +2338,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2742,6 +2742,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2656,7 +2656,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/hold", client.baseurl,);
+            let url = format!("{}/v1/control/hold", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -2702,7 +2702,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/resume", client.baseurl,);
+            let url = format!("{}/v1/control/resume", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -2758,7 +2758,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/task/{}",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -2805,7 +2805,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/tasks", client.baseurl,);
+            let url = format!("{}/v1/tasks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -2878,7 +2878,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/tasks", client.baseurl,);
+            let url = format!("{}/v1/tasks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -2963,7 +2963,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/tasks/{}/events",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3031,7 +3031,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/tasks/{}/outputs",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3114,7 +3114,7 @@ pub mod builder {
                 "{}/v1/tasks/{}/outputs/{}",
                 client.baseurl,
                 encode_path(&task.to_string()),
-                encode_path(&output.to_string()),
+                encode_path(&output.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3180,7 +3180,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/users", client.baseurl,);
+            let url = format!("{}/v1/users", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3227,7 +3227,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/whoami", client.baseurl,);
+            let url = format!("{}/v1/whoami", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3289,7 +3289,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/whoami/name", client.baseurl,);
+            let url = format!("{}/v1/whoami/name", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3363,7 +3363,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let url = format!("{}/v1/worker/bootstrap", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3410,7 +3410,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/worker/ping", client.baseurl,);
+            let url = format!("{}/v1/worker/ping", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3501,7 +3501,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/append",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3576,7 +3576,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/chunk",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3673,7 +3673,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/complete",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3760,7 +3760,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/worker/task/{}/output",
                 client.baseurl,
-                encode_path(&task.to_string()),
+                encode_path(&task.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3804,7 +3804,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers", client.baseurl,);
+            let url = format!("{}/v1/workers", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3850,7 +3850,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let url = format!("{}/v1/workers/recycle", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3904,7 +3904,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<::std::string::String>, Error<()>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/things", client.baseurl,);
+            let url = format!("{}/v1/things", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3969,7 +3969,7 @@ pub mod builder {
                 accept_language,
             } = self;
             let accept_language = accept_language.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/header-arg", client.baseurl,);
+            let url = format!("{}/v1/header-arg", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2373,7 +2373,12 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.control_hold()
     ///    .send()
     ///    .await;
@@ -2384,7 +2389,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/control/resume`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.control_resume()
     ///    .send()
     ///    .await;
@@ -2395,7 +2405,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/task/{Task}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_get()
     ///    .task(task)
     ///    .send()
@@ -2407,7 +2422,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.tasks_get()
     ///    .send()
     ///    .await;
@@ -2418,7 +2438,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/tasks`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_submit()
     ///    .body(body)
     ///    .send()
@@ -2430,7 +2455,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks/{task}/events`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_events_get()
     ///    .task(task)
     ///    .minseq(minseq)
@@ -2443,7 +2473,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_outputs_get()
     ///    .task(task)
     ///    .send()
@@ -2455,7 +2490,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.task_output_download()
     ///    .task(task)
     ///    .output(output)
@@ -2468,7 +2508,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/users`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.user_create()
     ///    .body(body)
     ///    .send()
@@ -2480,7 +2525,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/whoami`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.whoami()
     ///    .send()
     ///    .await;
@@ -2491,7 +2541,12 @@ impl Client {
 
     ///Sends a `PUT` request to `/v1/whoami/name`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.whoami_put_name()
     ///    .body(body)
     ///    .send()
@@ -2503,7 +2558,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/bootstrap`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_bootstrap()
     ///    .body(body)
     ///    .send()
@@ -2515,7 +2575,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/worker/ping`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_ping()
     ///    .send()
     ///    .await;
@@ -2526,7 +2591,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/append`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_append()
     ///    .task(task)
     ///    .body(body)
@@ -2539,7 +2609,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_upload_chunk()
     ///    .task(task)
     ///    .body(body)
@@ -2552,7 +2627,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_complete()
     ///    .task(task)
     ///    .body(body)
@@ -2565,7 +2645,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/output`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.worker_task_add_output()
     ///    .task(task)
     ///    .body(body)
@@ -2578,7 +2663,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/workers`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.workers_list()
     ///    .send()
     ///    .await;
@@ -2589,7 +2679,12 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/workers/recycle`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.workers_recycle()
     ///    .send()
     ///    .await;
@@ -2600,7 +2695,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/things`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.get_thing_or_things()
     ///    .id(id)
     ///    .send()
@@ -2612,7 +2712,12 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/header-arg`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.header_arg()
     ///    .accept_language(accept_language)
     ///    .send()
@@ -2654,6 +2759,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl);
@@ -2700,6 +2810,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl);
@@ -2752,6 +2867,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/task/{Task}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -2803,6 +2923,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl);
@@ -2873,6 +2998,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/tasks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body
@@ -2950,6 +3080,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<::std::vec::Vec<types::TaskEvent>>, Error<()>> {
@@ -3023,6 +3158,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<::std::vec::Vec<types::TaskOutput>>, Error<()>> {
@@ -3102,6 +3242,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
                 client,
@@ -3175,6 +3320,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/users`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body
@@ -3225,6 +3375,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/whoami`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl);
@@ -3286,6 +3441,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/whoami/name`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -3358,6 +3518,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body
@@ -3408,6 +3573,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl);
@@ -3492,6 +3662,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3569,6 +3744,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3664,6 +3844,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3751,6 +3936,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
@@ -3802,6 +3992,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/workers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl);
@@ -3848,6 +4043,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl);
@@ -3901,6 +4101,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/things`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<::std::string::String>, Error<()>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -3963,6 +4168,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/header-arg`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -895,6 +895,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -906,7 +906,7 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/control/hold", self.baseurl,);
+        let url = format!("{}/v1/control/hold", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -937,7 +937,7 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/control/resume", self.baseurl,);
+        let url = format!("{}/v1/control/resume", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -966,7 +966,7 @@ impl Client {
         let url = format!(
             "{}/v1/task/{}",
             self.baseurl,
-            encode_path(&task.to_string()),
+            encode_path(&task.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1000,7 +1000,7 @@ impl Client {
     pub async fn tasks_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
-        let url = format!("{}/v1/tasks", self.baseurl,);
+        let url = format!("{}/v1/tasks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1034,7 +1034,7 @@ impl Client {
         &'a self,
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-        let url = format!("{}/v1/tasks", self.baseurl,);
+        let url = format!("{}/v1/tasks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1073,7 +1073,7 @@ impl Client {
         let url = format!(
             "{}/v1/tasks/{}/events",
             self.baseurl,
-            encode_path(&task.to_string()),
+            encode_path(&task.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1112,7 +1112,7 @@ impl Client {
         let url = format!(
             "{}/v1/tasks/{}/outputs",
             self.baseurl,
-            encode_path(&task.to_string()),
+            encode_path(&task.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1152,7 +1152,7 @@ impl Client {
             "{}/v1/tasks/{}/outputs/{}",
             self.baseurl,
             encode_path(&task.to_string()),
-            encode_path(&output.to_string()),
+            encode_path(&output.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1179,7 +1179,7 @@ impl Client {
         &'a self,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-        let url = format!("{}/v1/users", self.baseurl,);
+        let url = format!("{}/v1/users", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1211,7 +1211,7 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-        let url = format!("{}/v1/whoami", self.baseurl,);
+        let url = format!("{}/v1/whoami", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1245,7 +1245,7 @@ impl Client {
         &'a self,
         body: String,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/whoami/name", self.baseurl,);
+        let url = format!("{}/v1/whoami/name", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1280,7 +1280,7 @@ impl Client {
         &'a self,
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-        let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
+        let url = format!("{}/v1/worker/bootstrap", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1314,7 +1314,7 @@ impl Client {
     pub async fn worker_ping<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-        let url = format!("{}/v1/worker/ping", self.baseurl,);
+        let url = format!("{}/v1/worker/ping", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1352,7 +1352,7 @@ impl Client {
         let url = format!(
             "{}/v1/worker/task/{}/append",
             self.baseurl,
-            encode_path(&task.to_string()),
+            encode_path(&task.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1388,7 +1388,7 @@ impl Client {
         let url = format!(
             "{}/v1/worker/task/{}/chunk",
             self.baseurl,
-            encode_path(&task.to_string()),
+            encode_path(&task.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1432,7 +1432,7 @@ impl Client {
         let url = format!(
             "{}/v1/worker/task/{}/complete",
             self.baseurl,
-            encode_path(&task.to_string()),
+            encode_path(&task.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1468,7 +1468,7 @@ impl Client {
         let url = format!(
             "{}/v1/worker/task/{}/output",
             self.baseurl,
-            encode_path(&task.to_string()),
+            encode_path(&task.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1499,7 +1499,7 @@ impl Client {
     pub async fn workers_list<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-        let url = format!("{}/v1/workers", self.baseurl,);
+        let url = format!("{}/v1/workers", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1530,7 +1530,7 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/workers/recycle", self.baseurl,);
+        let url = format!("{}/v1/workers/recycle", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1556,7 +1556,7 @@ impl Client {
         &'a self,
         id: Option<&'a types::GetThingOrThingsId>,
     ) -> Result<ResponseValue<::std::string::String>, Error<()>> {
-        let url = format!("{}/v1/things", self.baseurl,);
+        let url = format!("{}/v1/things", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1591,7 +1591,7 @@ impl Client {
         &'a self,
         accept_language: Option<types::HeaderArgAcceptLanguage>,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/header-arg", self.baseurl,);
+        let url = format!("{}/v1/header-arg", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -904,6 +904,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -842,6 +842,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -861,6 +862,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -905,6 +905,12 @@ impl ClientHooks<()> for &Client {}
 )]
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/hold", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
@@ -936,6 +942,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/control/resume`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/resume", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
@@ -959,6 +971,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/task/{Task}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn task_get<'a>(
         &'a self,
         task: &'a str,
@@ -997,6 +1015,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/tasks`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn tasks_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<::std::vec::Vec<types::Task>>, Error<()>> {
@@ -1030,6 +1054,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/tasks`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn task_submit<'a>(
         &'a self,
         body: &'a types::TaskSubmit,
@@ -1065,6 +1095,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/tasks/{task}/events`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn task_events_get<'a>(
         &'a self,
         task: &'a str,
@@ -1105,6 +1141,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn task_outputs_get<'a>(
         &'a self,
         task: &'a str,
@@ -1143,6 +1185,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn task_output_download<'a>(
         &'a self,
         task: &'a str,
@@ -1175,6 +1223,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/users`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn user_create<'a>(
         &'a self,
         body: &'a types::UserCreate,
@@ -1210,6 +1264,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/whoami`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
         let url = format!("{}/v1/whoami", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
@@ -1241,6 +1301,12 @@ impl Client {
     }
 
     ///Sends a `PUT` request to `/v1/whoami/name`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn whoami_put_name<'a>(
         &'a self,
         body: String,
@@ -1276,6 +1342,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/worker/bootstrap`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn worker_bootstrap<'a>(
         &'a self,
         body: &'a types::WorkerBootstrap,
@@ -1311,6 +1383,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/worker/ping`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn worker_ping<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
@@ -1344,6 +1422,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/append`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn worker_task_append<'a>(
         &'a self,
         task: &'a str,
@@ -1380,6 +1464,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn worker_task_upload_chunk<'a, B: Into<reqwest::Body>>(
         &'a self,
         task: &'a str,
@@ -1424,6 +1514,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn worker_task_complete<'a>(
         &'a self,
         task: &'a str,
@@ -1460,6 +1556,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/worker/task/{task}/output`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn worker_task_add_output<'a>(
         &'a self,
         task: &'a str,
@@ -1496,6 +1598,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/workers`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn workers_list<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
@@ -1529,6 +1637,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/v1/workers/recycle`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/workers/recycle", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
@@ -1552,6 +1666,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/things`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn get_thing_or_things<'a>(
         &'a self,
         id: Option<&'a types::GetThingOrThingsId>,
@@ -1587,6 +1707,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/v1/header-arg`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn header_arg<'a>(
         &'a self,
         accept_language: Option<types::HeaderArgAcceptLanguage>,

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -828,7 +828,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Buildomat
+///Client for `Buildomat`
 ///
 ///Version: 1.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -911,6 +911,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -953,7 +953,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
+            200u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
@@ -1270,7 +1270,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
+            200u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
@@ -1374,7 +1374,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(response)),
+            201u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
@@ -1454,7 +1454,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
+            200u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
@@ -1490,7 +1490,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(response)),
+            201u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
@@ -1546,7 +1546,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
+            200u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
@@ -1611,8 +1611,8 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::empty(response))),
+            200..=299 => Ok(ResponseValue::empty(&response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::empty(&response))),
         }
     }
 }

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -846,6 +846,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -889,6 +889,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -214,6 +214,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -295,7 +295,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/uno", client.baseurl,);
+            let url = format!("{}/uno", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -151,6 +151,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -170,6 +171,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -206,7 +206,12 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/uno`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.uno()
     ///    .gateway(gateway)
     ///    .body(body)
@@ -285,6 +290,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/uno`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -259,6 +259,10 @@ pub mod builder {
     }
 
     impl<'a> Uno<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -135,7 +135,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for CLI gen test
+///Client for `CLI gen test`
 ///
 ///Test case to exercise CLI generation
 ///

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -237,6 +237,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -155,6 +155,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -265,7 +265,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 gateway: Err("gateway was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }

--- a/progenitor-impl/tests/output/src/cli_gen_builder.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder.rs
@@ -220,6 +220,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -204,7 +204,12 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/uno`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.uno()
     ///    .gateway(gateway)
     ///    .body(body)
@@ -283,6 +288,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/uno`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -218,6 +218,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -149,6 +149,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -168,6 +169,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -263,7 +263,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 gateway: Err("gateway was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -235,6 +235,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -212,6 +212,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -293,7 +293,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::UnoBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/uno", client.baseurl,);
+            let url = format!("{}/uno", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -133,7 +133,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for CLI gen test
+///Client for `CLI gen test`
 ///
 ///Test case to exercise CLI generation
 ///

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -153,6 +153,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_builder_tagged.rs
@@ -257,6 +257,10 @@ pub mod builder {
     }
 
     impl<'a> Uno<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -146,7 +146,7 @@ impl Client {
         gateway: &'a str,
         body: &'a types::UnoBody,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
-        let url = format!("{}/uno", self.baseurl,);
+        let url = format!("{}/uno", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -62,7 +62,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for CLI gen test
+///Client for `CLI gen test`
 ///
 ///Test case to exercise CLI generation
 ///

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -82,6 +82,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -78,6 +78,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -97,6 +98,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -140,6 +140,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -147,6 +147,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -141,6 +141,12 @@ impl ClientHooks<()> for &Client {}
 )]
 impl Client {
     ///Sends a `GET` request to `/uno`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn uno<'a>(
         &'a self,
         gateway: &'a str,

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -125,6 +125,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `GET` request to `/uno`
     pub async fn uno<'a>(

--- a/progenitor-impl/tests/output/src/cli_gen_positional.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_positional.rs
@@ -131,6 +131,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `GET` request to `/uno`
     pub async fn uno<'a>(

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1405,6 +1405,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1215,6 +1215,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -1234,6 +1235,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1273,7 +1273,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.enrol()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1288,7 +1293,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.global_jobs()
     ///    .authorization(authorization)
     ///    .send()
@@ -1302,7 +1312,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ping()
     ///    .authorization(authorization)
     ///    .send()
@@ -1317,7 +1332,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.report_finish()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1333,7 +1353,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.report_output()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1349,7 +1374,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.report_start()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1428,6 +1458,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/enrol`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 client,
@@ -1494,6 +1529,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/global/jobs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
                 client,
@@ -1559,6 +1599,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/ping`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
                 client,
@@ -1648,6 +1693,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/report/finish`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
                 client,
@@ -1742,6 +1792,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/report/output`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
                 client,
@@ -1834,6 +1889,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/report/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1199,7 +1199,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Keeper API
+///Client for `Keeper API`
 ///
 ///report execution of cron jobs through a mechanism other than mail
 ///

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1219,6 +1219,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1363,6 +1363,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1357,6 +1357,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1427,6 +1427,10 @@ pub mod builder {
     }
 
     impl<'a> Enrol<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1519,6 +1523,10 @@ pub mod builder {
     }
 
     impl<'a> GlobalJobs<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1589,6 +1597,10 @@ pub mod builder {
     }
 
     impl<'a> Ping<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1660,6 +1672,10 @@ pub mod builder {
     }
 
     impl<'a> ReportFinish<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1759,6 +1775,10 @@ pub mod builder {
     }
 
     impl<'a> ReportOutput<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1858,6 +1878,10 @@ pub mod builder {
     }
 
     impl<'a> ReportStart<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1433,7 +1433,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -1529,7 +1529,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1603,7 +1603,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1678,7 +1678,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -1781,7 +1781,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -1884,7 +1884,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1460,7 +1460,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
+                201u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1438,7 +1438,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::EnrolBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/enrol", client.baseurl,);
+            let url = format!("{}/enrol", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1500,7 +1500,7 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/global/jobs", client.baseurl,);
+            let url = format!("{}/global/jobs", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1565,7 +1565,7 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ping", client.baseurl,);
+            let url = format!("{}/ping", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1658,7 +1658,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ReportFinishBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/finish", client.baseurl,);
+            let url = format!("{}/report/finish", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1752,7 +1752,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ReportOutputBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/output", client.baseurl,);
+            let url = format!("{}/report/output", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1844,7 +1844,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ReportStartBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/start", client.baseurl,);
+            let url = format!("{}/report/start", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1413,7 +1413,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -1509,7 +1509,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1583,7 +1583,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1658,7 +1658,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -1761,7 +1761,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -1864,7 +1864,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1418,7 +1418,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::EnrolBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/enrol", client.baseurl,);
+            let url = format!("{}/enrol", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1480,7 +1480,7 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/global/jobs", client.baseurl,);
+            let url = format!("{}/global/jobs", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1545,7 +1545,7 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ping", client.baseurl,);
+            let url = format!("{}/ping", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1638,7 +1638,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ReportFinishBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/finish", client.baseurl,);
+            let url = format!("{}/report/finish", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1732,7 +1732,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ReportOutputBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/output", client.baseurl,);
+            let url = format!("{}/report/output", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1824,7 +1824,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ReportStartBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/start", client.baseurl,);
+            let url = format!("{}/report/start", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1253,7 +1253,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.enrol()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1268,7 +1273,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.global_jobs()
     ///    .authorization(authorization)
     ///    .send()
@@ -1282,7 +1292,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ping()
     ///    .authorization(authorization)
     ///    .send()
@@ -1297,7 +1312,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.report_finish()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1313,7 +1333,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.report_output()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1329,7 +1354,12 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.report_start()
     ///    .authorization(authorization)
     ///    .body(body)
@@ -1408,6 +1438,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/enrol`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 client,
@@ -1474,6 +1509,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/global/jobs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
                 client,
@@ -1539,6 +1579,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/ping`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
                 client,
@@ -1628,6 +1673,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/report/finish`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
                 client,
@@ -1722,6 +1772,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/report/output`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
                 client,
@@ -1814,6 +1869,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/report/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1179,7 +1179,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Keeper API
+///Client for `Keeper API`
 ///
 ///report execution of cron jobs through a mechanism other than mail
 ///

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1440,7 +1440,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
+                201u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1385,6 +1385,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1343,6 +1343,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1199,6 +1199,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1407,6 +1407,10 @@ pub mod builder {
     }
 
     impl<'a> Enrol<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1499,6 +1503,10 @@ pub mod builder {
     }
 
     impl<'a> GlobalJobs<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1569,6 +1577,10 @@ pub mod builder {
     }
 
     impl<'a> Ping<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1640,6 +1652,10 @@ pub mod builder {
     }
 
     impl<'a> ReportFinish<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1739,6 +1755,10 @@ pub mod builder {
     }
 
     impl<'a> ReportOutput<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -1838,6 +1858,10 @@ pub mod builder {
     }
 
     impl<'a> ReportStart<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1337,6 +1337,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1195,6 +1195,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -1214,6 +1215,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -400,6 +400,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -419,6 +420,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -469,6 +469,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -453,6 +453,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `POST` request to `/enrol`
     ///

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -384,7 +384,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Keeper API
+///Client for `Keeper API`
 ///
 ///report execution of cron jobs through a mechanism other than mail
 ///

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -494,7 +494,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(response)),
+            201u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -404,6 +404,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -472,7 +472,7 @@ impl Client {
         authorization: &'a str,
         body: &'a types::EnrolBody,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/enrol", self.baseurl,);
+        let url = format!("{}/enrol", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -507,7 +507,7 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
-        let url = format!("{}/global/jobs", self.baseurl,);
+        let url = format!("{}/global/jobs", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -545,7 +545,7 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-        let url = format!("{}/ping", self.baseurl,);
+        let url = format!("{}/ping", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -585,7 +585,7 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportFinishBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/finish", self.baseurl,);
+        let url = format!("{}/report/finish", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -626,7 +626,7 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportOutputBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/output", self.baseurl,);
+        let url = format!("{}/report/output", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -667,7 +667,7 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportStartBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/start", self.baseurl,);
+        let url = format!("{}/report/start", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -462,6 +462,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -447,6 +447,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `POST` request to `/enrol`
     ///

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -467,6 +467,11 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn enrol<'a>(
         &'a self,
         authorization: &'a str,
@@ -503,6 +508,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn global_jobs<'a>(
         &'a self,
         authorization: &'a str,
@@ -541,6 +551,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ping<'a>(
         &'a self,
         authorization: &'a str,
@@ -580,6 +595,11 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn report_finish<'a>(
         &'a self,
         authorization: &'a str,
@@ -621,6 +641,11 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn report_output<'a>(
         &'a self,
         authorization: &'a str,
@@ -662,6 +687,11 @@ impl Client {
     ///Arguments:
     /// - `authorization`: Authorization header (bearer token)
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn report_start<'a>(
         &'a self,
         authorization: &'a str,

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -29864,6 +29864,10 @@ pub mod builder {
     }
 
     impl<'a> DiskViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -29940,6 +29944,10 @@ pub mod builder {
     }
 
     impl<'a> ImageViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30016,6 +30024,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30092,6 +30104,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30170,6 +30186,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30246,6 +30266,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30322,6 +30346,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30398,6 +30426,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30474,6 +30506,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30550,6 +30586,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30626,6 +30666,10 @@ pub mod builder {
     }
 
     impl<'a> VpcViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30702,6 +30746,10 @@ pub mod builder {
     }
 
     impl<'a> DeviceAuthRequest<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30779,6 +30827,10 @@ pub mod builder {
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30866,6 +30918,10 @@ pub mod builder {
     }
 
     impl<'a> DeviceAccessToken<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30949,6 +31005,10 @@ pub mod builder {
     }
 
     impl<'a> GroupList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31105,6 +31165,10 @@ pub mod builder {
     }
 
     impl<'a> LoginSpoof<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31191,6 +31255,10 @@ pub mod builder {
     }
 
     impl<'a> LoginLocal<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31300,6 +31368,10 @@ pub mod builder {
     }
 
     impl<'a> LoginSamlBegin<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31387,6 +31459,10 @@ pub mod builder {
     }
 
     impl<'a> LoginSaml<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31493,6 +31569,10 @@ pub mod builder {
     }
 
     impl<'a> Logout<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -31553,6 +31633,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31709,6 +31793,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31796,6 +31884,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31876,6 +31968,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31983,6 +32079,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32062,6 +32162,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32144,6 +32248,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32258,6 +32366,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32434,6 +32546,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32541,6 +32657,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32637,6 +32757,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32758,6 +32882,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32856,6 +32984,10 @@ pub mod builder {
     }
 
     impl<'a> DiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33047,6 +33179,10 @@ pub mod builder {
     }
 
     impl<'a> DiskCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33169,6 +33305,10 @@ pub mod builder {
     }
 
     impl<'a> DiskView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33280,6 +33420,10 @@ pub mod builder {
     }
 
     impl<'a> DiskDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33396,6 +33540,10 @@ pub mod builder {
     }
 
     impl<'a> DiskMetricsList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33640,6 +33788,10 @@ pub mod builder {
     }
 
     impl<'a> ImageList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33831,6 +33983,10 @@ pub mod builder {
     }
 
     impl<'a> ImageCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33953,6 +34109,10 @@ pub mod builder {
     }
 
     impl<'a> ImageView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34064,6 +34224,10 @@ pub mod builder {
     }
 
     impl<'a> ImageDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34177,6 +34341,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34370,6 +34538,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34493,6 +34665,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34604,6 +34780,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34718,6 +34898,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34926,6 +35110,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskAttach<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35064,6 +35252,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskDetach<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35201,6 +35393,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceExternalIpList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35315,6 +35511,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceMigrate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35455,6 +35655,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35664,6 +35868,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35808,6 +36016,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35937,6 +36149,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36095,6 +36311,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36220,6 +36440,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceReboot<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36334,6 +36558,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsole<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36498,6 +36726,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleStream<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36609,6 +36841,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleStreamV2<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36726,6 +36962,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStart<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36837,6 +37077,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStop<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36947,6 +37191,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37045,6 +37293,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37173,6 +37425,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37366,6 +37622,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37489,6 +37749,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37600,6 +37864,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37713,6 +37981,10 @@ pub mod builder {
     }
 
     impl<'a> VpcList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37904,6 +38176,10 @@ pub mod builder {
     }
 
     impl<'a> VpcCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38026,6 +38302,10 @@ pub mod builder {
     }
 
     impl<'a> VpcView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38138,6 +38418,10 @@ pub mod builder {
     }
 
     impl<'a> VpcUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38275,6 +38559,10 @@ pub mod builder {
     }
 
     impl<'a> VpcDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38386,6 +38674,10 @@ pub mod builder {
     }
 
     impl<'a> VpcFirewallRulesView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38500,6 +38792,10 @@ pub mod builder {
     }
 
     impl<'a> VpcFirewallRulesUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38649,6 +38945,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38857,6 +39157,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38995,6 +39299,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39122,6 +39430,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39274,6 +39586,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39403,6 +39719,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39626,6 +39946,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39785,6 +40109,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39927,6 +40255,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40100,6 +40432,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40242,6 +40578,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40450,6 +40790,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40588,6 +40932,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40715,6 +41063,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40867,6 +41219,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40996,6 +41352,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41215,6 +41575,10 @@ pub mod builder {
     }
 
     impl<'a> PolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -41275,6 +41639,10 @@ pub mod builder {
     }
 
     impl<'a> PolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41363,6 +41731,10 @@ pub mod builder {
     }
 
     impl<'a> RoleList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41503,6 +41875,10 @@ pub mod builder {
     }
 
     impl<'a> RoleView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41578,6 +41954,10 @@ pub mod builder {
     }
 
     impl<'a> SessionMe<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -41638,6 +42018,10 @@ pub mod builder {
     }
 
     impl<'a> SessionMeGroups<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41796,6 +42180,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41952,6 +42340,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42037,6 +42429,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42116,6 +42512,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42195,6 +42595,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42271,6 +42675,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42347,6 +42755,10 @@ pub mod builder {
     }
 
     impl<'a> SiloViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42425,6 +42837,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42581,6 +42997,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42668,6 +43088,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42747,6 +43171,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42828,6 +43256,10 @@ pub mod builder {
     }
 
     impl<'a> PhysicalDiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42986,6 +43418,10 @@ pub mod builder {
     }
 
     impl<'a> RackList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43142,6 +43578,10 @@ pub mod builder {
     }
 
     impl<'a> RackView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43220,6 +43660,10 @@ pub mod builder {
     }
 
     impl<'a> SledList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43376,6 +43820,10 @@ pub mod builder {
     }
 
     impl<'a> SledView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43455,6 +43903,10 @@ pub mod builder {
     }
 
     impl<'a> SledPhysicalDiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43630,6 +44082,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43786,6 +44242,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43873,6 +44333,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43949,6 +44413,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44027,6 +44495,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44183,6 +44655,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44268,6 +44744,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44345,6 +44825,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44450,6 +44934,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44528,6 +45016,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolRangeList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44686,6 +45178,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolRangeAdd<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44780,6 +45276,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolRangeRemove<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44873,6 +45373,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -44932,6 +45436,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceRangeList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45072,6 +45580,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45145,6 +45657,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45223,6 +45739,10 @@ pub mod builder {
     }
 
     impl<'a> SystemMetric<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45383,6 +45903,10 @@ pub mod builder {
     }
 
     impl<'a> SystemPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -45443,6 +45967,10 @@ pub mod builder {
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45532,6 +46060,10 @@ pub mod builder {
     }
 
     impl<'a> SagaList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45688,6 +46220,10 @@ pub mod builder {
     }
 
     impl<'a> SagaView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45766,6 +46302,10 @@ pub mod builder {
     }
 
     impl<'a> SiloList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45922,6 +46462,10 @@ pub mod builder {
     }
 
     impl<'a> SiloCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46007,6 +46551,10 @@ pub mod builder {
     }
 
     impl<'a> SiloView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46083,6 +46631,10 @@ pub mod builder {
     }
 
     impl<'a> SiloDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46162,6 +46714,10 @@ pub mod builder {
     }
 
     impl<'a> SiloIdentityProviderList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46339,6 +46895,10 @@ pub mod builder {
     }
 
     impl<'a> LocalIdpUserCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46446,6 +47006,10 @@ pub mod builder {
     }
 
     impl<'a> LocalIdpUserDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46542,6 +47106,10 @@ pub mod builder {
     }
 
     impl<'a> LocalIdpUserSetPassword<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46652,6 +47220,10 @@ pub mod builder {
     }
 
     impl<'a> SamlIdentityProviderCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46768,6 +47340,10 @@ pub mod builder {
     }
 
     impl<'a> SamlIdentityProviderView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46864,6 +47440,10 @@ pub mod builder {
     }
 
     impl<'a> SiloPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46943,6 +47523,10 @@ pub mod builder {
     }
 
     impl<'a> SiloPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47053,6 +47637,10 @@ pub mod builder {
     }
 
     impl<'a> SiloUsersList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47227,6 +47815,10 @@ pub mod builder {
     }
 
     impl<'a> SiloUserView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47323,6 +47915,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUserList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47479,6 +48075,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUserView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47556,6 +48156,10 @@ pub mod builder {
     }
 
     impl<'a> TimeseriesSchemaGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47699,6 +48303,10 @@ pub mod builder {
     }
 
     impl<'a> UserList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47859,6 +48467,10 @@ pub mod builder {
     }
 
     impl<'a> DiskListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48052,6 +48664,10 @@ pub mod builder {
     }
 
     impl<'a> DiskCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48174,6 +48790,10 @@ pub mod builder {
     }
 
     impl<'a> DiskViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48288,6 +48908,10 @@ pub mod builder {
     }
 
     impl<'a> DiskDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48404,6 +49028,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48597,6 +49225,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48719,6 +49351,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48833,6 +49469,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48950,6 +49590,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49161,6 +49805,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskAttachV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49302,6 +49950,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskDetachV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49443,6 +50095,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceMigrateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49583,6 +50239,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceRebootV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49700,6 +50360,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49867,6 +50531,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49988,6 +50656,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStartV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50102,6 +50774,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStopV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50216,6 +50892,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50372,6 +51052,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50459,6 +51143,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50539,6 +51227,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50646,6 +51338,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50725,6 +51421,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50807,6 +51507,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50921,6 +51625,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51097,6 +51805,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51203,6 +51915,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51302,6 +52018,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51426,6 +52146,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51524,6 +52248,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51625,6 +52353,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51754,6 +52486,10 @@ pub mod builder {
     }
 
     impl<'a> SystemComponentVersionList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51914,6 +52650,10 @@ pub mod builder {
     }
 
     impl<'a> UpdateDeploymentsList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52071,6 +52811,10 @@ pub mod builder {
     }
 
     impl<'a> UpdateDeploymentView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52148,6 +52892,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -52206,6 +52954,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateStart<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52294,6 +53046,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateStop<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -52354,6 +53110,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52510,6 +53270,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52586,6 +53350,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52664,6 +53432,10 @@ pub mod builder {
     }
 
     impl<'a> SystemVersion<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -29843,6 +29843,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -25155,6 +25155,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -25135,7 +25135,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Oxide Region API
+///Client for `Oxide Region API`
 ///
 ///API for interacting with the Oxide control plane
 ///

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -25210,7 +25210,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/disks/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25224,7 +25229,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/images/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25238,7 +25248,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/instances/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25252,7 +25267,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/network-interfaces/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25270,7 +25290,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/organizations/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25286,7 +25311,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/projects/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25300,7 +25330,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/snapshots/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25314,7 +25349,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25328,7 +25368,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25342,7 +25387,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25356,7 +25406,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/by-id/vpcs/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25374,7 +25429,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/device/auth`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.device_auth_request()
     ///    .body(body)
     ///    .send()
@@ -25393,7 +25453,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/device/confirm`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.device_auth_confirm()
     ///    .body(body)
     ///    .send()
@@ -25410,7 +25475,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/device/token`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.device_access_token()
     ///    .body(body)
     ///    .send()
@@ -25429,7 +25499,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.group_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -25443,7 +25518,12 @@ impl Client {
 
     ///Sends a `POST` request to `/login`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_spoof()
     ///    .body(body)
     ///    .send()
@@ -25457,7 +25537,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/login/{silo_name}/local`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_local()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -25475,7 +25560,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_saml_begin()
     ///    .silo_name(silo_name)
     ///    .provider_name(provider_name)
@@ -25490,7 +25580,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_saml()
     ///    .silo_name(silo_name)
     ///    .provider_name(provider_name)
@@ -25504,7 +25599,12 @@ impl Client {
 
     ///Sends a `POST` request to `/logout`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.logout()
     ///    .send()
     ///    .await;
@@ -25524,7 +25624,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -25542,7 +25647,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/organizations`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_create()
     ///    .body(body)
     ///    .send()
@@ -25560,7 +25670,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_view()
     ///    .organization_name(organization_name)
     ///    .send()
@@ -25579,7 +25694,12 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_update()
     ///    .organization_name(organization_name)
     ///    .body(body)
@@ -25598,7 +25718,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_delete()
     ///    .organization_name(organization_name)
     ///    .send()
@@ -25616,7 +25741,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_view()
     ///    .organization_name(organization_name)
     ///    .send()
@@ -25635,7 +25765,12 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_update()
     ///    .organization_name(organization_name)
     ///    .body(body)
@@ -25658,7 +25793,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_list()
     ///    .organization_name(organization_name)
     ///    .limit(limit)
@@ -25680,7 +25820,12 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_create()
     ///    .organization_name(organization_name)
     ///    .body(body)
@@ -25701,7 +25846,12 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25723,7 +25873,12 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25745,7 +25900,12 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25770,7 +25930,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25793,7 +25958,12 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25813,7 +25983,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25831,7 +26006,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25859,7 +26039,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_metrics_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25891,7 +26076,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25916,7 +26106,12 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25936,7 +26131,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25958,7 +26158,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25982,7 +26187,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26007,7 +26217,12 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26027,7 +26242,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26045,7 +26265,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26073,7 +26298,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26096,7 +26326,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/attach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_attach()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26117,7 +26352,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/detach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_detach()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26136,7 +26376,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/external-ips`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_external_ip_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26156,7 +26401,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/migrate`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_migrate()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26183,7 +26433,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26204,7 +26459,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26223,7 +26483,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26242,7 +26507,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26267,7 +26537,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26288,7 +26563,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/reboot`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_reboot()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26323,7 +26603,12 @@ impl Client {
     ///   read, counting *backward* from the most recently buffered data
     ///   retrieved from the instance. (See note on `from_start` about mutual
     ///   exclusivity)
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26346,7 +26631,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_stream()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26366,7 +26656,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream_v2`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_stream_v2()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26386,7 +26681,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/start`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_start()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26406,7 +26706,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/stop`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_stop()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26428,7 +26733,12 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26448,7 +26758,12 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26472,7 +26787,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26497,7 +26817,12 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26515,7 +26840,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26533,7 +26863,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26557,7 +26892,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26580,7 +26920,12 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26598,7 +26943,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26616,7 +26966,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26635,7 +26990,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26653,7 +27013,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_firewall_rules_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26671,7 +27036,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_firewall_rules_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26698,7 +27068,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26719,7 +27094,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26738,7 +27118,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26757,7 +27142,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26777,7 +27167,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26807,7 +27202,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26829,7 +27229,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26849,7 +27254,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26869,7 +27279,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26890,7 +27305,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26918,7 +27338,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26939,7 +27364,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26958,7 +27388,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26977,7 +27412,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26997,7 +27437,12 @@ impl Client {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -27025,7 +27470,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_list_network_interfaces()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -27047,7 +27497,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.policy_view()
     ///    .send()
     ///    .await;
@@ -27060,7 +27515,12 @@ impl Client {
     ///
     ///Sends a `PUT` request to `/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.policy_update()
     ///    .body(body)
     ///    .send()
@@ -27078,7 +27538,12 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.role_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27095,7 +27560,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `role_name`: The built-in role's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.role_view()
     ///    .role_name(role_name)
     ///    .send()
@@ -27109,7 +27579,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/session/me`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_me()
     ///    .send()
     ///    .await;
@@ -27127,7 +27602,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_me_groups()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27150,7 +27630,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27168,7 +27653,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/session/me/sshkeys`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_create()
     ///    .body(body)
     ///    .send()
@@ -27185,7 +27675,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_view()
     ///    .ssh_key_name(ssh_key_name)
     ///    .send()
@@ -27202,7 +27697,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_delete()
     ///    .ssh_key_name(ssh_key_name)
     ///    .send()
@@ -27216,7 +27716,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/by-id/images/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -27230,7 +27735,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -27244,7 +27754,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/by-id/silos/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -27267,7 +27782,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27286,7 +27806,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/certificates`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_create()
     ///    .body(body)
     ///    .send()
@@ -27302,7 +27827,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/certificates/{certificate}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_view()
     ///    .certificate(certificate)
     ///    .send()
@@ -27318,7 +27848,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/system/certificates/{certificate}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_delete()
     ///    .certificate(certificate)
     ///    .send()
@@ -27337,7 +27872,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.physical_disk_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27358,7 +27898,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.rack_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27376,7 +27921,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `rack_id`: The rack's unique ID.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.rack_view()
     ///    .rack_id(rack_id)
     ///    .send()
@@ -27395,7 +27945,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.sled_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27413,7 +27968,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `sled_id`: The sled's unique ID.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.sled_view()
     ///    .sled_id(sled_id)
     ///    .send()
@@ -27433,7 +27993,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.sled_physical_disk_list()
     ///    .sled_id(sled_id)
     ///    .limit(limit)
@@ -27459,7 +28024,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27478,7 +28048,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/images`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_create()
     ///    .body(body)
     ///    .send()
@@ -27494,7 +28069,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/images/{image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_view()
     ///    .image_name(image_name)
     ///    .send()
@@ -27512,7 +28092,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/system/images/{image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_delete()
     ///    .image_name(image_name)
     ///    .send()
@@ -27531,7 +28116,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27547,7 +28137,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/ip-pools`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_create()
     ///    .body(body)
     ///    .send()
@@ -27561,7 +28156,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_view()
     ///    .pool_name(pool_name)
     ///    .send()
@@ -27575,7 +28175,12 @@ impl Client {
     ///
     ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_update()
     ///    .pool_name(pool_name)
     ///    .body(body)
@@ -27590,7 +28195,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_delete()
     ///    .pool_name(pool_name)
     ///    .send()
@@ -27611,7 +28221,12 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_range_list()
     ///    .pool_name(pool_name)
     ///    .limit(limit)
@@ -27627,7 +28242,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_range_add()
     ///    .pool_name(pool_name)
     ///    .body(body)
@@ -27642,7 +28262,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/remove`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_range_remove()
     ///    .pool_name(pool_name)
     ///    .body(body)
@@ -27657,7 +28282,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/ip-pools-service`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_view()
     ///    .send()
     ///    .await;
@@ -27676,7 +28306,12 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_range_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27691,7 +28326,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_range_add()
     ///    .body(body)
     ///    .send()
@@ -27705,7 +28345,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_range_remove()
     ///    .body(body)
     ///    .send()
@@ -27727,7 +28372,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_metric()
     ///    .metric_name(metric_name)
     ///    .end_time(end_time)
@@ -27746,7 +28396,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_policy_view()
     ///    .send()
     ///    .await;
@@ -27759,7 +28414,12 @@ impl Client {
     ///
     ///Sends a `PUT` request to `/system/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_policy_update()
     ///    .body(body)
     ///    .send()
@@ -27778,7 +28438,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saga_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27794,7 +28459,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/system/sagas/{saga_id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saga_view()
     ///    .saga_id(saga_id)
     ///    .send()
@@ -27815,7 +28485,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27831,7 +28506,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/system/silos`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_create()
     ///    .body(body)
     ///    .send()
@@ -27849,7 +28529,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_view()
     ///    .silo_name(silo_name)
     ///    .send()
@@ -27867,7 +28552,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_delete()
     ///    .silo_name(silo_name)
     ///    .send()
@@ -27887,7 +28577,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_identity_provider_list()
     ///    .silo_name(silo_name)
     ///    .limit(limit)
@@ -27912,7 +28607,12 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.local_idp_user_create()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -27931,7 +28631,12 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.local_idp_user_delete()
     ///    .silo_name(silo_name)
     ///    .user_id(user_id)
@@ -27955,7 +28660,12 @@ impl Client {
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.local_idp_user_set_password()
     ///    .silo_name(silo_name)
     ///    .user_id(user_id)
@@ -27975,7 +28685,12 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saml_identity_provider_create()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -27994,7 +28709,12 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `provider_name`: The SAML identity provider's name
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saml_identity_provider_view()
     ///    .silo_name(silo_name)
     ///    .provider_name(provider_name)
@@ -28011,7 +28731,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_policy_view()
     ///    .silo_name(silo_name)
     ///    .send()
@@ -28028,7 +28753,12 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_policy_update()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -28049,7 +28779,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_users_list()
     ///    .silo_name(silo_name)
     ///    .limit(limit)
@@ -28069,7 +28804,12 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_user_view()
     ///    .silo_name(silo_name)
     ///    .user_id(user_id)
@@ -28089,7 +28829,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_user_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -28107,7 +28852,12 @@ impl Client {
     ///
     ///Arguments:
     /// - `user_name`: The built-in user's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_user_view()
     ///    .user_name(user_name)
     ///    .send()
@@ -28125,7 +28875,12 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.timeseries_schema_get()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -28145,7 +28900,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.user_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -28168,7 +28928,12 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_list_v1()
     ///    .limit(limit)
     ///    .organization(organization)
@@ -28186,7 +28951,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/disks`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_create_v1()
     ///    .organization(organization)
     ///    .project(project)
@@ -28202,7 +28972,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/disks/{disk}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_view_v1()
     ///    .disk(disk)
     ///    .organization(organization)
@@ -28218,7 +28993,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/v1/disks/{disk}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_delete_v1()
     ///    .disk(disk)
     ///    .organization(organization)
@@ -28241,7 +29021,12 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_list_v1()
     ///    .limit(limit)
     ///    .organization(organization)
@@ -28259,7 +29044,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/instances`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_create_v1()
     ///    .organization(organization)
     ///    .project(project)
@@ -28275,7 +29065,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/instances/{instance}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_view_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28291,7 +29086,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/v1/instances/{instance}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_delete_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28315,7 +29115,12 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_list_v1()
     ///    .instance(instance)
     ///    .limit(limit)
@@ -28334,7 +29139,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_attach_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28351,7 +29161,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_detach_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28368,7 +29183,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_migrate_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28385,7 +29205,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_reboot_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28416,7 +29241,12 @@ impl Client {
     ///   exclusivity)
     /// - `organization`
     /// - `project`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_v1()
     ///    .instance(instance)
     ///    .from_start(from_start)
@@ -28436,7 +29266,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/v1/instances/{instance}/serial-console/stream`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_stream_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28452,7 +29287,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/start`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_start_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28468,7 +29308,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/stop`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_stop_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -28489,7 +29334,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_list_v1()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -28505,7 +29355,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/organizations`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_create_v1()
     ///    .body(body)
     ///    .send()
@@ -28519,7 +29374,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_view_v1()
     ///    .organization(organization)
     ///    .send()
@@ -28533,7 +29393,12 @@ impl Client {
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_update_v1()
     ///    .organization(organization)
     ///    .body(body)
@@ -28548,7 +29413,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/v1/organizations/{organization}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_delete_v1()
     ///    .organization(organization)
     ///    .send()
@@ -28562,7 +29432,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_view_v1()
     ///    .organization(organization)
     ///    .send()
@@ -28576,7 +29451,12 @@ impl Client {
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_update_v1()
     ///    .organization(organization)
     ///    .body(body)
@@ -28597,7 +29477,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_list_v1()
     ///    .limit(limit)
     ///    .organization(organization)
@@ -28614,7 +29499,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/projects`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_create_v1()
     ///    .organization(organization)
     ///    .body(body)
@@ -28629,7 +29519,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/projects/{project}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_view_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -28644,7 +29539,12 @@ impl Client {
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_update_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -28660,7 +29560,12 @@ impl Client {
     ///
     ///Sends a `DELETE` request to `/v1/projects/{project}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_delete_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -28675,7 +29580,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/projects/{project}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_view_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -28690,7 +29600,12 @@ impl Client {
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_update_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -28711,7 +29626,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_component_version_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -28732,7 +29652,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.update_deployments_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -28748,7 +29673,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/system/update/deployments/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.update_deployment_view()
     ///    .id(id)
     ///    .send()
@@ -28762,7 +29692,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/system/update/refresh`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_refresh()
     ///    .send()
     ///    .await;
@@ -28775,7 +29710,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/system/update/start`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_start()
     ///    .body(body)
     ///    .send()
@@ -28791,7 +29731,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/v1/system/update/stop`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_stop()
     ///    .send()
     ///    .await;
@@ -28809,7 +29754,12 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -28825,7 +29775,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/system/update/updates/{version}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_view()
     ///    .version(version)
     ///    .send()
@@ -28840,7 +29795,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/v1/system/update/updates/{version}/components`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_components_list()
     ///    .version(version)
     ///    .send()
@@ -28854,7 +29814,12 @@ impl Client {
     ///
     ///Sends a `GET` request to `/v1/system/update/version`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_version()
     ///    .send()
     ///    .await;
@@ -28909,6 +29874,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -28980,6 +29950,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/images/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29051,6 +30026,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29122,6 +30102,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/network-interfaces/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -29195,6 +30180,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29266,6 +30256,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29337,6 +30332,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29408,6 +30408,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29479,6 +30484,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29550,6 +30560,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29621,6 +30636,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29704,6 +30724,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/device/auth`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body
@@ -29776,6 +30801,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/device/confirm`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -29860,6 +30890,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/device/token`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body
@@ -29947,6 +30982,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/groups`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
@@ -30085,6 +31125,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/login`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -30182,6 +31227,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/login/{silo_name}/local`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
                 client,
@@ -30271,6 +31321,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
                 client,
@@ -30364,6 +31419,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
                 client,
@@ -30430,6 +31490,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/logout`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl);
@@ -30521,6 +31586,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
@@ -30661,6 +31731,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -30731,6 +31806,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/organizations/{organization_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -30829,6 +31909,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/organizations/{organization_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -30908,6 +31993,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -30982,6 +32072,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/organizations/{organization_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -31084,6 +32179,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/organizations/{organization_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -31203,6 +32303,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
@@ -31361,6 +32466,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -31453,6 +32563,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -31565,6 +32680,11 @@ pub mod builder {
 
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -31660,6 +32780,11 @@ pub mod builder {
 
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -31787,6 +32912,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -31960,6 +33090,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -32068,6 +33203,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks/
         /// {disk_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -32174,6 +33314,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks/
         /// {disk_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -32344,6 +33489,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks/
         /// {disk_name}/metrics/{metric_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
@@ -32546,6 +33696,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
@@ -32719,6 +33874,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
                 client,
@@ -32827,6 +33987,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images/
         /// {image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
                 client,
@@ -32933,6 +34098,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images/
         /// {image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -33064,6 +34234,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
@@ -33239,6 +34414,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -33347,6 +34527,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -33453,6 +34638,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -33596,6 +34786,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -33786,6 +34981,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/disks/attach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -33919,6 +35119,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/disks/detach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -34030,6 +35235,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/external-ips`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
@@ -34160,6 +35370,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/migrate`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -34308,6 +35523,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
@@ -34503,6 +35723,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -34628,6 +35853,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces/{interface_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -34777,6 +36007,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces/{interface_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -34905,6 +36140,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces/{interface_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -35014,6 +36254,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/reboot`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -35159,6 +36404,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/serial-console`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
@@ -35282,6 +36532,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/serial-console/stream`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<()>> {
             let Self {
                 client,
@@ -35388,6 +36643,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/serial-console/stream_v2`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self {
                 client,
@@ -35500,6 +36760,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -35606,6 +36871,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/stop`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -35699,6 +36969,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -35815,6 +37090,11 @@ pub mod builder {
 
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -35950,6 +37230,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
@@ -36125,6 +37410,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
                 client,
@@ -36233,6 +37523,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots/{snapshot_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
                 client,
@@ -36339,6 +37634,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots/{snapshot_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -36469,6 +37769,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
@@ -36642,6 +37947,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
                 client,
@@ -36750,6 +38060,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
                 client,
@@ -36878,6 +38193,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
                 client,
@@ -36989,6 +38309,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -37095,6 +38420,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/firewall/rules`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
@@ -37230,6 +38560,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/firewall/rules`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
@@ -37382,6 +38717,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
@@ -37572,6 +38912,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
                 client,
@@ -37695,6 +39040,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
                 client,
@@ -37838,6 +39188,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
                 client,
@@ -37964,6 +39319,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -38122,6 +39482,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
@@ -38331,6 +39696,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
                 client,
@@ -38471,6 +39841,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
                 client,
@@ -38633,6 +40008,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
                 client,
@@ -38776,6 +40156,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -38925,6 +40310,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
@@ -39115,6 +40505,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
                 client,
@@ -39238,6 +40633,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
                 client,
@@ -39381,6 +40781,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
                 client,
@@ -39507,6 +40912,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -39665,6 +41075,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}/network-interfaces`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
@@ -39797,6 +41212,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -39875,6 +41295,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -39959,6 +41384,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/roles`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
@@ -40083,6 +41513,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/roles/{role_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
@@ -40140,6 +41575,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl);
@@ -40231,6 +41671,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me/groups`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
@@ -40384,6 +41829,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me/sshkeys`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
@@ -40522,6 +41972,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/session/me/sshkeys`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -40592,6 +42047,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
                 client,
@@ -40666,6 +42126,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -40740,6 +42205,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -40811,6 +42281,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -40882,6 +42357,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -40978,6 +42458,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/certificates`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
@@ -41118,6 +42603,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/certificates`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -41188,6 +42678,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/certificates/{certificate}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
                 client,
@@ -41262,6 +42757,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -41361,6 +42861,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
@@ -41514,6 +43019,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/racks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
@@ -41642,6 +43152,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
@@ -41738,6 +43253,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/sleds`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
@@ -41866,6 +43386,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
@@ -41974,6 +43499,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
@@ -42133,6 +43663,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
@@ -42273,6 +43808,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -42343,6 +43883,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/images/{image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
@@ -42414,6 +43959,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/images/{image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
@@ -42510,6 +44060,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
@@ -42648,6 +44203,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -42718,6 +44278,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
@@ -42811,6 +44376,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
                 client,
@@ -42890,6 +44460,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
@@ -42985,6 +44560,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}/ranges`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
@@ -43127,6 +44707,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
                 client,
@@ -43217,6 +44802,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/system/ip-pools/{pool_name}/ranges/remove`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -43280,6 +44870,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl);
@@ -43358,6 +44953,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service/ranges`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
@@ -43482,6 +45082,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -43550,6 +45155,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -43682,6 +45292,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/metrics/{metric_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
@@ -43765,6 +45380,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
@@ -43843,6 +45463,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/system/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
@@ -43940,6 +45565,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/sagas`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
@@ -44068,6 +45698,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
@@ -44164,6 +45799,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
@@ -44302,6 +45942,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/silos`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -44372,6 +46017,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
@@ -44443,6 +46093,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
@@ -44552,6 +46207,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/system/silos/{silo_name}/identity-providers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
@@ -44711,6 +46371,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/system/silos/{silo_name}/identity-providers/local/users`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
                 client,
@@ -44803,6 +46468,11 @@ pub mod builder {
 
         ///Sends a `DELETE` request to
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -44906,6 +46576,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}/
         /// set-password`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -45014,6 +46689,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/system/silos/{silo_name}/identity-providers/saml`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
@@ -45110,6 +46790,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/system/silos/{silo_name}/identity-providers/saml/{provider_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
@@ -45189,6 +46874,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos/{silo_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -45284,6 +46974,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/system/silos/{silo_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -45402,6 +47097,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos/{silo_name}/users/all`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
@@ -45549,6 +47249,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/system/silos/{silo_name}/users/id/{user_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
                 client,
@@ -45651,6 +47356,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/user`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
@@ -45779,6 +47489,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/user/{user_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
@@ -45862,6 +47577,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/timeseries/schema`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
@@ -46012,6 +47732,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/users`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
@@ -46191,6 +47916,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -46365,6 +48095,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -46473,6 +48208,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/disks/{disk}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -46582,6 +48322,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -46716,6 +48461,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
@@ -46890,6 +48640,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -46998,6 +48753,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances/{instance}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -47107,6 +48867,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -47253,6 +49018,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances/{instance}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -47446,6 +49216,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -47582,6 +49357,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -47718,6 +49498,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -47832,6 +49617,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -47980,6 +49770,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances/{instance}/serial-console`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
@@ -48107,6 +49902,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/v1/instances/{instance}/serial-console/stream`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self {
                 client,
@@ -48222,6 +50022,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -48331,6 +50136,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -48439,6 +50249,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
@@ -48579,6 +50394,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -48649,6 +50469,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/organizations/{organization}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -48747,6 +50572,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -48826,6 +50656,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -48900,6 +50735,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/organizations/{organization}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -49002,6 +50842,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/organizations/{organization}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -49121,6 +50966,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
@@ -49278,6 +51128,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -49370,6 +51225,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/projects/{project}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -49485,6 +51345,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/projects/{project}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -49583,6 +51448,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/projects/{project}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -49676,6 +51546,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/projects/{project}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -49795,6 +51670,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/projects/{project}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -49907,6 +51787,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/components`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
@@ -50062,6 +51947,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/deployments`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
@@ -50191,6 +52081,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/deployments/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
@@ -50250,6 +52145,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl);
@@ -50328,6 +52228,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/system/update/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
@@ -50386,6 +52291,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl);
@@ -50477,6 +52387,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/updates`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
@@ -50605,6 +52520,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
             let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
@@ -50677,6 +52597,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/v1/system/update/updates/{version}/components`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
@@ -50736,6 +52661,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -28860,6 +28860,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -29870,7 +29870,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -29950,7 +29950,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30030,7 +30030,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30110,7 +30110,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30192,7 +30192,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30272,7 +30272,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30352,7 +30352,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30432,7 +30432,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30512,7 +30512,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30592,7 +30592,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30672,7 +30672,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30752,7 +30752,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -30833,7 +30833,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -30924,7 +30924,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -31011,7 +31011,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31171,7 +31171,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -31261,7 +31261,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -31374,7 +31374,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -31465,7 +31465,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -31574,7 +31574,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/logout`
@@ -31639,7 +31639,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31799,7 +31799,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -31890,7 +31890,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -31974,7 +31974,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -32085,7 +32085,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -32168,7 +32168,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -32254,7 +32254,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -32372,7 +32372,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -32552,7 +32552,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -32663,7 +32663,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -32763,7 +32763,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -32888,7 +32888,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -32990,7 +32990,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -33185,7 +33185,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -33311,7 +33311,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -33426,7 +33426,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -33546,7 +33546,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -33794,7 +33794,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -33989,7 +33989,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -34115,7 +34115,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -34230,7 +34230,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -34347,7 +34347,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -34544,7 +34544,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -34671,7 +34671,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -34786,7 +34786,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -34904,7 +34904,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35116,7 +35116,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35258,7 +35258,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35399,7 +35399,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35517,7 +35517,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35661,7 +35661,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35874,7 +35874,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36022,7 +36022,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36155,7 +36155,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36317,7 +36317,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36446,7 +36446,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36564,7 +36564,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36732,7 +36732,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36847,7 +36847,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36968,7 +36968,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -37083,7 +37083,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -37197,7 +37197,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -37299,7 +37299,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -37431,7 +37431,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -37628,7 +37628,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -37755,7 +37755,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -37870,7 +37870,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -37987,7 +37987,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -38182,7 +38182,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -38308,7 +38308,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38424,7 +38424,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38565,7 +38565,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38680,7 +38680,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38798,7 +38798,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38951,7 +38951,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39163,7 +39163,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39305,7 +39305,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39436,7 +39436,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39592,7 +39592,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39725,7 +39725,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39952,7 +39952,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40115,7 +40115,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40261,7 +40261,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40438,7 +40438,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40584,7 +40584,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40796,7 +40796,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40938,7 +40938,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -41069,7 +41069,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -41225,7 +41225,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -41358,7 +41358,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -41580,7 +41580,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/policy`
@@ -41645,7 +41645,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -41737,7 +41737,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -41881,7 +41881,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -41959,7 +41959,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/session/me`
@@ -42024,7 +42024,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -42186,7 +42186,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -42346,7 +42346,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -42435,7 +42435,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -42518,7 +42518,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -42601,7 +42601,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -42681,7 +42681,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -42761,7 +42761,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -42843,7 +42843,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -43003,7 +43003,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -43094,7 +43094,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -43177,7 +43177,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -43262,7 +43262,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -43424,7 +43424,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -43584,7 +43584,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -43666,7 +43666,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -43826,7 +43826,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -43909,7 +43909,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -44088,7 +44088,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -44248,7 +44248,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -44339,7 +44339,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -44419,7 +44419,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -44501,7 +44501,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -44661,7 +44661,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -44750,7 +44750,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -44831,7 +44831,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -44940,7 +44940,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -45022,7 +45022,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -45184,7 +45184,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -45282,7 +45282,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -45378,7 +45378,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
@@ -45442,7 +45442,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -45586,7 +45586,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -45663,7 +45663,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -45745,7 +45745,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -45908,7 +45908,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/system/policy`
@@ -45973,7 +45973,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -46066,7 +46066,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -46226,7 +46226,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -46308,7 +46308,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -46468,7 +46468,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -46557,7 +46557,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -46637,7 +46637,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -46720,7 +46720,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -46901,7 +46901,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -47012,7 +47012,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -47112,7 +47112,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -47226,7 +47226,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -47346,7 +47346,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -47446,7 +47446,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -47529,7 +47529,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -47643,7 +47643,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -47821,7 +47821,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -47921,7 +47921,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -48081,7 +48081,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -48162,7 +48162,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -48309,7 +48309,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -48473,7 +48473,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -48670,7 +48670,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -48796,7 +48796,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -48914,7 +48914,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49034,7 +49034,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -49231,7 +49231,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -49357,7 +49357,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49475,7 +49475,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49596,7 +49596,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -49811,7 +49811,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49956,7 +49956,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50101,7 +50101,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50245,7 +50245,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50366,7 +50366,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -50537,7 +50537,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50662,7 +50662,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50780,7 +50780,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50898,7 +50898,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -51058,7 +51058,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -51149,7 +51149,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -51233,7 +51233,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -51344,7 +51344,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -51427,7 +51427,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -51513,7 +51513,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -51631,7 +51631,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -51811,7 +51811,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -51921,7 +51921,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -52024,7 +52024,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(::std::default::Default::default()),
@@ -52152,7 +52152,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -52254,7 +52254,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -52359,7 +52359,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(::std::default::Default::default()),
@@ -52492,7 +52492,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -52656,7 +52656,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -52817,7 +52817,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -52897,7 +52897,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
@@ -52960,7 +52960,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -53051,7 +53051,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
@@ -53116,7 +53116,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -53276,7 +53276,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -53356,7 +53356,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -53437,7 +53437,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -28866,6 +28866,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -29806,7 +29806,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -30115,7 +30115,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -30456,7 +30456,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -30942,7 +30942,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -31697,7 +31697,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -32214,7 +32214,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -32973,7 +32973,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -33493,7 +33493,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -34948,7 +34948,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -36379,7 +36379,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -37029,7 +37029,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -38007,7 +38007,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -38822,7 +38822,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -39550,7 +39550,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -40700,7 +40700,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -41296,7 +41296,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -42445,7 +42445,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -42921,7 +42921,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -43254,7 +43254,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -43578,7 +43578,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -44474,7 +44474,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -44840,7 +44840,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -44946,7 +44946,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -46625,7 +46625,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -47150,7 +47150,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -48860,7 +48860,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -49623,7 +49623,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -50276,7 +50276,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -50412,7 +50412,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -28915,7 +28915,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/disks/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -28986,7 +28986,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/images/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29057,7 +29057,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/instances/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29130,7 +29130,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/network-interfaces/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29201,7 +29201,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/organizations/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29272,7 +29272,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/projects/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29343,7 +29343,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/snapshots/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29414,7 +29414,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpc-router-routes/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29485,7 +29485,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpc-routers/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29556,7 +29556,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpc-subnets/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29627,7 +29627,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpcs/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29709,7 +29709,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/auth", client.baseurl,);
+            let url = format!("{}/device/auth", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -29781,7 +29781,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/confirm", client.baseurl,);
+            let url = format!("{}/device/confirm", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -29867,7 +29867,7 @@ pub mod builder {
                     types::DeviceAccessTokenRequest::try_from(v).map_err(|e| e.to_string())
                 })
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/token", client.baseurl,);
+            let url = format!("{}/device/token", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -29959,7 +29959,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/groups", client.baseurl,);
+            let url = format!("{}/groups", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30090,7 +30090,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/login", client.baseurl,);
+            let url = format!("{}/login", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30197,7 +30197,7 @@ pub mod builder {
             let url = format!(
                 "{}/login/{}/local",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30283,7 +30283,7 @@ pub mod builder {
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
+                encode_path(&provider_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30378,7 +30378,7 @@ pub mod builder {
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
+                encode_path(&provider_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30432,7 +30432,7 @@ pub mod builder {
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/logout", client.baseurl,);
+            let url = format!("{}/logout", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30533,7 +30533,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
+            let url = format!("{}/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30666,7 +30666,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
+            let url = format!("{}/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30740,7 +30740,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30842,7 +30842,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30917,7 +30917,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30993,7 +30993,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31099,7 +31099,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31220,7 +31220,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31374,7 +31374,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31465,7 +31465,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31581,7 +31581,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31672,7 +31672,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31807,7 +31807,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31976,7 +31976,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32083,7 +32083,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
+                encode_path(&disk_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32189,7 +32189,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
+                encode_path(&disk_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32372,7 +32372,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
-                encode_path(&metric_name.to_string()),
+                encode_path(&metric_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32566,7 +32566,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32735,7 +32735,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32842,7 +32842,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32948,7 +32948,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33084,7 +33084,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33255,7 +33255,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33362,7 +33362,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33468,7 +33468,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33619,7 +33619,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33805,7 +33805,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33938,7 +33938,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34047,7 +34047,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34179,7 +34179,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34332,7 +34332,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34524,7 +34524,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34648,7 +34648,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
+                encode_path(&interface_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34801,7 +34801,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
+                encode_path(&interface_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34923,7 +34923,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
+                encode_path(&interface_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35029,7 +35029,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35182,7 +35182,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35297,7 +35297,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35403,7 +35403,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35515,7 +35515,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35621,7 +35621,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35713,7 +35713,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35833,7 +35833,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35970,7 +35970,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36141,7 +36141,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36248,7 +36248,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
+                encode_path(&snapshot_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36354,7 +36354,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
+                encode_path(&snapshot_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36489,7 +36489,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36658,7 +36658,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36765,7 +36765,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36897,7 +36897,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37004,7 +37004,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37112,7 +37112,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37253,7 +37253,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37405,7 +37405,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37591,7 +37591,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37713,7 +37713,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37860,7 +37860,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37982,7 +37982,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38148,7 +38148,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38355,7 +38355,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38492,7 +38492,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
+                encode_path(&route_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38660,7 +38660,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
+                encode_path(&route_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38797,7 +38797,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
+                encode_path(&route_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38948,7 +38948,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39134,7 +39134,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39256,7 +39256,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39403,7 +39403,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39525,7 +39525,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39692,7 +39692,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39801,7 +39801,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/policy", client.baseurl,);
+            let url = format!("{}/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -39882,7 +39882,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/policy", client.baseurl,);
+            let url = format!("{}/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -39969,7 +39969,7 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/roles", client.baseurl,);
+            let url = format!("{}/roles", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40089,7 +40089,7 @@ pub mod builder {
             let url = format!(
                 "{}/roles/{}",
                 client.baseurl,
-                encode_path(&role_name.to_string()),
+                encode_path(&role_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40142,7 +40142,7 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/session/me", client.baseurl,);
+            let url = format!("{}/session/me", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40243,7 +40243,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/groups", client.baseurl,);
+            let url = format!("{}/session/me/groups", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40396,7 +40396,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let url = format!("{}/session/me/sshkeys", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40527,7 +40527,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let url = format!("{}/session/me/sshkeys", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40601,7 +40601,7 @@ pub mod builder {
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
+                encode_path(&ssh_key_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40675,7 +40675,7 @@ pub mod builder {
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
+                encode_path(&ssh_key_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40746,7 +40746,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/by-id/images/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40817,7 +40817,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/by-id/ip-pools/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40888,7 +40888,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/by-id/silos/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40990,7 +40990,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
+            let url = format!("{}/system/certificates", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41123,7 +41123,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
+            let url = format!("{}/system/certificates", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41197,7 +41197,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
-                encode_path(&certificate.to_string()),
+                encode_path(&certificate.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41271,7 +41271,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
-                encode_path(&certificate.to_string()),
+                encode_path(&certificate.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41373,7 +41373,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/disks", client.baseurl,);
+            let url = format!("{}/system/hardware/disks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41526,7 +41526,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/racks", client.baseurl,);
+            let url = format!("{}/system/hardware/racks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41648,7 +41648,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/hardware/racks/{}",
                 client.baseurl,
-                encode_path(&rack_id.to_string()),
+                encode_path(&rack_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41750,7 +41750,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let url = format!("{}/system/hardware/sleds", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41872,7 +41872,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/hardware/sleds/{}",
                 client.baseurl,
-                encode_path(&sled_id.to_string()),
+                encode_path(&sled_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41991,7 +41991,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/hardware/sleds/{}/disks",
                 client.baseurl,
-                encode_path(&sled_id.to_string()),
+                encode_path(&sled_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42145,7 +42145,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
+            let url = format!("{}/system/images", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42278,7 +42278,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
+            let url = format!("{}/system/images", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42349,7 +42349,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42420,7 +42420,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42522,7 +42522,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let url = format!("{}/system/ip-pools", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42653,7 +42653,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let url = format!("{}/system/ip-pools", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42724,7 +42724,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42824,7 +42824,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42896,7 +42896,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43000,7 +43000,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}/ranges",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43138,7 +43138,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43228,7 +43228,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43282,7 +43282,7 @@ pub mod builder {
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43368,7 +43368,7 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43485,7 +43485,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43553,7 +43553,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43703,7 +43703,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/metrics/{}",
                 client.baseurl,
-                encode_path(&metric_name.to_string()),
+                encode_path(&metric_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43769,7 +43769,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/policy", client.baseurl,);
+            let url = format!("{}/system/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43850,7 +43850,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/policy", client.baseurl,);
+            let url = format!("{}/system/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43952,7 +43952,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/sagas", client.baseurl,);
+            let url = format!("{}/system/sagas", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -44074,7 +44074,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/sagas/{}",
                 client.baseurl,
-                encode_path(&saga_id.to_string()),
+                encode_path(&saga_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44176,7 +44176,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
+            let url = format!("{}/system/silos", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -44307,7 +44307,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
+            let url = format!("{}/system/silos", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -44378,7 +44378,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44449,7 +44449,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44570,7 +44570,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/identity-providers",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44724,7 +44724,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44815,7 +44815,7 @@ pub mod builder {
                 "{}/system/silos/{}/identity-providers/local/users/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&user_id.to_string()),
+                encode_path(&user_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44920,7 +44920,7 @@ pub mod builder {
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&user_id.to_string()),
+                encode_path(&user_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45031,7 +45031,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45124,7 +45124,7 @@ pub mod builder {
                 "{}/system/silos/{}/identity-providers/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
+                encode_path(&provider_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45197,7 +45197,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45299,7 +45299,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45419,7 +45419,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/users/all",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45561,7 +45561,7 @@ pub mod builder {
                 "{}/system/silos/{}/users/id/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&user_id.to_string()),
+                encode_path(&user_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45663,7 +45663,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/user", client.baseurl,);
+            let url = format!("{}/system/user", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -45785,7 +45785,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/user/{}",
                 client.baseurl,
-                encode_path(&user_name.to_string()),
+                encode_path(&user_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45873,7 +45873,7 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/timeseries/schema", client.baseurl,);
+            let url = format!("{}/timeseries/schema", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46024,7 +46024,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/users", client.baseurl,);
+            let url = format!("{}/users", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46207,7 +46207,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
+            let url = format!("{}/v1/disks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46377,7 +46377,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
+            let url = format!("{}/v1/disks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46486,7 +46486,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
-                encode_path(&disk.to_string()),
+                encode_path(&disk.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -46595,7 +46595,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
-                encode_path(&disk.to_string()),
+                encode_path(&disk.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -46732,7 +46732,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
+            let url = format!("{}/v1/instances", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46902,7 +46902,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
+            let url = format!("{}/v1/instances", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -47011,7 +47011,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47120,7 +47120,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47274,7 +47274,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/disks",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47463,7 +47463,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/disks/attach",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47599,7 +47599,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/disks/detach",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47735,7 +47735,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/migrate",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47845,7 +47845,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/reboot",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48001,7 +48001,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/serial-console",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48120,7 +48120,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48235,7 +48235,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/start",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48344,7 +48344,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/stop",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48451,7 +48451,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
+            let url = format!("{}/v1/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -48584,7 +48584,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
+            let url = format!("{}/v1/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -48658,7 +48658,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48760,7 +48760,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48835,7 +48835,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48911,7 +48911,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49017,7 +49017,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49135,7 +49135,7 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
+            let url = format!("{}/v1/projects", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -49288,7 +49288,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
+            let url = format!("{}/v1/projects", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -49381,7 +49381,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49500,7 +49500,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49594,7 +49594,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49689,7 +49689,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49812,7 +49812,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49920,7 +49920,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/components", client.baseurl,);
+            let url = format!("{}/v1/system/update/components", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50075,7 +50075,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let url = format!("{}/v1/system/update/deployments", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50199,7 +50199,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/system/update/deployments/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -50252,7 +50252,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let url = format!("{}/v1/system/update/refresh", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50335,7 +50335,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/start", client.baseurl,);
+            let url = format!("{}/v1/system/update/start", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50388,7 +50388,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let url = format!("{}/v1/system/update/stop", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50489,7 +50489,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let url = format!("{}/v1/system/update/updates", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50611,7 +50611,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/system/update/updates/{}",
                 client.baseurl,
-                encode_path(&version.to_string()),
+                encode_path(&version.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -50685,7 +50685,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/system/update/updates/{}/components",
                 client.baseurl,
-                encode_path(&version.to_string()),
+                encode_path(&version.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -50740,7 +50740,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/version", client.baseurl,);
+            let url = format!("{}/v1/system/update/version", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -25151,6 +25151,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -25170,6 +25171,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -29696,6 +29696,10 @@ pub mod builder {
     }
 
     impl<'a> DiskViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -29772,6 +29776,10 @@ pub mod builder {
     }
 
     impl<'a> ImageViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -29848,6 +29856,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -29925,6 +29937,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30003,6 +30019,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30079,6 +30099,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30155,6 +30179,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30231,6 +30259,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30307,6 +30339,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30383,6 +30419,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30459,6 +30499,10 @@ pub mod builder {
     }
 
     impl<'a> VpcViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30535,6 +30579,10 @@ pub mod builder {
     }
 
     impl<'a> DeviceAuthRequest<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30612,6 +30660,10 @@ pub mod builder {
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30699,6 +30751,10 @@ pub mod builder {
     }
 
     impl<'a> DeviceAccessToken<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30782,6 +30838,10 @@ pub mod builder {
     }
 
     impl<'a> GroupList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -30938,6 +30998,10 @@ pub mod builder {
     }
 
     impl<'a> LoginSpoof<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31024,6 +31088,10 @@ pub mod builder {
     }
 
     impl<'a> LoginLocal<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31133,6 +31201,10 @@ pub mod builder {
     }
 
     impl<'a> LoginSamlBegin<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31220,6 +31292,10 @@ pub mod builder {
     }
 
     impl<'a> LoginSaml<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31326,6 +31402,10 @@ pub mod builder {
     }
 
     impl<'a> Logout<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -31386,6 +31466,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31542,6 +31626,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31629,6 +31717,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31709,6 +31801,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31816,6 +31912,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31895,6 +31995,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -31977,6 +32081,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32091,6 +32199,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32267,6 +32379,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32374,6 +32490,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32470,6 +32590,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32591,6 +32715,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32689,6 +32817,10 @@ pub mod builder {
     }
 
     impl<'a> DiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -32880,6 +33012,10 @@ pub mod builder {
     }
 
     impl<'a> DiskCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33002,6 +33138,10 @@ pub mod builder {
     }
 
     impl<'a> DiskView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33113,6 +33253,10 @@ pub mod builder {
     }
 
     impl<'a> DiskDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33229,6 +33373,10 @@ pub mod builder {
     }
 
     impl<'a> DiskMetricsList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33473,6 +33621,10 @@ pub mod builder {
     }
 
     impl<'a> ImageList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33664,6 +33816,10 @@ pub mod builder {
     }
 
     impl<'a> ImageCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33786,6 +33942,10 @@ pub mod builder {
     }
 
     impl<'a> ImageView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -33897,6 +34057,10 @@ pub mod builder {
     }
 
     impl<'a> ImageDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34010,6 +34174,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34203,6 +34371,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34326,6 +34498,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34437,6 +34613,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34551,6 +34731,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34759,6 +34943,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskAttach<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -34897,6 +35085,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskDetach<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35034,6 +35226,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceExternalIpList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35148,6 +35344,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceMigrate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35288,6 +35488,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35497,6 +35701,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35641,6 +35849,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35770,6 +35982,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -35928,6 +36144,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36053,6 +36273,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceReboot<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36167,6 +36391,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsole<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36331,6 +36559,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleStream<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36442,6 +36674,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleStreamV2<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36559,6 +36795,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStart<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36670,6 +36910,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStop<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36780,6 +37024,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -36878,6 +37126,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37006,6 +37258,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37199,6 +37455,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37322,6 +37582,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37433,6 +37697,10 @@ pub mod builder {
     }
 
     impl<'a> SnapshotDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37546,6 +37814,10 @@ pub mod builder {
     }
 
     impl<'a> VpcList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37737,6 +38009,10 @@ pub mod builder {
     }
 
     impl<'a> VpcCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37859,6 +38135,10 @@ pub mod builder {
     }
 
     impl<'a> VpcView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -37971,6 +38251,10 @@ pub mod builder {
     }
 
     impl<'a> VpcUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38108,6 +38392,10 @@ pub mod builder {
     }
 
     impl<'a> VpcDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38219,6 +38507,10 @@ pub mod builder {
     }
 
     impl<'a> VpcFirewallRulesView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38333,6 +38625,10 @@ pub mod builder {
     }
 
     impl<'a> VpcFirewallRulesUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38482,6 +38778,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38690,6 +38990,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38828,6 +39132,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -38955,6 +39263,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39107,6 +39419,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39236,6 +39552,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39459,6 +39779,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39618,6 +39942,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39760,6 +40088,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -39933,6 +40265,10 @@ pub mod builder {
     }
 
     impl<'a> VpcRouterRouteDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40075,6 +40411,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40283,6 +40623,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40421,6 +40765,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40548,6 +40896,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40700,6 +41052,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -40829,6 +41185,10 @@ pub mod builder {
     }
 
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41048,6 +41408,10 @@ pub mod builder {
     }
 
     impl<'a> PolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -41108,6 +41472,10 @@ pub mod builder {
     }
 
     impl<'a> PolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41196,6 +41564,10 @@ pub mod builder {
     }
 
     impl<'a> RoleList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41336,6 +41708,10 @@ pub mod builder {
     }
 
     impl<'a> RoleView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41411,6 +41787,10 @@ pub mod builder {
     }
 
     impl<'a> SessionMe<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -41471,6 +41851,10 @@ pub mod builder {
     }
 
     impl<'a> SessionMeGroups<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41629,6 +42013,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41785,6 +42173,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41870,6 +42262,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -41949,6 +42345,10 @@ pub mod builder {
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42028,6 +42428,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42104,6 +42508,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42180,6 +42588,10 @@ pub mod builder {
     }
 
     impl<'a> SiloViewById<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42258,6 +42670,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42414,6 +42830,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42501,6 +42921,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42580,6 +43004,10 @@ pub mod builder {
     }
 
     impl<'a> CertificateDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42661,6 +43089,10 @@ pub mod builder {
     }
 
     impl<'a> PhysicalDiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42819,6 +43251,10 @@ pub mod builder {
     }
 
     impl<'a> RackList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -42975,6 +43411,10 @@ pub mod builder {
     }
 
     impl<'a> RackView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43053,6 +43493,10 @@ pub mod builder {
     }
 
     impl<'a> SledList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43209,6 +43653,10 @@ pub mod builder {
     }
 
     impl<'a> SledView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43288,6 +43736,10 @@ pub mod builder {
     }
 
     impl<'a> SledPhysicalDiskList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43463,6 +43915,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43619,6 +44075,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43706,6 +44166,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43782,6 +44246,10 @@ pub mod builder {
     }
 
     impl<'a> SystemImageDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -43860,6 +44328,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44016,6 +44488,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44101,6 +44577,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44178,6 +44658,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44283,6 +44767,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44361,6 +44849,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolRangeList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44519,6 +45011,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolRangeAdd<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44613,6 +45109,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolRangeRemove<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44706,6 +45206,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -44765,6 +45269,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceRangeList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44905,6 +45413,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -44978,6 +45490,10 @@ pub mod builder {
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45056,6 +45572,10 @@ pub mod builder {
     }
 
     impl<'a> SystemMetric<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45216,6 +45736,10 @@ pub mod builder {
     }
 
     impl<'a> SystemPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -45276,6 +45800,10 @@ pub mod builder {
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45365,6 +45893,10 @@ pub mod builder {
     }
 
     impl<'a> SagaList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45521,6 +46053,10 @@ pub mod builder {
     }
 
     impl<'a> SagaView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45599,6 +46135,10 @@ pub mod builder {
     }
 
     impl<'a> SiloList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45755,6 +46295,10 @@ pub mod builder {
     }
 
     impl<'a> SiloCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45840,6 +46384,10 @@ pub mod builder {
     }
 
     impl<'a> SiloView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45916,6 +46464,10 @@ pub mod builder {
     }
 
     impl<'a> SiloDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -45995,6 +46547,10 @@ pub mod builder {
     }
 
     impl<'a> SiloIdentityProviderList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46172,6 +46728,10 @@ pub mod builder {
     }
 
     impl<'a> LocalIdpUserCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46279,6 +46839,10 @@ pub mod builder {
     }
 
     impl<'a> LocalIdpUserDelete<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46375,6 +46939,10 @@ pub mod builder {
     }
 
     impl<'a> LocalIdpUserSetPassword<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46485,6 +47053,10 @@ pub mod builder {
     }
 
     impl<'a> SamlIdentityProviderCreate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46601,6 +47173,10 @@ pub mod builder {
     }
 
     impl<'a> SamlIdentityProviderView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46697,6 +47273,10 @@ pub mod builder {
     }
 
     impl<'a> SiloPolicyView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46776,6 +47356,10 @@ pub mod builder {
     }
 
     impl<'a> SiloPolicyUpdate<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -46886,6 +47470,10 @@ pub mod builder {
     }
 
     impl<'a> SiloUsersList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47060,6 +47648,10 @@ pub mod builder {
     }
 
     impl<'a> SiloUserView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47156,6 +47748,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUserList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47312,6 +47908,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUserView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47389,6 +47989,10 @@ pub mod builder {
     }
 
     impl<'a> TimeseriesSchemaGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47532,6 +48136,10 @@ pub mod builder {
     }
 
     impl<'a> UserList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47692,6 +48300,10 @@ pub mod builder {
     }
 
     impl<'a> DiskListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -47885,6 +48497,10 @@ pub mod builder {
     }
 
     impl<'a> DiskCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48007,6 +48623,10 @@ pub mod builder {
     }
 
     impl<'a> DiskViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48121,6 +48741,10 @@ pub mod builder {
     }
 
     impl<'a> DiskDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48237,6 +48861,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48430,6 +49058,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48552,6 +49184,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48666,6 +49302,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48783,6 +49423,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -48994,6 +49638,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskAttachV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49135,6 +49783,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceDiskDetachV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49276,6 +49928,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceMigrateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49416,6 +50072,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceRebootV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49533,6 +50193,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49700,6 +50364,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49821,6 +50489,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStartV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -49935,6 +50607,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStopV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50049,6 +50725,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50205,6 +50885,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50292,6 +50976,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50372,6 +51060,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50479,6 +51171,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50558,6 +51254,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50640,6 +51340,10 @@ pub mod builder {
     }
 
     impl<'a> OrganizationPolicyUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50754,6 +51458,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectListV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -50930,6 +51638,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectCreateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51036,6 +51748,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51135,6 +51851,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51259,6 +51979,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectDeleteV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51357,6 +52081,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyViewV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51458,6 +52186,10 @@ pub mod builder {
     }
 
     impl<'a> ProjectPolicyUpdateV1<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51587,6 +52319,10 @@ pub mod builder {
     }
 
     impl<'a> SystemComponentVersionList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51747,6 +52483,10 @@ pub mod builder {
     }
 
     impl<'a> UpdateDeploymentsList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51904,6 +52644,10 @@ pub mod builder {
     }
 
     impl<'a> UpdateDeploymentView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -51981,6 +52725,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -52039,6 +52787,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateStart<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52127,6 +52879,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateStop<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -52187,6 +52943,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52343,6 +53103,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateView<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52419,6 +53183,10 @@ pub mod builder {
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -52497,6 +53265,10 @@ pub mod builder {
     }
 
     impl<'a> SystemVersion<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -28698,6 +28698,10 @@ impl ClientVpcsExt for Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -28747,7 +28747,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/disks/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -28818,7 +28818,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/images/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -28889,7 +28889,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/instances/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -28963,7 +28963,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/network-interfaces/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29034,7 +29034,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/organizations/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29105,7 +29105,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/projects/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29176,7 +29176,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/snapshots/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29247,7 +29247,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpc-router-routes/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29318,7 +29318,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpc-routers/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29389,7 +29389,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpc-subnets/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29460,7 +29460,7 @@ pub mod builder {
             let url = format!(
                 "{}/by-id/vpcs/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -29542,7 +29542,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/auth", client.baseurl,);
+            let url = format!("{}/device/auth", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -29614,7 +29614,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/confirm", client.baseurl,);
+            let url = format!("{}/device/confirm", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -29700,7 +29700,7 @@ pub mod builder {
                     types::DeviceAccessTokenRequest::try_from(v).map_err(|e| e.to_string())
                 })
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/token", client.baseurl,);
+            let url = format!("{}/device/token", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -29792,7 +29792,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/groups", client.baseurl,);
+            let url = format!("{}/groups", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -29923,7 +29923,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/login", client.baseurl,);
+            let url = format!("{}/login", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30030,7 +30030,7 @@ pub mod builder {
             let url = format!(
                 "{}/login/{}/local",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30116,7 +30116,7 @@ pub mod builder {
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
+                encode_path(&provider_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30211,7 +30211,7 @@ pub mod builder {
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
+                encode_path(&provider_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30265,7 +30265,7 @@ pub mod builder {
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/logout", client.baseurl,);
+            let url = format!("{}/logout", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30366,7 +30366,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
+            let url = format!("{}/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30499,7 +30499,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
+            let url = format!("{}/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -30573,7 +30573,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30675,7 +30675,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30750,7 +30750,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30826,7 +30826,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -30932,7 +30932,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31053,7 +31053,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31207,7 +31207,7 @@ pub mod builder {
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
-                encode_path(&organization_name.to_string()),
+                encode_path(&organization_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31298,7 +31298,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31414,7 +31414,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31505,7 +31505,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31640,7 +31640,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31809,7 +31809,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -31916,7 +31916,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
+                encode_path(&disk_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32022,7 +32022,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
+                encode_path(&disk_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32205,7 +32205,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
-                encode_path(&metric_name.to_string()),
+                encode_path(&metric_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32399,7 +32399,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32568,7 +32568,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32675,7 +32675,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32781,7 +32781,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -32917,7 +32917,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33088,7 +33088,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33195,7 +33195,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33301,7 +33301,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33452,7 +33452,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33638,7 +33638,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33771,7 +33771,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -33880,7 +33880,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34012,7 +34012,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34165,7 +34165,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34357,7 +34357,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34481,7 +34481,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
+                encode_path(&interface_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34634,7 +34634,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
+                encode_path(&interface_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34756,7 +34756,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
+                encode_path(&interface_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -34862,7 +34862,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35015,7 +35015,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35130,7 +35130,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35236,7 +35236,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35348,7 +35348,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35454,7 +35454,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
+                encode_path(&instance_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35546,7 +35546,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35666,7 +35666,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35803,7 +35803,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -35974,7 +35974,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36081,7 +36081,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
+                encode_path(&snapshot_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36187,7 +36187,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
+                encode_path(&snapshot_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36322,7 +36322,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36491,7 +36491,7 @@ pub mod builder {
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
+                encode_path(&project_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36598,7 +36598,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36730,7 +36730,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36837,7 +36837,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -36945,7 +36945,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37086,7 +37086,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37238,7 +37238,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37424,7 +37424,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37546,7 +37546,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37693,7 +37693,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37815,7 +37815,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -37981,7 +37981,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38188,7 +38188,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
+                encode_path(&router_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38325,7 +38325,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
+                encode_path(&route_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38493,7 +38493,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
+                encode_path(&route_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38630,7 +38630,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
+                encode_path(&route_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38781,7 +38781,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -38967,7 +38967,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
+                encode_path(&vpc_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39089,7 +39089,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39236,7 +39236,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39358,7 +39358,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39525,7 +39525,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
+                encode_path(&subnet_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39634,7 +39634,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/policy", client.baseurl,);
+            let url = format!("{}/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -39715,7 +39715,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/policy", client.baseurl,);
+            let url = format!("{}/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -39802,7 +39802,7 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/roles", client.baseurl,);
+            let url = format!("{}/roles", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -39922,7 +39922,7 @@ pub mod builder {
             let url = format!(
                 "{}/roles/{}",
                 client.baseurl,
-                encode_path(&role_name.to_string()),
+                encode_path(&role_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -39975,7 +39975,7 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/session/me", client.baseurl,);
+            let url = format!("{}/session/me", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40076,7 +40076,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/groups", client.baseurl,);
+            let url = format!("{}/session/me/groups", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40229,7 +40229,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let url = format!("{}/session/me/sshkeys", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40360,7 +40360,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let url = format!("{}/session/me/sshkeys", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40434,7 +40434,7 @@ pub mod builder {
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
+                encode_path(&ssh_key_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40508,7 +40508,7 @@ pub mod builder {
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
+                encode_path(&ssh_key_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40579,7 +40579,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/by-id/images/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40650,7 +40650,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/by-id/ip-pools/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40721,7 +40721,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/by-id/silos/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -40823,7 +40823,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
+            let url = format!("{}/system/certificates", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -40956,7 +40956,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
+            let url = format!("{}/system/certificates", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41030,7 +41030,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
-                encode_path(&certificate.to_string()),
+                encode_path(&certificate.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41104,7 +41104,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
-                encode_path(&certificate.to_string()),
+                encode_path(&certificate.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41206,7 +41206,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/disks", client.baseurl,);
+            let url = format!("{}/system/hardware/disks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41359,7 +41359,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/racks", client.baseurl,);
+            let url = format!("{}/system/hardware/racks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41481,7 +41481,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/hardware/racks/{}",
                 client.baseurl,
-                encode_path(&rack_id.to_string()),
+                encode_path(&rack_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41583,7 +41583,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let url = format!("{}/system/hardware/sleds", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -41705,7 +41705,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/hardware/sleds/{}",
                 client.baseurl,
-                encode_path(&sled_id.to_string()),
+                encode_path(&sled_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41824,7 +41824,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/hardware/sleds/{}/disks",
                 client.baseurl,
-                encode_path(&sled_id.to_string()),
+                encode_path(&sled_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -41978,7 +41978,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
+            let url = format!("{}/system/images", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42111,7 +42111,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
+            let url = format!("{}/system/images", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42182,7 +42182,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42253,7 +42253,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
-                encode_path(&image_name.to_string()),
+                encode_path(&image_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42355,7 +42355,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let url = format!("{}/system/ip-pools", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42486,7 +42486,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let url = format!("{}/system/ip-pools", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -42557,7 +42557,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42657,7 +42657,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42729,7 +42729,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42833,7 +42833,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}/ranges",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -42971,7 +42971,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43061,7 +43061,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
                 client.baseurl,
-                encode_path(&pool_name.to_string()),
+                encode_path(&pool_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43115,7 +43115,7 @@ pub mod builder {
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43201,7 +43201,7 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43318,7 +43318,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43386,7 +43386,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43536,7 +43536,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/metrics/{}",
                 client.baseurl,
-                encode_path(&metric_name.to_string()),
+                encode_path(&metric_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -43602,7 +43602,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/policy", client.baseurl,);
+            let url = format!("{}/system/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43683,7 +43683,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/policy", client.baseurl,);
+            let url = format!("{}/system/policy", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43785,7 +43785,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/sagas", client.baseurl,);
+            let url = format!("{}/system/sagas", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -43907,7 +43907,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/sagas/{}",
                 client.baseurl,
-                encode_path(&saga_id.to_string()),
+                encode_path(&saga_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44009,7 +44009,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
+            let url = format!("{}/system/silos", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -44140,7 +44140,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
+            let url = format!("{}/system/silos", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -44211,7 +44211,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44282,7 +44282,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44403,7 +44403,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/identity-providers",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44557,7 +44557,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44648,7 +44648,7 @@ pub mod builder {
                 "{}/system/silos/{}/identity-providers/local/users/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&user_id.to_string()),
+                encode_path(&user_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44753,7 +44753,7 @@ pub mod builder {
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&user_id.to_string()),
+                encode_path(&user_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44864,7 +44864,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -44957,7 +44957,7 @@ pub mod builder {
                 "{}/system/silos/{}/identity-providers/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
+                encode_path(&provider_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45030,7 +45030,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45132,7 +45132,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45252,7 +45252,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/silos/{}/users/all",
                 client.baseurl,
-                encode_path(&silo_name.to_string()),
+                encode_path(&silo_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45394,7 +45394,7 @@ pub mod builder {
                 "{}/system/silos/{}/users/id/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
-                encode_path(&user_id.to_string()),
+                encode_path(&user_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45496,7 +45496,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/user", client.baseurl,);
+            let url = format!("{}/system/user", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -45618,7 +45618,7 @@ pub mod builder {
             let url = format!(
                 "{}/system/user/{}",
                 client.baseurl,
-                encode_path(&user_name.to_string()),
+                encode_path(&user_name.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -45706,7 +45706,7 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/timeseries/schema", client.baseurl,);
+            let url = format!("{}/timeseries/schema", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -45857,7 +45857,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/users", client.baseurl,);
+            let url = format!("{}/users", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46040,7 +46040,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
+            let url = format!("{}/v1/disks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46210,7 +46210,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::DiskCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
+            let url = format!("{}/v1/disks", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46319,7 +46319,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
-                encode_path(&disk.to_string()),
+                encode_path(&disk.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -46428,7 +46428,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
-                encode_path(&disk.to_string()),
+                encode_path(&disk.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -46565,7 +46565,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
+            let url = format!("{}/v1/instances", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46735,7 +46735,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::InstanceCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
+            let url = format!("{}/v1/instances", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -46844,7 +46844,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -46953,7 +46953,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47107,7 +47107,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/disks",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47296,7 +47296,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/disks/attach",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47432,7 +47432,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/disks/detach",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47568,7 +47568,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/migrate",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47678,7 +47678,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/reboot",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47834,7 +47834,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/serial-console",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -47953,7 +47953,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48068,7 +48068,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/start",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48177,7 +48177,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/instances/{}/stop",
                 client.baseurl,
-                encode_path(&instance.to_string()),
+                encode_path(&instance.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48284,7 +48284,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
+            let url = format!("{}/v1/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -48417,7 +48417,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
+            let url = format!("{}/v1/organizations", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -48491,7 +48491,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48593,7 +48593,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48668,7 +48668,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48744,7 +48744,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48850,7 +48850,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
-                encode_path(&organization.to_string()),
+                encode_path(&organization.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -48968,7 +48968,7 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
+            let url = format!("{}/v1/projects", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -49121,7 +49121,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::ProjectCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
+            let url = format!("{}/v1/projects", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -49214,7 +49214,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49333,7 +49333,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49427,7 +49427,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49522,7 +49522,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49645,7 +49645,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
-                encode_path(&project.to_string()),
+                encode_path(&project.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -49753,7 +49753,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/components", client.baseurl,);
+            let url = format!("{}/v1/system/update/components", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -49908,7 +49908,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let url = format!("{}/v1/system/update/deployments", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50032,7 +50032,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/system/update/deployments/{}",
                 client.baseurl,
-                encode_path(&id.to_string()),
+                encode_path(&id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -50085,7 +50085,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let url = format!("{}/v1/system/update/refresh", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50168,7 +50168,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/start", client.baseurl,);
+            let url = format!("{}/v1/system/update/start", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50221,7 +50221,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let url = format!("{}/v1/system/update/stop", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50322,7 +50322,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let url = format!("{}/v1/system/update/updates", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -50444,7 +50444,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/system/update/updates/{}",
                 client.baseurl,
-                encode_path(&version.to_string()),
+                encode_path(&version.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -50518,7 +50518,7 @@ pub mod builder {
             let url = format!(
                 "{}/v1/system/update/updates/{}/components",
                 client.baseurl,
-                encode_path(&version.to_string()),
+                encode_path(&version.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -50573,7 +50573,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/version", client.baseurl,);
+            let url = format!("{}/v1/system/update/version", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -24678,7 +24678,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Oxide Region API
+///Client for `Oxide Region API`
 ///
 ///API for interacting with the Oxide control plane
 ///

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -29702,7 +29702,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -29782,7 +29782,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -29862,7 +29862,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -29943,7 +29943,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30025,7 +30025,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30105,7 +30105,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30185,7 +30185,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30265,7 +30265,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30345,7 +30345,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30425,7 +30425,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30505,7 +30505,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -30585,7 +30585,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -30666,7 +30666,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -30757,7 +30757,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -30844,7 +30844,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31004,7 +31004,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -31094,7 +31094,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -31207,7 +31207,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -31298,7 +31298,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -31407,7 +31407,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/logout`
@@ -31472,7 +31472,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31632,7 +31632,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -31723,7 +31723,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -31807,7 +31807,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -31918,7 +31918,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -32001,7 +32001,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -32087,7 +32087,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -32205,7 +32205,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -32385,7 +32385,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -32496,7 +32496,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -32596,7 +32596,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -32721,7 +32721,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -32823,7 +32823,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -33018,7 +33018,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -33144,7 +33144,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -33259,7 +33259,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -33379,7 +33379,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -33627,7 +33627,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -33822,7 +33822,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -33948,7 +33948,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -34063,7 +34063,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -34180,7 +34180,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -34377,7 +34377,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -34504,7 +34504,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -34619,7 +34619,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -34737,7 +34737,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -34949,7 +34949,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35091,7 +35091,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35232,7 +35232,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35350,7 +35350,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35494,7 +35494,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35707,7 +35707,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35855,7 +35855,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -35988,7 +35988,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36150,7 +36150,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36279,7 +36279,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36397,7 +36397,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36565,7 +36565,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36680,7 +36680,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36801,7 +36801,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -36916,7 +36916,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -37030,7 +37030,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -37132,7 +37132,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -37264,7 +37264,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -37461,7 +37461,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -37588,7 +37588,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -37703,7 +37703,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -37820,7 +37820,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -38015,7 +38015,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -38141,7 +38141,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38257,7 +38257,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38398,7 +38398,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38513,7 +38513,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38631,7 +38631,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38784,7 +38784,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -38996,7 +38996,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39138,7 +39138,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39269,7 +39269,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39425,7 +39425,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39558,7 +39558,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39785,7 +39785,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -39948,7 +39948,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40094,7 +40094,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40271,7 +40271,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40417,7 +40417,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40629,7 +40629,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40771,7 +40771,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -40902,7 +40902,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -41058,7 +41058,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -41191,7 +41191,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -41413,7 +41413,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/policy`
@@ -41478,7 +41478,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -41570,7 +41570,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -41714,7 +41714,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -41792,7 +41792,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/session/me`
@@ -41857,7 +41857,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -42019,7 +42019,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -42179,7 +42179,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -42268,7 +42268,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -42351,7 +42351,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -42434,7 +42434,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -42514,7 +42514,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -42594,7 +42594,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -42676,7 +42676,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -42836,7 +42836,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -42927,7 +42927,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -43010,7 +43010,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -43095,7 +43095,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -43257,7 +43257,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -43417,7 +43417,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -43499,7 +43499,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -43659,7 +43659,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -43742,7 +43742,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -43921,7 +43921,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -44081,7 +44081,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -44172,7 +44172,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -44252,7 +44252,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -44334,7 +44334,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -44494,7 +44494,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -44583,7 +44583,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -44664,7 +44664,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -44773,7 +44773,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -44855,7 +44855,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -45017,7 +45017,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -45115,7 +45115,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -45211,7 +45211,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
@@ -45275,7 +45275,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -45419,7 +45419,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -45496,7 +45496,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -45578,7 +45578,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -45741,7 +45741,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/system/policy`
@@ -45806,7 +45806,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -45899,7 +45899,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -46059,7 +46059,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -46141,7 +46141,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -46301,7 +46301,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -46390,7 +46390,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -46470,7 +46470,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -46553,7 +46553,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -46734,7 +46734,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -46845,7 +46845,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -46945,7 +46945,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -47059,7 +47059,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -47179,7 +47179,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -47279,7 +47279,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -47362,7 +47362,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -47476,7 +47476,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -47654,7 +47654,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -47754,7 +47754,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -47914,7 +47914,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -47995,7 +47995,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -48142,7 +48142,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -48306,7 +48306,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -48503,7 +48503,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -48629,7 +48629,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -48747,7 +48747,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -48867,7 +48867,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -49064,7 +49064,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
@@ -49190,7 +49190,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49308,7 +49308,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49429,7 +49429,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -49644,7 +49644,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49789,7 +49789,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -49934,7 +49934,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50078,7 +50078,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50199,7 +50199,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -50370,7 +50370,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50495,7 +50495,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50613,7 +50613,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -50731,7 +50731,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -50891,7 +50891,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -50982,7 +50982,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -51066,7 +51066,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -51177,7 +51177,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -51260,7 +51260,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -51346,7 +51346,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -51464,7 +51464,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -51644,7 +51644,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(::std::default::Default::default()),
             }
@@ -51754,7 +51754,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -51857,7 +51857,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(::std::default::Default::default()),
@@ -51985,7 +51985,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -52087,7 +52087,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -52192,7 +52192,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(::std::default::Default::default()),
@@ -52325,7 +52325,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -52489,7 +52489,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -52650,7 +52650,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -52730,7 +52730,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
@@ -52793,7 +52793,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -52884,7 +52884,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
@@ -52949,7 +52949,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -53109,7 +53109,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -53189,7 +53189,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -53270,7 +53270,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -29639,7 +29639,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -29948,7 +29948,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -30289,7 +30289,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -30775,7 +30775,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -31530,7 +31530,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -32047,7 +32047,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -32806,7 +32806,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -33326,7 +33326,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -34781,7 +34781,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -36212,7 +36212,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -36862,7 +36862,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -37840,7 +37840,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -38655,7 +38655,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -39383,7 +39383,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -40533,7 +40533,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -41129,7 +41129,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -42278,7 +42278,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -42754,7 +42754,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -43087,7 +43087,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -43411,7 +43411,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -44307,7 +44307,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -44673,7 +44673,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -44779,7 +44779,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -46458,7 +46458,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -46983,7 +46983,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -48693,7 +48693,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -49456,7 +49456,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -50109,7 +50109,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),
@@ -50245,7 +50245,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -29675,6 +29675,13 @@ impl ClientVpcsExt for Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -24698,6 +24698,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -24694,6 +24694,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -24713,6 +24714,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -24755,7 +24755,12 @@ pub trait ClientDisksExt {
     ///
     ///Sends a `GET` request to `/by-id/disks/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -24776,7 +24781,12 @@ pub trait ClientDisksExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -24796,7 +24806,12 @@ pub trait ClientDisksExt {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -24813,7 +24828,12 @@ pub trait ClientDisksExt {
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -24828,7 +24848,12 @@ pub trait ClientDisksExt {
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -24853,7 +24878,12 @@ pub trait ClientDisksExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_metrics_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -24878,7 +24908,12 @@ pub trait ClientDisksExt {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_list_v1()
     ///    .limit(limit)
     ///    .organization(organization)
@@ -24893,7 +24928,12 @@ pub trait ClientDisksExt {
     ///
     ///Sends a `POST` request to `/v1/disks`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_create_v1()
     ///    .organization(organization)
     ///    .project(project)
@@ -24906,7 +24946,12 @@ pub trait ClientDisksExt {
     ///
     ///Sends a `GET` request to `/v1/disks/{disk}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_view_v1()
     ///    .disk(disk)
     ///    .organization(organization)
@@ -24919,7 +24964,12 @@ pub trait ClientDisksExt {
     ///
     ///Sends a `DELETE` request to `/v1/disks/{disk}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.disk_delete_v1()
     ///    .disk(disk)
     ///    .organization(organization)
@@ -24982,7 +25032,12 @@ pub trait ClientHiddenExt {
     ///
     ///Sends a `POST` request to `/device/auth`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.device_auth_request()
     ///    .body(body)
     ///    .send()
@@ -24998,7 +25053,12 @@ pub trait ClientHiddenExt {
     ///
     ///Sends a `POST` request to `/device/confirm`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.device_auth_confirm()
     ///    .body(body)
     ///    .send()
@@ -25012,7 +25072,12 @@ pub trait ClientHiddenExt {
     ///
     ///Sends a `POST` request to `/device/token`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.device_access_token()
     ///    .body(body)
     ///    .send()
@@ -25021,7 +25086,12 @@ pub trait ClientHiddenExt {
     fn device_access_token(&self) -> builder::DeviceAccessToken<'_>;
     ///Sends a `POST` request to `/login`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_spoof()
     ///    .body(body)
     ///    .send()
@@ -25030,7 +25100,12 @@ pub trait ClientHiddenExt {
     fn login_spoof(&self) -> builder::LoginSpoof<'_>;
     ///Sends a `POST` request to `/logout`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.logout()
     ///    .send()
     ///    .await;
@@ -25040,7 +25115,12 @@ pub trait ClientHiddenExt {
     ///
     ///Sends a `GET` request to `/session/me`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_me()
     ///    .send()
     ///    .await;
@@ -25055,7 +25135,12 @@ pub trait ClientHiddenExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_me_groups()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -25102,7 +25187,12 @@ pub trait ClientImagesExt {
     ///
     ///Sends a `GET` request to `/by-id/images/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25124,7 +25214,12 @@ pub trait ClientImagesExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25146,7 +25241,12 @@ pub trait ClientImagesExt {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25163,7 +25263,12 @@ pub trait ClientImagesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25182,7 +25287,12 @@ pub trait ClientImagesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.image_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25222,7 +25332,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `GET` request to `/by-id/instances/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25233,7 +25348,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `GET` request to `/by-id/network-interfaces/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -25254,7 +25374,12 @@ pub trait ClientInstancesExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25276,7 +25401,12 @@ pub trait ClientInstancesExt {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25293,7 +25423,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25308,7 +25443,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25333,7 +25473,12 @@ pub trait ClientInstancesExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25353,7 +25498,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/attach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_attach()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25371,7 +25521,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/detach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_detach()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25387,7 +25542,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/external-ips`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_external_ip_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25404,7 +25564,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/migrate`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_migrate()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25428,7 +25593,12 @@ pub trait ClientInstancesExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25446,7 +25616,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25462,7 +25637,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25478,7 +25658,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25500,7 +25685,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_network_interface_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25518,7 +25708,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/reboot`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_reboot()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25550,7 +25745,12 @@ pub trait ClientInstancesExt {
     ///   read, counting *backward* from the most recently buffered data
     ///   retrieved from the instance. (See note on `from_start` about mutual
     ///   exclusivity)
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25570,7 +25770,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_stream()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25587,7 +25792,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream_v2`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_stream_v2()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25604,7 +25814,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/start`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_start()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25621,7 +25836,12 @@ pub trait ClientInstancesExt {
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/stop`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_stop()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -25641,7 +25861,12 @@ pub trait ClientInstancesExt {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_list_v1()
     ///    .limit(limit)
     ///    .organization(organization)
@@ -25656,7 +25881,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `POST` request to `/v1/instances`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_create_v1()
     ///    .organization(organization)
     ///    .project(project)
@@ -25669,7 +25899,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `GET` request to `/v1/instances/{instance}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_view_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25682,7 +25917,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `DELETE` request to `/v1/instances/{instance}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_delete_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25703,7 +25943,12 @@ pub trait ClientInstancesExt {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_list_v1()
     ///    .instance(instance)
     ///    .limit(limit)
@@ -25719,7 +25964,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_attach_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25733,7 +25983,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_disk_detach_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25747,7 +26002,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_migrate_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25761,7 +26021,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_reboot_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25789,7 +26054,12 @@ pub trait ClientInstancesExt {
     ///   exclusivity)
     /// - `organization`
     /// - `project`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_v1()
     ///    .instance(instance)
     ///    .from_start(from_start)
@@ -25806,7 +26076,12 @@ pub trait ClientInstancesExt {
     ///Sends a `GET` request to
     /// `/v1/instances/{instance}/serial-console/stream`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial_console_stream_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25819,7 +26094,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/start`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_start_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25832,7 +26112,12 @@ pub trait ClientInstancesExt {
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/stop`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_stop_v1()
     ///    .instance(instance)
     ///    .organization(organization)
@@ -25993,7 +26278,12 @@ pub trait ClientLoginExt {
     ///
     ///Sends a `POST` request to `/login/{silo_name}/local`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_local()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -26008,7 +26298,12 @@ pub trait ClientLoginExt {
     ///
     ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_saml_begin()
     ///    .silo_name(silo_name)
     ///    .provider_name(provider_name)
@@ -26020,7 +26315,12 @@ pub trait ClientLoginExt {
     ///
     ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.login_saml()
     ///    .silo_name(silo_name)
     ///    .provider_name(provider_name)
@@ -26057,7 +26357,12 @@ pub trait ClientMetricsExt {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.timeseries_schema_get()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -26082,7 +26387,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `GET` request to `/by-id/organizations/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -26100,7 +26410,12 @@ pub trait ClientOrganizationsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -26115,7 +26430,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `POST` request to `/organizations`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_create()
     ///    .body(body)
     ///    .send()
@@ -26130,7 +26450,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_view()
     ///    .organization_name(organization_name)
     ///    .send()
@@ -26146,7 +26471,12 @@ pub trait ClientOrganizationsExt {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_update()
     ///    .organization_name(organization_name)
     ///    .body(body)
@@ -26162,7 +26492,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_delete()
     ///    .organization_name(organization_name)
     ///    .send()
@@ -26177,7 +26512,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_view()
     ///    .organization_name(organization_name)
     ///    .send()
@@ -26193,7 +26533,12 @@ pub trait ClientOrganizationsExt {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_update()
     ///    .organization_name(organization_name)
     ///    .body(body)
@@ -26210,7 +26555,12 @@ pub trait ClientOrganizationsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_list_v1()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -26223,7 +26573,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `POST` request to `/v1/organizations`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_create_v1()
     ///    .body(body)
     ///    .send()
@@ -26234,7 +26589,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_view_v1()
     ///    .organization(organization)
     ///    .send()
@@ -26245,7 +26605,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_update_v1()
     ///    .organization(organization)
     ///    .body(body)
@@ -26257,7 +26622,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `DELETE` request to `/v1/organizations/{organization}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_delete_v1()
     ///    .organization(organization)
     ///    .send()
@@ -26268,7 +26638,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_view_v1()
     ///    .organization(organization)
     ///    .send()
@@ -26279,7 +26654,12 @@ pub trait ClientOrganizationsExt {
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.organization_policy_update_v1()
     ///    .organization(organization)
     ///    .body(body)
@@ -26357,7 +26737,12 @@ pub trait ClientPolicyExt {
     ///
     ///Sends a `GET` request to `/system/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_policy_view()
     ///    .send()
     ///    .await;
@@ -26367,7 +26752,12 @@ pub trait ClientPolicyExt {
     ///
     ///Sends a `PUT` request to `/system/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_policy_update()
     ///    .body(body)
     ///    .send()
@@ -26395,7 +26785,12 @@ pub trait ClientProjectsExt {
     ///
     ///Sends a `GET` request to `/by-id/projects/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -26414,7 +26809,12 @@ pub trait ClientProjectsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_list()
     ///    .organization_name(organization_name)
     ///    .limit(limit)
@@ -26433,7 +26833,12 @@ pub trait ClientProjectsExt {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_create()
     ///    .organization_name(organization_name)
     ///    .body(body)
@@ -26451,7 +26856,12 @@ pub trait ClientProjectsExt {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26470,7 +26880,12 @@ pub trait ClientProjectsExt {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26489,7 +26904,12 @@ pub trait ClientProjectsExt {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26507,7 +26927,12 @@ pub trait ClientProjectsExt {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26524,7 +26949,12 @@ pub trait ClientProjectsExt {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26543,7 +26973,12 @@ pub trait ClientProjectsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_list_v1()
     ///    .limit(limit)
     ///    .organization(organization)
@@ -26557,7 +26992,12 @@ pub trait ClientProjectsExt {
     ///
     ///Sends a `POST` request to `/v1/projects`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_create_v1()
     ///    .organization(organization)
     ///    .body(body)
@@ -26569,7 +27009,12 @@ pub trait ClientProjectsExt {
     ///
     ///Sends a `GET` request to `/v1/projects/{project}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_view_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -26581,7 +27026,12 @@ pub trait ClientProjectsExt {
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_update_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -26594,7 +27044,12 @@ pub trait ClientProjectsExt {
     ///
     ///Sends a `DELETE` request to `/v1/projects/{project}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_delete_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -26606,7 +27061,12 @@ pub trait ClientProjectsExt {
     ///
     ///Sends a `GET` request to `/v1/projects/{project}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_view_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -26618,7 +27078,12 @@ pub trait ClientProjectsExt {
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.project_policy_update_v1()
     ///    .project(project)
     ///    .organization(organization)
@@ -26702,7 +27167,12 @@ pub trait ClientRolesExt {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.role_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -26716,7 +27186,12 @@ pub trait ClientRolesExt {
     ///
     ///Arguments:
     /// - `role_name`: The built-in role's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.role_view()
     ///    .role_name(role_name)
     ///    .send()
@@ -26748,7 +27223,12 @@ pub trait ClientSessionExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -26763,7 +27243,12 @@ pub trait ClientSessionExt {
     ///
     ///Sends a `POST` request to `/session/me/sshkeys`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_create()
     ///    .body(body)
     ///    .send()
@@ -26777,7 +27262,12 @@ pub trait ClientSessionExt {
     ///
     ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_view()
     ///    .ssh_key_name(ssh_key_name)
     ///    .send()
@@ -26791,7 +27281,12 @@ pub trait ClientSessionExt {
     ///
     ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.session_sshkey_delete()
     ///    .ssh_key_name(ssh_key_name)
     ///    .send()
@@ -26829,7 +27324,12 @@ pub trait ClientSilosExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.group_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -26842,7 +27342,12 @@ pub trait ClientSilosExt {
     ///
     ///Sends a `GET` request to `/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.policy_view()
     ///    .send()
     ///    .await;
@@ -26852,7 +27357,12 @@ pub trait ClientSilosExt {
     ///
     ///Sends a `PUT` request to `/policy`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.policy_update()
     ///    .body(body)
     ///    .send()
@@ -26868,7 +27378,12 @@ pub trait ClientSilosExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.user_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -26903,7 +27418,12 @@ pub trait ClientSnapshotsExt {
     ///
     ///Sends a `GET` request to `/by-id/snapshots/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -26922,7 +27442,12 @@ pub trait ClientSnapshotsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26944,7 +27469,12 @@ pub trait ClientSnapshotsExt {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26959,7 +27489,12 @@ pub trait ClientSnapshotsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -26974,7 +27509,12 @@ pub trait ClientSnapshotsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.snapshot_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -27013,7 +27553,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/by-id/images/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -27024,7 +27569,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -27035,7 +27585,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/by-id/silos/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -27055,7 +27610,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27071,7 +27631,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/certificates`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_create()
     ///    .body(body)
     ///    .send()
@@ -27084,7 +27649,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/certificates/{certificate}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_view()
     ///    .certificate(certificate)
     ///    .send()
@@ -27097,7 +27667,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `DELETE` request to `/system/certificates/{certificate}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.certificate_delete()
     ///    .certificate(certificate)
     ///    .send()
@@ -27113,7 +27688,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.physical_disk_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27131,7 +27711,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.rack_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27146,7 +27731,12 @@ pub trait ClientSystemExt {
     ///
     ///Arguments:
     /// - `rack_id`: The rack's unique ID.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.rack_view()
     ///    .rack_id(rack_id)
     ///    .send()
@@ -27162,7 +27752,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.sled_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27177,7 +27772,12 @@ pub trait ClientSystemExt {
     ///
     ///Arguments:
     /// - `sled_id`: The sled's unique ID.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.sled_view()
     ///    .sled_id(sled_id)
     ///    .send()
@@ -27194,7 +27794,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.sled_physical_disk_list()
     ///    .sled_id(sled_id)
     ///    .limit(limit)
@@ -27217,7 +27822,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27233,7 +27843,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/images`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_create()
     ///    .body(body)
     ///    .send()
@@ -27246,7 +27861,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/images/{image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_view()
     ///    .image_name(image_name)
     ///    .send()
@@ -27261,7 +27881,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `DELETE` request to `/system/images/{image_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_image_delete()
     ///    .image_name(image_name)
     ///    .send()
@@ -27277,7 +27902,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27290,7 +27920,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/ip-pools`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_create()
     ///    .body(body)
     ///    .send()
@@ -27301,7 +27936,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_view()
     ///    .pool_name(pool_name)
     ///    .send()
@@ -27312,7 +27952,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_update()
     ///    .pool_name(pool_name)
     ///    .body(body)
@@ -27324,7 +27969,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_delete()
     ///    .pool_name(pool_name)
     ///    .send()
@@ -27342,7 +27992,12 @@ pub trait ClientSystemExt {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_range_list()
     ///    .pool_name(pool_name)
     ///    .limit(limit)
@@ -27355,7 +28010,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_range_add()
     ///    .pool_name(pool_name)
     ///    .body(body)
@@ -27367,7 +28027,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/remove`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_range_remove()
     ///    .pool_name(pool_name)
     ///    .body(body)
@@ -27379,7 +28044,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/ip-pools-service`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_view()
     ///    .send()
     ///    .await;
@@ -27395,7 +28065,12 @@ pub trait ClientSystemExt {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_range_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27407,7 +28082,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_range_add()
     ///    .body(body)
     ///    .send()
@@ -27418,7 +28098,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.ip_pool_service_range_remove()
     ///    .body(body)
     ///    .send()
@@ -27437,7 +28122,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_metric()
     ///    .metric_name(metric_name)
     ///    .end_time(end_time)
@@ -27458,7 +28148,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saga_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27471,7 +28166,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/system/sagas/{saga_id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saga_view()
     ///    .saga_id(saga_id)
     ///    .send()
@@ -27489,7 +28189,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27502,7 +28207,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/system/silos`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_create()
     ///    .body(body)
     ///    .send()
@@ -27517,7 +28227,12 @@ pub trait ClientSystemExt {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_view()
     ///    .silo_name(silo_name)
     ///    .send()
@@ -27532,7 +28247,12 @@ pub trait ClientSystemExt {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_delete()
     ///    .silo_name(silo_name)
     ///    .send()
@@ -27549,7 +28269,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_identity_provider_list()
     ///    .silo_name(silo_name)
     ///    .limit(limit)
@@ -27571,7 +28296,12 @@ pub trait ClientSystemExt {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.local_idp_user_create()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -27587,7 +28317,12 @@ pub trait ClientSystemExt {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.local_idp_user_delete()
     ///    .silo_name(silo_name)
     ///    .user_id(user_id)
@@ -27608,7 +28343,12 @@ pub trait ClientSystemExt {
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.local_idp_user_set_password()
     ///    .silo_name(silo_name)
     ///    .user_id(user_id)
@@ -27625,7 +28365,12 @@ pub trait ClientSystemExt {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saml_identity_provider_create()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -27641,7 +28386,12 @@ pub trait ClientSystemExt {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `provider_name`: The SAML identity provider's name
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.saml_identity_provider_view()
     ///    .silo_name(silo_name)
     ///    .provider_name(provider_name)
@@ -27655,7 +28405,12 @@ pub trait ClientSystemExt {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_policy_view()
     ///    .silo_name(silo_name)
     ///    .send()
@@ -27669,7 +28424,12 @@ pub trait ClientSystemExt {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_policy_update()
     ///    .silo_name(silo_name)
     ///    .body(body)
@@ -27687,7 +28447,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_users_list()
     ///    .silo_name(silo_name)
     ///    .limit(limit)
@@ -27704,7 +28469,12 @@ pub trait ClientSystemExt {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.silo_user_view()
     ///    .silo_name(silo_name)
     ///    .user_id(user_id)
@@ -27721,7 +28491,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_user_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27736,7 +28511,12 @@ pub trait ClientSystemExt {
     ///
     ///Arguments:
     /// - `user_name`: The built-in user's unique name.
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_user_view()
     ///    .user_name(user_name)
     ///    .send()
@@ -27752,7 +28532,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_component_version_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27770,7 +28555,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.update_deployments_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27783,7 +28573,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/v1/system/update/deployments/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.update_deployment_view()
     ///    .id(id)
     ///    .send()
@@ -27794,7 +28589,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/v1/system/update/refresh`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_refresh()
     ///    .send()
     ///    .await;
@@ -27804,7 +28604,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/v1/system/update/start`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_start()
     ///    .body(body)
     ///    .send()
@@ -27817,7 +28622,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `POST` request to `/v1/system/update/stop`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_stop()
     ///    .send()
     ///    .await;
@@ -27832,7 +28642,12 @@ pub trait ClientSystemExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_list()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -27845,7 +28660,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/v1/system/update/updates/{version}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_view()
     ///    .version(version)
     ///    .send()
@@ -27857,7 +28677,12 @@ pub trait ClientSystemExt {
     ///Sends a `GET` request to
     /// `/v1/system/update/updates/{version}/components`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_update_components_list()
     ///    .version(version)
     ///    .send()
@@ -27868,7 +28693,12 @@ pub trait ClientSystemExt {
     ///
     ///Sends a `GET` request to `/v1/system/update/version`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.system_version()
     ///    .send()
     ///    .await;
@@ -28117,7 +28947,12 @@ pub trait ClientVpcsExt {
     ///
     ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -28128,7 +28963,12 @@ pub trait ClientVpcsExt {
     ///
     ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -28139,7 +28979,12 @@ pub trait ClientVpcsExt {
     ///
     ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -28150,7 +28995,12 @@ pub trait ClientVpcsExt {
     ///
     ///Sends a `GET` request to `/by-id/vpcs/{id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_view_by_id()
     ///    .id(id)
     ///    .send()
@@ -28169,7 +29019,12 @@ pub trait ClientVpcsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28189,7 +29044,12 @@ pub trait ClientVpcsExt {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28204,7 +29064,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28219,7 +29084,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28235,7 +29105,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28250,7 +29125,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_firewall_rules_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28265,7 +29145,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_firewall_rules_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28289,7 +29174,12 @@ pub trait ClientVpcsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28307,7 +29197,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28323,7 +29218,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28339,7 +29239,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28356,7 +29261,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28383,7 +29293,12 @@ pub trait ClientVpcsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28402,7 +29317,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28419,7 +29339,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28436,7 +29361,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28454,7 +29384,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_router_route_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28479,7 +29414,12 @@ pub trait ClientVpcsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_list()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28497,7 +29437,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_create()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28513,7 +29458,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_view()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28529,7 +29479,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_update()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28546,7 +29501,12 @@ pub trait ClientVpcsExt {
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_delete()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28571,7 +29531,12 @@ pub trait ClientVpcsExt {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.vpc_subnet_list_network_interfaces()
     ///    .organization_name(organization_name)
     ///    .project_name(project_name)
@@ -28741,6 +29706,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -28812,6 +29782,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/images/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -28883,6 +29858,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -28955,6 +29935,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/network-interfaces/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -29028,6 +30013,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29099,6 +30089,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29170,6 +30165,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29241,6 +30241,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29312,6 +30317,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29383,6 +30393,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29454,6 +30469,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -29537,6 +30557,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/device/auth`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body
@@ -29609,6 +30634,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/device/confirm`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -29693,6 +30723,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/device/token`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body
@@ -29780,6 +30815,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/groups`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
@@ -29918,6 +30958,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/login`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -30015,6 +31060,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/login/{silo_name}/local`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
                 client,
@@ -30104,6 +31154,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
                 client,
@@ -30197,6 +31252,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
                 client,
@@ -30263,6 +31323,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/logout`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl);
@@ -30354,6 +31419,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
@@ -30494,6 +31564,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -30564,6 +31639,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/organizations/{organization_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -30662,6 +31742,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/organizations/{organization_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -30741,6 +31826,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -30815,6 +31905,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/organizations/{organization_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -30917,6 +32012,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/organizations/{organization_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -31036,6 +32136,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
@@ -31194,6 +32299,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -31286,6 +32396,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -31398,6 +32513,11 @@ pub mod builder {
 
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -31493,6 +32613,11 @@ pub mod builder {
 
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -31620,6 +32745,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -31793,6 +32923,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -31901,6 +33036,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks/
         /// {disk_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -32007,6 +33147,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks/
         /// {disk_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -32177,6 +33322,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/disks/
         /// {disk_name}/metrics/{metric_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
@@ -32379,6 +33529,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
@@ -32552,6 +33707,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
                 client,
@@ -32660,6 +33820,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images/
         /// {image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
                 client,
@@ -32766,6 +33931,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/images/
         /// {image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -32897,6 +34067,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
@@ -33072,6 +34247,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -33180,6 +34360,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -33286,6 +34471,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -33429,6 +34619,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -33619,6 +34814,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/disks/attach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -33752,6 +34952,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/disks/detach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -33863,6 +35068,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/external-ips`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
@@ -33993,6 +35203,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/migrate`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -34141,6 +35356,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
@@ -34336,6 +35556,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -34461,6 +35686,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces/{interface_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -34610,6 +35840,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces/{interface_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
@@ -34738,6 +35973,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/network-interfaces/{interface_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -34847,6 +36087,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/reboot`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -34992,6 +36237,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/serial-console`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
@@ -35115,6 +36365,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/serial-console/stream`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<()>> {
             let Self {
                 client,
@@ -35221,6 +36476,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/serial-console/stream_v2`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self {
                 client,
@@ -35333,6 +36593,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -35439,6 +36704,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// instances/{instance_name}/stop`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -35532,6 +36802,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -35648,6 +36923,11 @@ pub mod builder {
 
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -35783,6 +37063,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
@@ -35958,6 +37243,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
                 client,
@@ -36066,6 +37356,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots/{snapshot_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
                 client,
@@ -36172,6 +37467,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/
         /// snapshots/{snapshot_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -36302,6 +37602,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
@@ -36475,6 +37780,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
                 client,
@@ -36583,6 +37893,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
                 client,
@@ -36711,6 +38026,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
                 client,
@@ -36822,6 +38142,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -36928,6 +38253,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/firewall/rules`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
@@ -37063,6 +38393,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/firewall/rules`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
@@ -37215,6 +38550,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
@@ -37405,6 +38745,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
                 client,
@@ -37528,6 +38873,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
                 client,
@@ -37671,6 +39021,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
                 client,
@@ -37797,6 +39152,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -37955,6 +39315,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
@@ -38164,6 +39529,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
                 client,
@@ -38304,6 +39674,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
                 client,
@@ -38466,6 +39841,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
                 client,
@@ -38609,6 +39989,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -38758,6 +40143,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
@@ -38948,6 +40338,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
                 client,
@@ -39071,6 +40466,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
                 client,
@@ -39214,6 +40614,11 @@ pub mod builder {
         ///Sends a `PUT` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
                 client,
@@ -39340,6 +40745,11 @@ pub mod builder {
         ///Sends a `DELETE` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -39498,6 +40908,11 @@ pub mod builder {
         ///Sends a `GET` request to
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
         /// {vpc_name}/subnets/{subnet_name}/network-interfaces`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
@@ -39630,6 +41045,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -39708,6 +41128,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -39792,6 +41217,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/roles`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
@@ -39916,6 +41346,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/roles/{role_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
@@ -39973,6 +41408,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl);
@@ -40064,6 +41504,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me/groups`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
@@ -40217,6 +41662,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me/sshkeys`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
@@ -40355,6 +41805,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/session/me/sshkeys`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -40425,6 +41880,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
                 client,
@@ -40499,6 +41959,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -40573,6 +42038,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -40644,6 +42114,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -40715,6 +42190,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
@@ -40811,6 +42291,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/certificates`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
@@ -40951,6 +42436,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/certificates`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -41021,6 +42511,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/certificates/{certificate}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
                 client,
@@ -41095,6 +42590,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -41194,6 +42694,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
@@ -41347,6 +42852,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/racks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
@@ -41475,6 +42985,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
@@ -41571,6 +43086,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/sleds`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
@@ -41699,6 +43219,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
@@ -41807,6 +43332,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
@@ -41966,6 +43496,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
@@ -42106,6 +43641,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/images`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -42176,6 +43716,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/images/{image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
@@ -42247,6 +43792,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/images/{image_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
@@ -42343,6 +43893,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
@@ -42481,6 +44036,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -42551,6 +44111,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
@@ -42644,6 +44209,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
                 client,
@@ -42723,6 +44293,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
@@ -42818,6 +44393,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}/ranges`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
@@ -42960,6 +44540,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
                 client,
@@ -43050,6 +44635,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/system/ip-pools/{pool_name}/ranges/remove`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -43113,6 +44703,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl);
@@ -43191,6 +44786,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service/ranges`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
@@ -43315,6 +44915,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -43383,6 +44988,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -43515,6 +45125,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/metrics/{metric_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
@@ -43598,6 +45213,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
@@ -43676,6 +45296,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/system/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
@@ -43773,6 +45398,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/sagas`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
@@ -43901,6 +45531,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
@@ -43997,6 +45632,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
@@ -44135,6 +45775,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/system/silos`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -44205,6 +45850,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
@@ -44276,6 +45926,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
@@ -44385,6 +46040,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/system/silos/{silo_name}/identity-providers`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
@@ -44544,6 +46204,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/system/silos/{silo_name}/identity-providers/local/users`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
                 client,
@@ -44636,6 +46301,11 @@ pub mod builder {
 
         ///Sends a `DELETE` request to
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -44739,6 +46409,11 @@ pub mod builder {
         ///Sends a `POST` request to
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}/
         /// set-password`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -44847,6 +46522,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/system/silos/{silo_name}/identity-providers/saml`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
@@ -44943,6 +46623,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/system/silos/{silo_name}/identity-providers/saml/{provider_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
@@ -45022,6 +46707,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos/{silo_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -45117,6 +46807,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/system/silos/{silo_name}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -45235,6 +46930,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/silos/{silo_name}/users/all`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
@@ -45382,6 +47082,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/system/silos/{silo_name}/users/id/{user_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
                 client,
@@ -45484,6 +47189,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/user`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
@@ -45612,6 +47322,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/system/user/{user_name}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
@@ -45695,6 +47410,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/timeseries/schema`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
@@ -45845,6 +47565,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/users`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
@@ -46024,6 +47749,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -46198,6 +47928,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -46306,6 +48041,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/disks/{disk}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -46415,6 +48155,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -46549,6 +48294,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
@@ -46723,6 +48473,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -46831,6 +48586,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances/{instance}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -46940,6 +48700,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -47086,6 +48851,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances/{instance}/disks`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
@@ -47279,6 +49049,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -47415,6 +49190,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
                 client,
@@ -47551,6 +49331,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -47665,6 +49450,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -47813,6 +49603,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/instances/{instance}/serial-console`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
@@ -47940,6 +49735,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/v1/instances/{instance}/serial-console/stream`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self {
                 client,
@@ -48055,6 +49855,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -48164,6 +49969,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
                 client,
@@ -48272,6 +50082,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
@@ -48412,6 +50227,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/organizations`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body
@@ -48482,6 +50302,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/organizations/{organization}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -48580,6 +50405,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
                 client,
@@ -48659,6 +50489,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -48733,6 +50568,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/organizations/{organization}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -48835,6 +50675,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/organizations/{organization}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
@@ -48954,6 +50799,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
@@ -49111,6 +50961,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/projects`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -49203,6 +51058,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/projects/{project}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -49318,6 +51178,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/projects/{project}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
                 client,
@@ -49416,6 +51281,11 @@ pub mod builder {
         }
 
         ///Sends a `DELETE` request to `/v1/projects/{project}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -49509,6 +51379,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/projects/{project}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -49628,6 +51503,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/v1/projects/{project}/policy`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
@@ -49740,6 +51620,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/components`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
@@ -49895,6 +51780,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/deployments`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
@@ -50024,6 +51914,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/deployments/{id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
@@ -50083,6 +51978,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl);
@@ -50161,6 +52061,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/system/update/start`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
@@ -50219,6 +52124,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl);
@@ -50310,6 +52220,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/updates`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
@@ -50438,6 +52353,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
             let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
@@ -50510,6 +52430,11 @@ pub mod builder {
 
         ///Sends a `GET` request to
         /// `/v1/system/update/updates/{version}/components`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
@@ -50569,6 +52494,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -28692,6 +28692,10 @@ impl ClientVpcsExt for Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12951,6 +12951,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -13734,6 +13734,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn group_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -14083,6 +14087,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn organization_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -14533,6 +14541,10 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn project_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14893,6 +14905,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn disk_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15209,6 +15225,10 @@ impl Client {
     /// - `end_time`: An exclusive end time of metrics.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `start_time`: An inclusive start time of metrics.
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn disk_metrics_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15352,6 +15372,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn image_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15658,6 +15682,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15970,6 +15998,10 @@ impl Client {
     /// - `instance_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_disk_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16349,6 +16381,10 @@ impl Client {
     /// - `instance_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_network_interface_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17241,6 +17277,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn snapshot_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17542,6 +17582,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18023,6 +18067,10 @@ impl Client {
     /// - `vpc_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_router_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18410,6 +18458,10 @@ impl Client {
     /// - `router_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_router_route_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18799,6 +18851,10 @@ impl Client {
     /// - `vpc_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_subnet_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -19182,6 +19238,10 @@ impl Client {
     /// - `subnet_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_subnet_list_network_interfaces_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -19395,6 +19455,10 @@ impl Client {
     ///
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn role_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19595,6 +19659,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn session_me_groups_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19699,6 +19767,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn session_sshkey_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20124,6 +20196,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn certificate_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20385,6 +20461,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn physical_disk_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20486,6 +20566,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn rack_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20640,6 +20724,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn sled_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20802,6 +20890,10 @@ impl Client {
     /// - `sled_id`: The sled's unique ID.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn sled_physical_disk_list_stream<'a>(
         &'a self,
         sled_id: &'a ::uuid::Uuid,
@@ -20912,6 +21004,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_image_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21175,6 +21271,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn ip_pool_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21489,6 +21589,10 @@ impl Client {
     ///Arguments:
     /// - `pool_name`
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn ip_pool_range_list_stream<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -21745,6 +21849,10 @@ impl Client {
     ///
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn ip_pool_service_range_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22115,6 +22223,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn saga_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22271,6 +22383,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn silo_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22540,6 +22656,10 @@ impl Client {
     /// - `silo_name`: The silo's unique name.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn silo_identity_provider_list_stream<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -23061,6 +23181,10 @@ impl Client {
     /// - `silo_name`: The silo's unique name.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn silo_users_list_stream<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -23219,6 +23343,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_user_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23370,6 +23498,10 @@ impl Client {
     ///
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn timeseries_schema_get_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23470,6 +23602,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn user_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23581,6 +23717,10 @@ impl Client {
     /// - `organization`
     /// - `project`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn disk_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23868,6 +24008,10 @@ impl Client {
     /// - `organization`
     /// - `project`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24163,6 +24307,10 @@ impl Client {
     /// - `organization`
     /// - `project`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_disk_list_v1_stream<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -24785,6 +24933,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn organization_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25206,6 +25358,10 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `organization`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn project_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25650,6 +25806,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_component_version_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25751,6 +25911,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn update_deployments_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -26049,6 +26213,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_update_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12866,7 +12866,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Oxide Region API
+///Client for `Oxide Region API`
 ///
 ///API for interacting with the Oxide control plane
 ///

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12949,6 +12949,12 @@ impl Client {
     ///Use `GET /v1/disks/{disk}` instead
     ///
     ///Sends a `GET` request to `/by-id/disks/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -12995,6 +13001,12 @@ impl Client {
     ///Fetch an image by id
     ///
     ///Sends a `GET` request to `/by-id/images/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13041,6 +13053,12 @@ impl Client {
     ///Fetch an instance by id
     ///
     ///Sends a `GET` request to `/by-id/instances/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13087,6 +13105,12 @@ impl Client {
     ///Fetch a network interface by id
     ///
     ///Sends a `GET` request to `/by-id/network-interfaces/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13135,6 +13159,12 @@ impl Client {
     ///Use `GET /v1/organizations/{organization}` instead
     ///
     ///Sends a `GET` request to `/by-id/organizations/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13183,6 +13213,12 @@ impl Client {
     ///Use `GET /v1/projects/{project}` instead
     ///
     ///Sends a `GET` request to `/by-id/projects/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13229,6 +13265,12 @@ impl Client {
     ///Fetch a snapshot by id
     ///
     ///Sends a `GET` request to `/by-id/snapshots/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13275,6 +13317,12 @@ impl Client {
     ///Fetch a route by id
     ///
     ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13321,6 +13369,12 @@ impl Client {
     ///Get a router by id
     ///
     ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13367,6 +13421,12 @@ impl Client {
     ///Fetch a subnet by id
     ///
     ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13413,6 +13473,12 @@ impl Client {
     ///Fetch a VPC
     ///
     ///Sends a `GET` request to `/by-id/vpcs/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13463,6 +13529,12 @@ impl Client {
     /// must be verified and confirmed prior to a token being granted.
     ///
     ///Sends a `POST` request to `/device/auth`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn device_auth_request<'a>(
         &'a self,
         body: &'a types::DeviceAuthRequest,
@@ -13501,6 +13573,12 @@ impl Client {
     /// `/device/token`.
     ///
     ///Sends a `POST` request to `/device/confirm`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn device_auth_confirm<'a>(
         &'a self,
         body: &'a types::DeviceAuthVerify,
@@ -13547,6 +13625,12 @@ impl Client {
     /// verified and the grant is confirmed.
     ///
     ///Sends a `POST` request to `/device/token`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn device_access_token<'a>(
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
@@ -13586,6 +13670,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn group_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -13673,6 +13762,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/login`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_spoof<'a>(
         &'a self,
         body: &'a types::SpoofLoginBody,
@@ -13716,6 +13811,12 @@ impl Client {
     ///Authenticate a user (i.e., log in) via username and password
     ///
     ///Sends a `POST` request to `/login/{silo_name}/local`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_local<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -13763,6 +13864,12 @@ impl Client {
     /// them to their identity provider.
     ///
     ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_saml_begin<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -13803,6 +13910,12 @@ impl Client {
     ///Authenticate a user (i.e., log in) via SAML
     ///
     ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_saml<'a, B: Into<reqwest::Body>>(
         &'a self,
         silo_name: &'a types::Name,
@@ -13851,6 +13964,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/logout`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/logout", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
@@ -13898,6 +14017,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -13992,6 +14116,12 @@ impl Client {
     ///Use `POST /v1/organizations` instead
     ///
     ///Sends a `POST` request to `/organizations`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_create<'a>(
         &'a self,
         body: &'a types::OrganizationCreate,
@@ -14040,6 +14170,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14092,6 +14227,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14145,6 +14285,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14196,6 +14341,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14248,6 +14398,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14305,6 +14460,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14410,6 +14570,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14465,6 +14630,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14521,6 +14691,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14578,6 +14753,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14637,6 +14817,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14752,6 +14937,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14806,6 +14996,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14858,6 +15054,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14921,6 +15123,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_metrics_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15068,6 +15275,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15186,6 +15398,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15240,6 +15457,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15296,6 +15519,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15355,6 +15584,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15471,6 +15705,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15525,6 +15764,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15577,6 +15822,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15640,6 +15891,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15765,6 +16021,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/attach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_attach<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15821,6 +16083,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/detach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_detach<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15875,6 +16143,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/external-ips`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_external_ip_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15929,6 +16203,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/migrate`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_migrate<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15992,6 +16272,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16114,6 +16399,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16168,6 +16459,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16222,6 +16519,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16283,6 +16586,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16339,6 +16648,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/reboot`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_reboot<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16409,6 +16724,11 @@ impl Client {
     ///   read, counting *backward* from the most recently buffered data
     ///   retrieved from the instance. (See note on `from_start` about mutual
     ///   exclusivity)
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16475,6 +16795,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16529,6 +16855,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream_v2`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_stream_v2<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16589,6 +16921,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/start`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_start<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16643,6 +16981,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/stop`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_stop<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16700,6 +17044,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16754,6 +17103,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16813,6 +17167,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16929,6 +17288,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16981,6 +17345,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17033,6 +17403,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17092,6 +17468,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17205,6 +17586,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17257,6 +17643,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17309,6 +17701,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17363,6 +17761,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17415,6 +17819,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_firewall_rules_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17467,6 +17877,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_firewall_rules_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17530,6 +17946,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17652,6 +18073,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17706,6 +18133,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17760,6 +18193,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17816,6 +18255,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17882,6 +18327,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18013,6 +18463,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18069,6 +18525,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18125,6 +18587,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18183,6 +18651,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18248,6 +18722,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18370,6 +18849,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18424,6 +18909,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18478,6 +18969,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18534,6 +19031,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18598,6 +19101,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_list_network_interfaces<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18725,6 +19233,12 @@ impl Client {
     ///Fetch the current silo's IAM policy
     ///
     ///Sends a `GET` request to `/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -18766,6 +19280,12 @@ impl Client {
     ///Update the current silo's IAM policy
     ///
     ///Sends a `PUT` request to `/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn policy_update<'a>(
         &'a self,
         body: &'a types::SiloRolePolicy,
@@ -18814,6 +19334,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn role_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -18902,6 +19427,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `role_name`: The built-in role's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn role_view<'a>(
         &'a self,
         role_name: &'a str,
@@ -18948,6 +19478,12 @@ impl Client {
     ///Fetch the user associated with the current session
     ///
     ///Sends a `GET` request to `/session/me`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
@@ -18995,6 +19531,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_me_groups<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19092,6 +19633,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19185,6 +19731,12 @@ impl Client {
     ///Create an SSH public key for the currently authenticated user.
     ///
     ///Sends a `POST` request to `/session/me/sshkeys`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_create<'a>(
         &'a self,
         body: &'a types::SshKeyCreate,
@@ -19231,6 +19783,12 @@ impl Client {
     /// user.
     ///
     ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_view<'a>(
         &'a self,
         ssh_key_name: &'a types::Name,
@@ -19280,6 +19838,12 @@ impl Client {
     /// user.
     ///
     ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_delete<'a>(
         &'a self,
         ssh_key_name: &'a types::Name,
@@ -19326,6 +19890,12 @@ impl Client {
     ///Fetch a system-wide image by id
     ///
     ///Sends a `GET` request to `/system/by-id/images/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -19372,6 +19942,12 @@ impl Client {
     ///Fetch an IP pool by id
     ///
     ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -19418,6 +19994,12 @@ impl Client {
     ///Fetch a silo by id
     ///
     ///Sends a `GET` request to `/system/by-id/silos/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -19474,6 +20056,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19571,6 +20158,12 @@ impl Client {
     /// serve external connections.
     ///
     ///Sends a `POST` request to `/system/certificates`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_create<'a>(
         &'a self,
         body: &'a types::CertificateCreate,
@@ -19616,6 +20209,12 @@ impl Client {
     ///Returns the details of a specific certificate
     ///
     ///Sends a `GET` request to `/system/certificates/{certificate}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_view<'a>(
         &'a self,
         certificate: &'a types::NameOrId,
@@ -19664,6 +20263,12 @@ impl Client {
     ///Permanently delete a certificate. This operation cannot be undone.
     ///
     ///Sends a `DELETE` request to `/system/certificates/{certificate}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_delete<'a>(
         &'a self,
         certificate: &'a types::NameOrId,
@@ -19716,6 +20321,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn physical_disk_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19812,6 +20422,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn rack_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19904,6 +20519,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `rack_id`: The rack's unique ID.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn rack_view<'a>(
         &'a self,
         rack_id: &'a ::uuid::Uuid,
@@ -19956,6 +20576,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn sled_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20048,6 +20673,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `sled_id`: The sled's unique ID.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn sled_view<'a>(
         &'a self,
         sled_id: &'a ::uuid::Uuid,
@@ -20101,6 +20731,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn sled_physical_disk_list<'a>(
         &'a self,
         sled_id: &'a ::uuid::Uuid,
@@ -20209,6 +20844,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20306,6 +20946,12 @@ impl Client {
     /// in any silo as a base for instances.
     ///
     ///Sends a `POST` request to `/system/images`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_create<'a>(
         &'a self,
         body: &'a types::GlobalImageCreate,
@@ -20351,6 +20997,12 @@ impl Client {
     ///Returns the details of a specific system-wide image.
     ///
     ///Sends a `GET` request to `/system/images/{image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_view<'a>(
         &'a self,
         image_name: &'a types::Name,
@@ -20401,6 +21053,12 @@ impl Client {
     /// new instances can not be created with this image.
     ///
     ///Sends a `DELETE` request to `/system/images/{image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_delete<'a>(
         &'a self,
         image_name: &'a types::Name,
@@ -20453,6 +21111,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20542,6 +21205,12 @@ impl Client {
     ///Create an IP pool
     ///
     ///Sends a `POST` request to `/system/ip-pools`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_create<'a>(
         &'a self,
         body: &'a types::IpPoolCreate,
@@ -20585,6 +21254,12 @@ impl Client {
     ///Fetch an IP pool
     ///
     ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_view<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20631,6 +21306,12 @@ impl Client {
     ///Update an IP Pool
     ///
     ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_update<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20679,6 +21360,12 @@ impl Client {
     ///Delete an IP Pool
     ///
     ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_delete<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20733,6 +21420,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_range_list<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20828,6 +21520,12 @@ impl Client {
     ///Add a range to an IP pool
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_range_add<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20876,6 +21574,12 @@ impl Client {
     ///Remove a range from an IP pool
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/remove`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_range_remove<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20924,6 +21628,12 @@ impl Client {
     ///Fetch the IP pool used for Oxide services
     ///
     ///Sends a `GET` request to `/system/ip-pools-service`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
@@ -20972,6 +21682,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_range_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21060,6 +21775,12 @@ impl Client {
     ///Add a range to an IP pool used for Oxide services
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_range_add<'a>(
         &'a self,
         body: &'a types::IpRange,
@@ -21103,6 +21824,12 @@ impl Client {
     ///Remove a range from an IP pool used for Oxide services
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_range_remove<'a>(
         &'a self,
         body: &'a types::IpRange,
@@ -21155,6 +21882,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_metric<'a>(
         &'a self,
         metric_name: types::SystemMetricName,
@@ -21217,6 +21949,12 @@ impl Client {
     ///Fetch the top-level IAM policy
     ///
     ///Sends a `GET` request to `/system/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
@@ -21258,6 +21996,12 @@ impl Client {
     ///Update the top-level IAM policy
     ///
     ///Sends a `PUT` request to `/system/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_policy_update<'a>(
         &'a self,
         body: &'a types::FleetRolePolicy,
@@ -21307,6 +22051,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saga_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21396,6 +22145,12 @@ impl Client {
     ///Fetch a saga
     ///
     ///Sends a `GET` request to `/system/sagas/{saga_id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saga_view<'a>(
         &'a self,
         saga_id: &'a ::uuid::Uuid,
@@ -21450,6 +22205,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21541,6 +22301,12 @@ impl Client {
     ///Create a silo
     ///
     ///Sends a `POST` request to `/system/silos`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_create<'a>(
         &'a self,
         body: &'a types::SiloCreate,
@@ -21589,6 +22355,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21640,6 +22411,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_delete<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21693,6 +22469,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_identity_provider_list<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21800,6 +22581,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn local_idp_user_create<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21853,6 +22639,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn local_idp_user_delete<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21911,6 +22702,11 @@ impl Client {
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn local_idp_user_set_password<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21966,6 +22762,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saml_identity_provider_create<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22019,6 +22820,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `provider_name`: The SAML identity provider's name
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saml_identity_provider_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22070,6 +22876,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_policy_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22120,6 +22931,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_policy_update<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22175,6 +22991,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_users_list<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22275,6 +23096,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_user_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22329,6 +23155,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_user_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22422,6 +23253,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `user_name`: The built-in user's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_user_view<'a>(
         &'a self,
         user_name: &'a types::Name,
@@ -22473,6 +23309,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn timeseries_schema_get<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22565,6 +23406,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn user_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22662,6 +23508,11 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22762,6 +23613,12 @@ impl Client {
     ///Create a disk
     ///
     ///Sends a `POST` request to `/v1/disks`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_create_v1<'a>(
         &'a self,
         organization: Option<&'a types::NameOrId>,
@@ -22812,6 +23669,12 @@ impl Client {
     ///Fetch a disk
     ///
     ///Sends a `GET` request to `/v1/disks/{disk}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_view_v1<'a>(
         &'a self,
         disk: &'a types::NameOrId,
@@ -22865,6 +23728,12 @@ impl Client {
     ///Delete a disk
     ///
     ///Sends a `DELETE` request to `/v1/disks/{disk}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_delete_v1<'a>(
         &'a self,
         disk: &'a types::NameOrId,
@@ -22926,6 +23795,11 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23027,6 +23901,12 @@ impl Client {
     ///Create an instance
     ///
     ///Sends a `POST` request to `/v1/instances`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_create_v1<'a>(
         &'a self,
         organization: Option<&'a types::NameOrId>,
@@ -23077,6 +23957,12 @@ impl Client {
     ///Fetch an instance
     ///
     ///Sends a `GET` request to `/v1/instances/{instance}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_view_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23130,6 +24016,12 @@ impl Client {
     ///Delete an instance
     ///
     ///Sends a `DELETE` request to `/v1/instances/{instance}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_delete_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23192,6 +24084,11 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_list_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23306,6 +24203,12 @@ impl Client {
     ///Attach a disk to an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_attach_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23361,6 +24264,12 @@ impl Client {
     ///Detach a disk from an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_detach_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23416,6 +24325,12 @@ impl Client {
     ///Migrate an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_migrate_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23471,6 +24386,12 @@ impl Client {
     ///Reboot an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_reboot_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23540,6 +24461,11 @@ impl Client {
     ///   exclusivity)
     /// - `organization`
     /// - `project`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23606,6 +24532,12 @@ impl Client {
     ///
     ///Sends a `GET` request to
     /// `/v1/instances/{instance}/serial-console/stream`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_stream_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23665,6 +24597,12 @@ impl Client {
     ///Boot an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/start`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_start_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23718,6 +24656,12 @@ impl Client {
     ///Stop an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/stop`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_stop_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23777,6 +24721,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23867,6 +24816,12 @@ impl Client {
     ///Create an organization
     ///
     ///Sends a `POST` request to `/v1/organizations`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_create_v1<'a>(
         &'a self,
         body: &'a types::OrganizationCreate,
@@ -23910,6 +24865,12 @@ impl Client {
     ///Fetch an organization
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_view_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -23956,6 +24917,12 @@ impl Client {
     ///Update an organization
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_update_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24004,6 +24971,12 @@ impl Client {
     ///Delete an organization
     ///
     ///Sends a `DELETE` request to `/v1/organizations/{organization}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_delete_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24050,6 +25023,12 @@ impl Client {
     ///Fetch an organization's IAM policy
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_view_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24096,6 +25075,12 @@ impl Client {
     ///Update an organization's IAM policy
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_update_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24151,6 +25136,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24247,6 +25237,12 @@ impl Client {
     ///Create a project
     ///
     ///Sends a `POST` request to `/v1/projects`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_create_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24295,6 +25291,12 @@ impl Client {
     ///Fetch a project
     ///
     ///Sends a `GET` request to `/v1/projects/{project}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_view_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24346,6 +25348,12 @@ impl Client {
     ///Update a project
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_update_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24399,6 +25407,12 @@ impl Client {
     ///Delete a project
     ///
     ///Sends a `DELETE` request to `/v1/projects/{project}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_delete_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24450,6 +25464,12 @@ impl Client {
     ///Fetch a project's IAM policy
     ///
     ///Sends a `GET` request to `/v1/projects/{project}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_view_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24501,6 +25521,12 @@ impl Client {
     ///Update a project's IAM policy
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_update_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24560,6 +25586,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_component_version_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24656,6 +25687,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn update_deployments_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24746,6 +25782,12 @@ impl Client {
     ///Fetch a system update deployment
     ///
     ///Sends a `GET` request to `/v1/system/update/deployments/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn update_deployment_view<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -24792,6 +25834,12 @@ impl Client {
     ///Refresh update data
     ///
     ///Sends a `POST` request to `/v1/system/update/refresh`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_refresh<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
@@ -24833,6 +25881,12 @@ impl Client {
     ///Start system update
     ///
     ///Sends a `POST` request to `/v1/system/update/start`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_start<'a>(
         &'a self,
         body: &'a types::SystemUpdateStart,
@@ -24878,6 +25932,12 @@ impl Client {
     ///If there is no update in progress, do nothing.
     ///
     ///Sends a `POST` request to `/v1/system/update/stop`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_stop<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
@@ -24925,6 +25985,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25015,6 +26080,12 @@ impl Client {
     ///View system update
     ///
     ///Sends a `GET` request to `/v1/system/update/updates/{version}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_view<'a>(
         &'a self,
         version: &'a types::SemverVersion,
@@ -25062,6 +26133,12 @@ impl Client {
     ///
     ///Sends a `GET` request to
     /// `/v1/system/update/updates/{version}/components`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_components_list<'a>(
         &'a self,
         version: &'a types::SemverVersion,
@@ -25108,6 +26185,12 @@ impl Client {
     ///View system version and update status
     ///
     ///Sends a `GET` request to `/v1/system/update/version`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_version<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12956,7 +12956,7 @@ impl Client {
         let url = format!(
             "{}/by-id/disks/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13002,7 +13002,7 @@ impl Client {
         let url = format!(
             "{}/by-id/images/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13048,7 +13048,7 @@ impl Client {
         let url = format!(
             "{}/by-id/instances/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13094,7 +13094,7 @@ impl Client {
         let url = format!(
             "{}/by-id/network-interfaces/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13142,7 +13142,7 @@ impl Client {
         let url = format!(
             "{}/by-id/organizations/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13190,7 +13190,7 @@ impl Client {
         let url = format!(
             "{}/by-id/projects/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13236,7 +13236,7 @@ impl Client {
         let url = format!(
             "{}/by-id/snapshots/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13282,7 +13282,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpc-router-routes/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13328,7 +13328,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpc-routers/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13374,7 +13374,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpc-subnets/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13420,7 +13420,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpcs/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13467,7 +13467,7 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/auth", self.baseurl,);
+        let url = format!("{}/device/auth", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13505,7 +13505,7 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/device/confirm", self.baseurl,);
+        let url = format!("{}/device/confirm", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13551,7 +13551,7 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/token", self.baseurl,);
+        let url = format!("{}/device/token", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13592,7 +13592,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let url = format!("{}/groups", self.baseurl,);
+        let url = format!("{}/groups", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13677,7 +13677,7 @@ impl Client {
         &'a self,
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/login", self.baseurl,);
+        let url = format!("{}/login", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13724,7 +13724,7 @@ impl Client {
         let url = format!(
             "{}/login/{}/local",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13772,7 +13772,7 @@ impl Client {
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
+            encode_path(&provider_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13813,7 +13813,7 @@ impl Client {
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
+            encode_path(&provider_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13852,7 +13852,7 @@ impl Client {
 
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/logout", self.baseurl,);
+        let url = format!("{}/logout", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13904,7 +13904,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
+        let url = format!("{}/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13996,7 +13996,7 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
+        let url = format!("{}/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -14047,7 +14047,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14100,7 +14100,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14152,7 +14152,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14203,7 +14203,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14256,7 +14256,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14315,7 +14315,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14418,7 +14418,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14474,7 +14474,7 @@ impl Client {
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14531,7 +14531,7 @@ impl Client {
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14587,7 +14587,7 @@ impl Client {
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14649,7 +14649,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14762,7 +14762,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14817,7 +14817,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&disk_name.to_string()),
+            encode_path(&disk_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14869,7 +14869,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&disk_name.to_string()),
+            encode_path(&disk_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14938,7 +14938,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
-            encode_path(&metric_name.to_string()),
+            encode_path(&metric_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15080,7 +15080,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15196,7 +15196,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15251,7 +15251,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15307,7 +15307,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15367,7 +15367,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15481,7 +15481,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15536,7 +15536,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15588,7 +15588,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15654,7 +15654,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15777,7 +15777,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15833,7 +15833,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15886,7 +15886,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15941,7 +15941,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16006,7 +16006,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16126,7 +16126,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16181,7 +16181,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
+            encode_path(&interface_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16236,7 +16236,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
+            encode_path(&interface_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16296,7 +16296,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
+            encode_path(&interface_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16350,7 +16350,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16423,7 +16423,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16486,7 +16486,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16540,7 +16540,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16600,7 +16600,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16654,7 +16654,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16709,7 +16709,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16764,7 +16764,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16825,7 +16825,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16939,7 +16939,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16992,7 +16992,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&snapshot_name.to_string()),
+            encode_path(&snapshot_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17044,7 +17044,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&snapshot_name.to_string()),
+            encode_path(&snapshot_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17104,7 +17104,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17215,7 +17215,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17268,7 +17268,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17321,7 +17321,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17374,7 +17374,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17426,7 +17426,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17479,7 +17479,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17544,7 +17544,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17664,7 +17664,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17719,7 +17719,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17774,7 +17774,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17829,7 +17829,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17898,7 +17898,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18027,7 +18027,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18084,7 +18084,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
+            encode_path(&route_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18141,7 +18141,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
+            encode_path(&route_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18198,7 +18198,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
+            encode_path(&route_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18262,7 +18262,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18382,7 +18382,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18437,7 +18437,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18492,7 +18492,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18547,7 +18547,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18614,7 +18614,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18728,7 +18728,7 @@ impl Client {
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
+        let url = format!("{}/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -18770,7 +18770,7 @@ impl Client {
         &'a self,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
+        let url = format!("{}/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -18819,7 +18819,7 @@ impl Client {
         limit: Option<::std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
-        let url = format!("{}/roles", self.baseurl,);
+        let url = format!("{}/roles", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -18909,7 +18909,7 @@ impl Client {
         let url = format!(
             "{}/roles/{}",
             self.baseurl,
-            encode_path(&role_name.to_string()),
+            encode_path(&role_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18951,7 +18951,7 @@ impl Client {
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let url = format!("{}/session/me", self.baseurl,);
+        let url = format!("{}/session/me", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19001,7 +19001,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let url = format!("{}/session/me/groups", self.baseurl,);
+        let url = format!("{}/session/me/groups", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19098,7 +19098,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let url = format!("{}/session/me/sshkeys", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19189,7 +19189,7 @@ impl Client {
         &'a self,
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let url = format!("{}/session/me/sshkeys", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19238,7 +19238,7 @@ impl Client {
         let url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
-            encode_path(&ssh_key_name.to_string()),
+            encode_path(&ssh_key_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19287,7 +19287,7 @@ impl Client {
         let url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
-            encode_path(&ssh_key_name.to_string()),
+            encode_path(&ssh_key_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19333,7 +19333,7 @@ impl Client {
         let url = format!(
             "{}/system/by-id/images/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19379,7 +19379,7 @@ impl Client {
         let url = format!(
             "{}/system/by-id/ip-pools/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19425,7 +19425,7 @@ impl Client {
         let url = format!(
             "{}/system/by-id/silos/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19480,7 +19480,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/certificates", self.baseurl,);
+        let url = format!("{}/system/certificates", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19575,7 +19575,7 @@ impl Client {
         &'a self,
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let url = format!("{}/system/certificates", self.baseurl,);
+        let url = format!("{}/system/certificates", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19623,7 +19623,7 @@ impl Client {
         let url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
-            encode_path(&certificate.to_string()),
+            encode_path(&certificate.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19671,7 +19671,7 @@ impl Client {
         let url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
-            encode_path(&certificate.to_string()),
+            encode_path(&certificate.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19722,7 +19722,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/disks", self.baseurl,);
+        let url = format!("{}/system/hardware/disks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19818,7 +19818,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/racks", self.baseurl,);
+        let url = format!("{}/system/hardware/racks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19911,7 +19911,7 @@ impl Client {
         let url = format!(
             "{}/system/hardware/racks/{}",
             self.baseurl,
-            encode_path(&rack_id.to_string()),
+            encode_path(&rack_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19962,7 +19962,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/sleds", self.baseurl,);
+        let url = format!("{}/system/hardware/sleds", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20055,7 +20055,7 @@ impl Client {
         let url = format!(
             "{}/system/hardware/sleds/{}",
             self.baseurl,
-            encode_path(&sled_id.to_string()),
+            encode_path(&sled_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20111,7 +20111,7 @@ impl Client {
         let url = format!(
             "{}/system/hardware/sleds/{}/disks",
             self.baseurl,
-            encode_path(&sled_id.to_string()),
+            encode_path(&sled_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20215,7 +20215,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/images", self.baseurl,);
+        let url = format!("{}/system/images", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20310,7 +20310,7 @@ impl Client {
         &'a self,
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!("{}/system/images", self.baseurl,);
+        let url = format!("{}/system/images", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20358,7 +20358,7 @@ impl Client {
         let url = format!(
             "{}/system/images/{}",
             self.baseurl,
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20408,7 +20408,7 @@ impl Client {
         let url = format!(
             "{}/system/images/{}",
             self.baseurl,
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20459,7 +20459,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools", self.baseurl,);
+        let url = format!("{}/system/ip-pools", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20546,7 +20546,7 @@ impl Client {
         &'a self,
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools", self.baseurl,);
+        let url = format!("{}/system/ip-pools", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20592,7 +20592,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20639,7 +20639,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20686,7 +20686,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20742,7 +20742,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}/ranges",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20836,7 +20836,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}/ranges/add",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20884,7 +20884,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}/ranges/remove",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20927,7 +20927,7 @@ impl Client {
     pub async fn ip_pool_service_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20977,7 +20977,7 @@ impl Client {
         limit: Option<::std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service/ranges", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21064,7 +21064,7 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21107,7 +21107,7 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21167,7 +21167,7 @@ impl Client {
         let url = format!(
             "{}/system/metrics/{}",
             self.baseurl,
-            encode_path(&metric_name.to_string()),
+            encode_path(&metric_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21220,7 +21220,7 @@ impl Client {
     pub async fn system_policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/system/policy", self.baseurl,);
+        let url = format!("{}/system/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21262,7 +21262,7 @@ impl Client {
         &'a self,
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/system/policy", self.baseurl,);
+        let url = format!("{}/system/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21313,7 +21313,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/sagas", self.baseurl,);
+        let url = format!("{}/system/sagas", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21403,7 +21403,7 @@ impl Client {
         let url = format!(
             "{}/system/sagas/{}",
             self.baseurl,
-            encode_path(&saga_id.to_string()),
+            encode_path(&saga_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21456,7 +21456,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/silos", self.baseurl,);
+        let url = format!("{}/system/silos", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21545,7 +21545,7 @@ impl Client {
         &'a self,
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let url = format!("{}/system/silos", self.baseurl,);
+        let url = format!("{}/system/silos", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21596,7 +21596,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21647,7 +21647,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21703,7 +21703,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/identity-providers",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21808,7 +21808,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/identity-providers/local/users",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21862,7 +21862,7 @@ impl Client {
             "{}/system/silos/{}/identity-providers/local/users/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&user_id.to_string()),
+            encode_path(&user_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21921,7 +21921,7 @@ impl Client {
             "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&user_id.to_string()),
+            encode_path(&user_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21974,7 +21974,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/identity-providers/saml",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22028,7 +22028,7 @@ impl Client {
             "{}/system/silos/{}/identity-providers/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
+            encode_path(&provider_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22077,7 +22077,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22128,7 +22128,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22185,7 +22185,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/users/all",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22284,7 +22284,7 @@ impl Client {
             "{}/system/silos/{}/users/id/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&user_id.to_string()),
+            encode_path(&user_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22335,7 +22335,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/user", self.baseurl,);
+        let url = format!("{}/system/user", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22429,7 +22429,7 @@ impl Client {
         let url = format!(
             "{}/system/user/{}",
             self.baseurl,
-            encode_path(&user_name.to_string()),
+            encode_path(&user_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22478,7 +22478,7 @@ impl Client {
         limit: Option<::std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/timeseries/schema", self.baseurl,);
+        let url = format!("{}/timeseries/schema", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22571,7 +22571,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let url = format!("{}/users", self.baseurl,);
+        let url = format!("{}/users", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22670,7 +22670,7 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/disks", self.baseurl,);
+        let url = format!("{}/v1/disks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22768,7 +22768,7 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!("{}/v1/disks", self.baseurl,);
+        let url = format!("{}/v1/disks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22821,7 +22821,7 @@ impl Client {
         let url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
-            encode_path(&disk.to_string()),
+            encode_path(&disk.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22874,7 +22874,7 @@ impl Client {
         let url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
-            encode_path(&disk.to_string()),
+            encode_path(&disk.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22934,7 +22934,7 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/instances", self.baseurl,);
+        let url = format!("{}/v1/instances", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23033,7 +23033,7 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!("{}/v1/instances", self.baseurl,);
+        let url = format!("{}/v1/instances", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23086,7 +23086,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23139,7 +23139,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23204,7 +23204,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/disks",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23316,7 +23316,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/disks/attach",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23371,7 +23371,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/disks/detach",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23426,7 +23426,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/migrate",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23480,7 +23480,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/reboot",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23552,7 +23552,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/serial-console",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23615,7 +23615,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/serial-console/stream",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23674,7 +23674,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/start",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23727,7 +23727,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/stop",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23783,7 +23783,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/organizations", self.baseurl,);
+        let url = format!("{}/v1/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23871,7 +23871,7 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!("{}/v1/organizations", self.baseurl,);
+        let url = format!("{}/v1/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23917,7 +23917,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23964,7 +23964,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24011,7 +24011,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24057,7 +24057,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24104,7 +24104,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24158,7 +24158,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/projects", self.baseurl,);
+        let url = format!("{}/v1/projects", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24252,7 +24252,7 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!("{}/v1/projects", self.baseurl,);
+        let url = format!("{}/v1/projects", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24303,7 +24303,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24355,7 +24355,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24407,7 +24407,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24458,7 +24458,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24510,7 +24510,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24566,7 +24566,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/components", self.baseurl,);
+        let url = format!("{}/v1/system/update/components", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24662,7 +24662,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/deployments", self.baseurl,);
+        let url = format!("{}/v1/system/update/deployments", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24753,7 +24753,7 @@ impl Client {
         let url = format!(
             "{}/v1/system/update/deployments/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24795,7 +24795,7 @@ impl Client {
     pub async fn system_update_refresh<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/refresh", self.baseurl,);
+        let url = format!("{}/v1/system/update/refresh", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24837,7 +24837,7 @@ impl Client {
         &'a self,
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/start", self.baseurl,);
+        let url = format!("{}/v1/system/update/start", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24881,7 +24881,7 @@ impl Client {
     pub async fn system_update_stop<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/stop", self.baseurl,);
+        let url = format!("{}/v1/system/update/stop", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24931,7 +24931,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/updates", self.baseurl,);
+        let url = format!("{}/v1/system/update/updates", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -25022,7 +25022,7 @@ impl Client {
         let url = format!(
             "{}/v1/system/update/updates/{}",
             self.baseurl,
-            encode_path(&version.to_string()),
+            encode_path(&version.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -25069,7 +25069,7 @@ impl Client {
         let url = format!(
             "{}/v1/system/update/updates/{}/components",
             self.baseurl,
-            encode_path(&version.to_string()),
+            encode_path(&version.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -25111,7 +25111,7 @@ impl Client {
     pub async fn system_version<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/version", self.baseurl,);
+        let url = format!("{}/v1/system/update/version", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12929,6 +12929,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Fetch a disk by id
     ///

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -13530,7 +13530,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -13702,7 +13702,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -13876,7 +13876,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -14177,7 +14177,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -14612,7 +14612,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -14894,7 +14894,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -15332,7 +15332,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -15613,7 +15613,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -16321,7 +16321,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -17069,7 +17069,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -17399,7 +17399,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -17854,7 +17854,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -18223,7 +18223,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -18572,7 +18572,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -19312,7 +19312,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -19696,7 +19696,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -20433,7 +20433,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -20711,7 +20711,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -20910,7 +20910,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21132,7 +21132,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21672,7 +21672,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21887,7 +21887,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21947,7 +21947,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -22904,7 +22904,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -23169,7 +23169,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24036,7 +24036,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24436,7 +24436,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24819,7 +24819,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24905,7 +24905,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12886,6 +12886,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12935,6 +12935,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Fetch a disk by id
     ///

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12882,6 +12882,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -12901,6 +12902,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -12944,6 +12944,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12951,6 +12951,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -13734,6 +13734,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn group_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -14083,6 +14087,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn organization_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -14533,6 +14541,10 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn project_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14893,6 +14905,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn disk_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15209,6 +15225,10 @@ impl Client {
     /// - `end_time`: An exclusive end time of metrics.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `start_time`: An inclusive start time of metrics.
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn disk_metrics_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15352,6 +15372,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn image_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15658,6 +15682,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15970,6 +15998,10 @@ impl Client {
     /// - `instance_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_disk_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16349,6 +16381,10 @@ impl Client {
     /// - `instance_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_network_interface_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17241,6 +17277,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn snapshot_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17542,6 +17582,10 @@ impl Client {
     /// - `project_name`: The project's unique name within the organization.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18023,6 +18067,10 @@ impl Client {
     /// - `vpc_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_router_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18410,6 +18458,10 @@ impl Client {
     /// - `router_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_router_route_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18799,6 +18851,10 @@ impl Client {
     /// - `vpc_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_subnet_list_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -19182,6 +19238,10 @@ impl Client {
     /// - `subnet_name`
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn vpc_subnet_list_network_interfaces_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -19395,6 +19455,10 @@ impl Client {
     ///
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn role_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19595,6 +19659,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn session_me_groups_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19699,6 +19767,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn session_sshkey_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20124,6 +20196,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn certificate_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20385,6 +20461,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn physical_disk_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20486,6 +20566,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn rack_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20640,6 +20724,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn sled_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20802,6 +20890,10 @@ impl Client {
     /// - `sled_id`: The sled's unique ID.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn sled_physical_disk_list_stream<'a>(
         &'a self,
         sled_id: &'a ::uuid::Uuid,
@@ -20912,6 +21004,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_image_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21175,6 +21271,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn ip_pool_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21489,6 +21589,10 @@ impl Client {
     ///Arguments:
     /// - `pool_name`
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn ip_pool_range_list_stream<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -21745,6 +21849,10 @@ impl Client {
     ///
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn ip_pool_service_range_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22115,6 +22223,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn saga_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22271,6 +22383,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn silo_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22540,6 +22656,10 @@ impl Client {
     /// - `silo_name`: The silo's unique name.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn silo_identity_provider_list_stream<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -23061,6 +23181,10 @@ impl Client {
     /// - `silo_name`: The silo's unique name.
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn silo_users_list_stream<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -23219,6 +23343,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_user_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23370,6 +23498,10 @@ impl Client {
     ///
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn timeseries_schema_get_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23470,6 +23602,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn user_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23581,6 +23717,10 @@ impl Client {
     /// - `organization`
     /// - `project`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn disk_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23868,6 +24008,10 @@ impl Client {
     /// - `organization`
     /// - `project`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24163,6 +24307,10 @@ impl Client {
     /// - `organization`
     /// - `project`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn instance_disk_list_v1_stream<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -24785,6 +24933,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn organization_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25206,6 +25358,10 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `organization`
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn project_list_v1_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25650,6 +25806,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_component_version_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25751,6 +25911,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn update_deployments_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -26049,6 +26213,10 @@ impl Client {
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
     /// - `sort_by`
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn system_update_list_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12866,7 +12866,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Oxide Region API
+///Client for `Oxide Region API`
 ///
 ///API for interacting with the Oxide control plane
 ///

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12949,6 +12949,12 @@ impl Client {
     ///Use `GET /v1/disks/{disk}` instead
     ///
     ///Sends a `GET` request to `/by-id/disks/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -12995,6 +13001,12 @@ impl Client {
     ///Fetch an image by id
     ///
     ///Sends a `GET` request to `/by-id/images/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13041,6 +13053,12 @@ impl Client {
     ///Fetch an instance by id
     ///
     ///Sends a `GET` request to `/by-id/instances/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13087,6 +13105,12 @@ impl Client {
     ///Fetch a network interface by id
     ///
     ///Sends a `GET` request to `/by-id/network-interfaces/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13135,6 +13159,12 @@ impl Client {
     ///Use `GET /v1/organizations/{organization}` instead
     ///
     ///Sends a `GET` request to `/by-id/organizations/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13183,6 +13213,12 @@ impl Client {
     ///Use `GET /v1/projects/{project}` instead
     ///
     ///Sends a `GET` request to `/by-id/projects/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13229,6 +13265,12 @@ impl Client {
     ///Fetch a snapshot by id
     ///
     ///Sends a `GET` request to `/by-id/snapshots/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13275,6 +13317,12 @@ impl Client {
     ///Fetch a route by id
     ///
     ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13321,6 +13369,12 @@ impl Client {
     ///Get a router by id
     ///
     ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13367,6 +13421,12 @@ impl Client {
     ///Fetch a subnet by id
     ///
     ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13413,6 +13473,12 @@ impl Client {
     ///Fetch a VPC
     ///
     ///Sends a `GET` request to `/by-id/vpcs/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -13463,6 +13529,12 @@ impl Client {
     /// must be verified and confirmed prior to a token being granted.
     ///
     ///Sends a `POST` request to `/device/auth`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn device_auth_request<'a>(
         &'a self,
         body: &'a types::DeviceAuthRequest,
@@ -13501,6 +13573,12 @@ impl Client {
     /// `/device/token`.
     ///
     ///Sends a `POST` request to `/device/confirm`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn device_auth_confirm<'a>(
         &'a self,
         body: &'a types::DeviceAuthVerify,
@@ -13547,6 +13625,12 @@ impl Client {
     /// verified and the grant is confirmed.
     ///
     ///Sends a `POST` request to `/device/token`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn device_access_token<'a>(
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
@@ -13586,6 +13670,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn group_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -13673,6 +13762,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/login`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_spoof<'a>(
         &'a self,
         body: &'a types::SpoofLoginBody,
@@ -13716,6 +13811,12 @@ impl Client {
     ///Authenticate a user (i.e., log in) via username and password
     ///
     ///Sends a `POST` request to `/login/{silo_name}/local`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_local<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -13763,6 +13864,12 @@ impl Client {
     /// them to their identity provider.
     ///
     ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_saml_begin<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -13803,6 +13910,12 @@ impl Client {
     ///Authenticate a user (i.e., log in) via SAML
     ///
     ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn login_saml<'a, B: Into<reqwest::Body>>(
         &'a self,
         silo_name: &'a types::Name,
@@ -13851,6 +13964,12 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/logout`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/logout", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
@@ -13898,6 +14017,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -13992,6 +14116,12 @@ impl Client {
     ///Use `POST /v1/organizations` instead
     ///
     ///Sends a `POST` request to `/organizations`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_create<'a>(
         &'a self,
         body: &'a types::OrganizationCreate,
@@ -14040,6 +14170,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14092,6 +14227,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14145,6 +14285,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14196,6 +14341,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14248,6 +14398,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14305,6 +14460,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14410,6 +14570,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14465,6 +14630,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14521,6 +14691,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14578,6 +14753,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14637,6 +14817,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14752,6 +14937,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14806,6 +14996,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14858,6 +15054,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/disks/
     /// {disk_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -14921,6 +15123,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_metrics_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15068,6 +15275,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15186,6 +15398,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15240,6 +15457,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15296,6 +15519,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/images/
     /// {image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn image_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15355,6 +15584,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15471,6 +15705,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15525,6 +15764,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15577,6 +15822,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15640,6 +15891,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15765,6 +16021,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/attach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_attach<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15821,6 +16083,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/disks/detach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_detach<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15875,6 +16143,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/external-ips`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_external_ip_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15929,6 +16203,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/migrate`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_migrate<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -15992,6 +16272,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16114,6 +16399,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16168,6 +16459,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16222,6 +16519,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16283,6 +16586,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/network-interfaces/{interface_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_network_interface_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16339,6 +16648,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/reboot`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_reboot<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16409,6 +16724,11 @@ impl Client {
     ///   read, counting *backward* from the most recently buffered data
     ///   retrieved from the instance. (See note on `from_start` about mutual
     ///   exclusivity)
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16475,6 +16795,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16529,6 +16855,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/serial-console/stream_v2`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_stream_v2<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16589,6 +16921,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/start`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_start<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16643,6 +16981,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/instances/
     /// {instance_name}/stop`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_stop<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16700,6 +17044,11 @@ impl Client {
     ///Arguments:
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16754,6 +17103,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16813,6 +17167,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16929,6 +17288,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -16981,6 +17345,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17033,6 +17403,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/snapshots/
     /// {snapshot_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn snapshot_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17092,6 +17468,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17205,6 +17586,11 @@ impl Client {
     /// - `organization_name`: The organization's unique name.
     /// - `project_name`: The project's unique name within the organization.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17257,6 +17643,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17309,6 +17701,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17363,6 +17761,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17415,6 +17819,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_firewall_rules_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17467,6 +17877,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/firewall/rules`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_firewall_rules_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17530,6 +17946,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17652,6 +18073,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17706,6 +18133,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17760,6 +18193,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17816,6 +18255,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -17882,6 +18327,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18013,6 +18463,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18069,6 +18525,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18125,6 +18587,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18183,6 +18651,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/routers/{router_name}/routes/{route_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_router_route_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18248,6 +18722,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_list<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18370,6 +18849,12 @@ impl Client {
     ///Sends a `POST` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_create<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18424,6 +18909,12 @@ impl Client {
     ///Sends a `GET` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_view<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18478,6 +18969,12 @@ impl Client {
     ///Sends a `PUT` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_update<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18534,6 +19031,12 @@ impl Client {
     ///Sends a `DELETE` request to
     /// `/organizations/{organization_name}/projects/{project_name}/vpcs/
     /// {vpc_name}/subnets/{subnet_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_delete<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18598,6 +19101,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn vpc_subnet_list_network_interfaces<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -18725,6 +19233,12 @@ impl Client {
     ///Fetch the current silo's IAM policy
     ///
     ///Sends a `GET` request to `/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
@@ -18766,6 +19280,12 @@ impl Client {
     ///Update the current silo's IAM policy
     ///
     ///Sends a `PUT` request to `/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn policy_update<'a>(
         &'a self,
         body: &'a types::SiloRolePolicy,
@@ -18814,6 +19334,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn role_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -18902,6 +19427,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `role_name`: The built-in role's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn role_view<'a>(
         &'a self,
         role_name: &'a str,
@@ -18948,6 +19478,12 @@ impl Client {
     ///Fetch the user associated with the current session
     ///
     ///Sends a `GET` request to `/session/me`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
@@ -18995,6 +19531,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_me_groups<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19092,6 +19633,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19185,6 +19731,12 @@ impl Client {
     ///Create an SSH public key for the currently authenticated user.
     ///
     ///Sends a `POST` request to `/session/me/sshkeys`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_create<'a>(
         &'a self,
         body: &'a types::SshKeyCreate,
@@ -19231,6 +19783,12 @@ impl Client {
     /// user.
     ///
     ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_view<'a>(
         &'a self,
         ssh_key_name: &'a types::Name,
@@ -19280,6 +19838,12 @@ impl Client {
     /// user.
     ///
     ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn session_sshkey_delete<'a>(
         &'a self,
         ssh_key_name: &'a types::Name,
@@ -19326,6 +19890,12 @@ impl Client {
     ///Fetch a system-wide image by id
     ///
     ///Sends a `GET` request to `/system/by-id/images/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -19372,6 +19942,12 @@ impl Client {
     ///Fetch an IP pool by id
     ///
     ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -19418,6 +19994,12 @@ impl Client {
     ///Fetch a silo by id
     ///
     ///Sends a `GET` request to `/system/by-id/silos/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_view_by_id<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -19474,6 +20056,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19571,6 +20158,12 @@ impl Client {
     /// serve external connections.
     ///
     ///Sends a `POST` request to `/system/certificates`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_create<'a>(
         &'a self,
         body: &'a types::CertificateCreate,
@@ -19616,6 +20209,12 @@ impl Client {
     ///Returns the details of a specific certificate
     ///
     ///Sends a `GET` request to `/system/certificates/{certificate}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_view<'a>(
         &'a self,
         certificate: &'a types::NameOrId,
@@ -19664,6 +20263,12 @@ impl Client {
     ///Permanently delete a certificate. This operation cannot be undone.
     ///
     ///Sends a `DELETE` request to `/system/certificates/{certificate}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn certificate_delete<'a>(
         &'a self,
         certificate: &'a types::NameOrId,
@@ -19716,6 +20321,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn physical_disk_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19812,6 +20422,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn rack_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -19904,6 +20519,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `rack_id`: The rack's unique ID.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn rack_view<'a>(
         &'a self,
         rack_id: &'a ::uuid::Uuid,
@@ -19956,6 +20576,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn sled_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20048,6 +20673,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `sled_id`: The sled's unique ID.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn sled_view<'a>(
         &'a self,
         sled_id: &'a ::uuid::Uuid,
@@ -20101,6 +20731,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn sled_physical_disk_list<'a>(
         &'a self,
         sled_id: &'a ::uuid::Uuid,
@@ -20209,6 +20844,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20306,6 +20946,12 @@ impl Client {
     /// in any silo as a base for instances.
     ///
     ///Sends a `POST` request to `/system/images`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_create<'a>(
         &'a self,
         body: &'a types::GlobalImageCreate,
@@ -20351,6 +20997,12 @@ impl Client {
     ///Returns the details of a specific system-wide image.
     ///
     ///Sends a `GET` request to `/system/images/{image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_view<'a>(
         &'a self,
         image_name: &'a types::Name,
@@ -20401,6 +21053,12 @@ impl Client {
     /// new instances can not be created with this image.
     ///
     ///Sends a `DELETE` request to `/system/images/{image_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_image_delete<'a>(
         &'a self,
         image_name: &'a types::Name,
@@ -20453,6 +21111,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -20542,6 +21205,12 @@ impl Client {
     ///Create an IP pool
     ///
     ///Sends a `POST` request to `/system/ip-pools`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_create<'a>(
         &'a self,
         body: &'a types::IpPoolCreate,
@@ -20585,6 +21254,12 @@ impl Client {
     ///Fetch an IP pool
     ///
     ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_view<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20631,6 +21306,12 @@ impl Client {
     ///Update an IP Pool
     ///
     ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_update<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20679,6 +21360,12 @@ impl Client {
     ///Delete an IP Pool
     ///
     ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_delete<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20733,6 +21420,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_range_list<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20828,6 +21520,12 @@ impl Client {
     ///Add a range to an IP pool
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_range_add<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20876,6 +21574,12 @@ impl Client {
     ///Remove a range from an IP pool
     ///
     ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/remove`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_range_remove<'a>(
         &'a self,
         pool_name: &'a types::Name,
@@ -20924,6 +21628,12 @@ impl Client {
     ///Fetch the IP pool used for Oxide services
     ///
     ///Sends a `GET` request to `/system/ip-pools-service`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
@@ -20972,6 +21682,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_range_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21060,6 +21775,12 @@ impl Client {
     ///Add a range to an IP pool used for Oxide services
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_range_add<'a>(
         &'a self,
         body: &'a types::IpRange,
@@ -21103,6 +21824,12 @@ impl Client {
     ///Remove a range from an IP pool used for Oxide services
     ///
     ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn ip_pool_service_range_remove<'a>(
         &'a self,
         body: &'a types::IpRange,
@@ -21155,6 +21882,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `start_time`: An inclusive start time of metrics.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_metric<'a>(
         &'a self,
         metric_name: types::SystemMetricName,
@@ -21217,6 +21949,12 @@ impl Client {
     ///Fetch the top-level IAM policy
     ///
     ///Sends a `GET` request to `/system/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
@@ -21258,6 +21996,12 @@ impl Client {
     ///Update the top-level IAM policy
     ///
     ///Sends a `PUT` request to `/system/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_policy_update<'a>(
         &'a self,
         body: &'a types::FleetRolePolicy,
@@ -21307,6 +22051,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saga_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21396,6 +22145,12 @@ impl Client {
     ///Fetch a saga
     ///
     ///Sends a `GET` request to `/system/sagas/{saga_id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saga_view<'a>(
         &'a self,
         saga_id: &'a ::uuid::Uuid,
@@ -21450,6 +22205,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -21541,6 +22301,12 @@ impl Client {
     ///Create a silo
     ///
     ///Sends a `POST` request to `/system/silos`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_create<'a>(
         &'a self,
         body: &'a types::SiloCreate,
@@ -21589,6 +22355,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21640,6 +22411,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_delete<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21693,6 +22469,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_identity_provider_list<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21800,6 +22581,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn local_idp_user_create<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21853,6 +22639,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn local_idp_user_delete<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21911,6 +22702,11 @@ impl Client {
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn local_idp_user_set_password<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -21966,6 +22762,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saml_identity_provider_create<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22019,6 +22820,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `provider_name`: The SAML identity provider's name
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn saml_identity_provider_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22070,6 +22876,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_policy_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22120,6 +22931,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `body`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_policy_update<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22175,6 +22991,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_users_list<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22275,6 +23096,11 @@ impl Client {
     ///Arguments:
     /// - `silo_name`: The silo's unique name.
     /// - `user_id`: The user's internal id
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn silo_user_view<'a>(
         &'a self,
         silo_name: &'a types::Name,
@@ -22329,6 +23155,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_user_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22422,6 +23253,11 @@ impl Client {
     ///
     ///Arguments:
     /// - `user_name`: The built-in user's unique name.
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_user_view<'a>(
         &'a self,
         user_name: &'a types::Name,
@@ -22473,6 +23309,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn timeseries_schema_get<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22565,6 +23406,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn user_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22662,6 +23508,11 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -22762,6 +23613,12 @@ impl Client {
     ///Create a disk
     ///
     ///Sends a `POST` request to `/v1/disks`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_create_v1<'a>(
         &'a self,
         organization: Option<&'a types::NameOrId>,
@@ -22812,6 +23669,12 @@ impl Client {
     ///Fetch a disk
     ///
     ///Sends a `GET` request to `/v1/disks/{disk}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_view_v1<'a>(
         &'a self,
         disk: &'a types::NameOrId,
@@ -22865,6 +23728,12 @@ impl Client {
     ///Delete a disk
     ///
     ///Sends a `DELETE` request to `/v1/disks/{disk}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn disk_delete_v1<'a>(
         &'a self,
         disk: &'a types::NameOrId,
@@ -22926,6 +23795,11 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23027,6 +23901,12 @@ impl Client {
     ///Create an instance
     ///
     ///Sends a `POST` request to `/v1/instances`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_create_v1<'a>(
         &'a self,
         organization: Option<&'a types::NameOrId>,
@@ -23077,6 +23957,12 @@ impl Client {
     ///Fetch an instance
     ///
     ///Sends a `GET` request to `/v1/instances/{instance}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_view_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23130,6 +24016,12 @@ impl Client {
     ///Delete an instance
     ///
     ///Sends a `DELETE` request to `/v1/instances/{instance}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_delete_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23192,6 +24084,11 @@ impl Client {
     ///   subsequent page
     /// - `project`
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_list_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23306,6 +24203,12 @@ impl Client {
     ///Attach a disk to an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_attach_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23361,6 +24264,12 @@ impl Client {
     ///Detach a disk from an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_disk_detach_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23416,6 +24325,12 @@ impl Client {
     ///Migrate an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_migrate_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23471,6 +24386,12 @@ impl Client {
     ///Reboot an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_reboot_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23540,6 +24461,11 @@ impl Client {
     ///   exclusivity)
     /// - `organization`
     /// - `project`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23606,6 +24532,12 @@ impl Client {
     ///
     ///Sends a `GET` request to
     /// `/v1/instances/{instance}/serial-console/stream`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial_console_stream_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23665,6 +24597,12 @@ impl Client {
     ///Boot an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/start`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_start_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23718,6 +24656,12 @@ impl Client {
     ///Stop an instance
     ///
     ///Sends a `POST` request to `/v1/instances/{instance}/stop`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_stop_v1<'a>(
         &'a self,
         instance: &'a types::NameOrId,
@@ -23777,6 +24721,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -23867,6 +24816,12 @@ impl Client {
     ///Create an organization
     ///
     ///Sends a `POST` request to `/v1/organizations`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_create_v1<'a>(
         &'a self,
         body: &'a types::OrganizationCreate,
@@ -23910,6 +24865,12 @@ impl Client {
     ///Fetch an organization
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_view_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -23956,6 +24917,12 @@ impl Client {
     ///Update an organization
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_update_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24004,6 +24971,12 @@ impl Client {
     ///Delete an organization
     ///
     ///Sends a `DELETE` request to `/v1/organizations/{organization}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_delete_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24050,6 +25023,12 @@ impl Client {
     ///Fetch an organization's IAM policy
     ///
     ///Sends a `GET` request to `/v1/organizations/{organization}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_view_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24096,6 +25075,12 @@ impl Client {
     ///Update an organization's IAM policy
     ///
     ///Sends a `PUT` request to `/v1/organizations/{organization}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn organization_policy_update_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24151,6 +25136,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_list_v1<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24247,6 +25237,12 @@ impl Client {
     ///Create a project
     ///
     ///Sends a `POST` request to `/v1/projects`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_create_v1<'a>(
         &'a self,
         organization: &'a types::NameOrId,
@@ -24295,6 +25291,12 @@ impl Client {
     ///Fetch a project
     ///
     ///Sends a `GET` request to `/v1/projects/{project}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_view_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24346,6 +25348,12 @@ impl Client {
     ///Update a project
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_update_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24399,6 +25407,12 @@ impl Client {
     ///Delete a project
     ///
     ///Sends a `DELETE` request to `/v1/projects/{project}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_delete_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24450,6 +25464,12 @@ impl Client {
     ///Fetch a project's IAM policy
     ///
     ///Sends a `GET` request to `/v1/projects/{project}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_view_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24501,6 +25521,12 @@ impl Client {
     ///Update a project's IAM policy
     ///
     ///Sends a `PUT` request to `/v1/projects/{project}/policy`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn project_policy_update_v1<'a>(
         &'a self,
         project: &'a types::NameOrId,
@@ -24560,6 +25586,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_component_version_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24656,6 +25687,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn update_deployments_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -24746,6 +25782,12 @@ impl Client {
     ///Fetch a system update deployment
     ///
     ///Sends a `GET` request to `/v1/system/update/deployments/{id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn update_deployment_view<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -24792,6 +25834,12 @@ impl Client {
     ///Refresh update data
     ///
     ///Sends a `POST` request to `/v1/system/update/refresh`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_refresh<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
@@ -24833,6 +25881,12 @@ impl Client {
     ///Start system update
     ///
     ///Sends a `POST` request to `/v1/system/update/start`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_start<'a>(
         &'a self,
         body: &'a types::SystemUpdateStart,
@@ -24878,6 +25932,12 @@ impl Client {
     ///If there is no update in progress, do nothing.
     ///
     ///Sends a `POST` request to `/v1/system/update/stop`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_stop<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
@@ -24925,6 +25985,11 @@ impl Client {
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
     /// - `sort_by`
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_list<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,
@@ -25015,6 +26080,12 @@ impl Client {
     ///View system update
     ///
     ///Sends a `GET` request to `/v1/system/update/updates/{version}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_view<'a>(
         &'a self,
         version: &'a types::SemverVersion,
@@ -25062,6 +26133,12 @@ impl Client {
     ///
     ///Sends a `GET` request to
     /// `/v1/system/update/updates/{version}/components`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_update_components_list<'a>(
         &'a self,
         version: &'a types::SemverVersion,
@@ -25108,6 +26185,12 @@ impl Client {
     ///View system version and update status
     ///
     ///Sends a `GET` request to `/v1/system/update/version`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn system_version<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12956,7 +12956,7 @@ impl Client {
         let url = format!(
             "{}/by-id/disks/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13002,7 +13002,7 @@ impl Client {
         let url = format!(
             "{}/by-id/images/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13048,7 +13048,7 @@ impl Client {
         let url = format!(
             "{}/by-id/instances/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13094,7 +13094,7 @@ impl Client {
         let url = format!(
             "{}/by-id/network-interfaces/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13142,7 +13142,7 @@ impl Client {
         let url = format!(
             "{}/by-id/organizations/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13190,7 +13190,7 @@ impl Client {
         let url = format!(
             "{}/by-id/projects/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13236,7 +13236,7 @@ impl Client {
         let url = format!(
             "{}/by-id/snapshots/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13282,7 +13282,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpc-router-routes/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13328,7 +13328,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpc-routers/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13374,7 +13374,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpc-subnets/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13420,7 +13420,7 @@ impl Client {
         let url = format!(
             "{}/by-id/vpcs/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13467,7 +13467,7 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/auth", self.baseurl,);
+        let url = format!("{}/device/auth", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13505,7 +13505,7 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/device/confirm", self.baseurl,);
+        let url = format!("{}/device/confirm", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13551,7 +13551,7 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/token", self.baseurl,);
+        let url = format!("{}/device/token", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13592,7 +13592,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let url = format!("{}/groups", self.baseurl,);
+        let url = format!("{}/groups", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13677,7 +13677,7 @@ impl Client {
         &'a self,
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/login", self.baseurl,);
+        let url = format!("{}/login", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13724,7 +13724,7 @@ impl Client {
         let url = format!(
             "{}/login/{}/local",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13772,7 +13772,7 @@ impl Client {
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
+            encode_path(&provider_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13813,7 +13813,7 @@ impl Client {
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
+            encode_path(&provider_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -13852,7 +13852,7 @@ impl Client {
 
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/logout", self.baseurl,);
+        let url = format!("{}/logout", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13904,7 +13904,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
+        let url = format!("{}/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -13996,7 +13996,7 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
+        let url = format!("{}/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -14047,7 +14047,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14100,7 +14100,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14152,7 +14152,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14203,7 +14203,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14256,7 +14256,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14315,7 +14315,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14418,7 +14418,7 @@ impl Client {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
-            encode_path(&organization_name.to_string()),
+            encode_path(&organization_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14474,7 +14474,7 @@ impl Client {
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14531,7 +14531,7 @@ impl Client {
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14587,7 +14587,7 @@ impl Client {
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14649,7 +14649,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14762,7 +14762,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14817,7 +14817,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&disk_name.to_string()),
+            encode_path(&disk_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14869,7 +14869,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&disk_name.to_string()),
+            encode_path(&disk_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -14938,7 +14938,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
-            encode_path(&metric_name.to_string()),
+            encode_path(&metric_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15080,7 +15080,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15196,7 +15196,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15251,7 +15251,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15307,7 +15307,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15367,7 +15367,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15481,7 +15481,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15536,7 +15536,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15588,7 +15588,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15654,7 +15654,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15777,7 +15777,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15833,7 +15833,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15886,7 +15886,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -15941,7 +15941,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16006,7 +16006,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16126,7 +16126,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16181,7 +16181,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
+            encode_path(&interface_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16236,7 +16236,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
+            encode_path(&interface_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16296,7 +16296,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
+            encode_path(&interface_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16350,7 +16350,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16423,7 +16423,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16486,7 +16486,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16540,7 +16540,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16600,7 +16600,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16654,7 +16654,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
+            encode_path(&instance_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16709,7 +16709,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16764,7 +16764,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16825,7 +16825,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16939,7 +16939,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -16992,7 +16992,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&snapshot_name.to_string()),
+            encode_path(&snapshot_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17044,7 +17044,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&snapshot_name.to_string()),
+            encode_path(&snapshot_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17104,7 +17104,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17215,7 +17215,7 @@ impl Client {
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
+            encode_path(&project_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17268,7 +17268,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17321,7 +17321,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17374,7 +17374,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17426,7 +17426,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17479,7 +17479,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17544,7 +17544,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17664,7 +17664,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17719,7 +17719,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17774,7 +17774,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17829,7 +17829,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -17898,7 +17898,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18027,7 +18027,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
+            encode_path(&router_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18084,7 +18084,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
+            encode_path(&route_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18141,7 +18141,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
+            encode_path(&route_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18198,7 +18198,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
+            encode_path(&route_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18262,7 +18262,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18382,7 +18382,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
+            encode_path(&vpc_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18437,7 +18437,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18492,7 +18492,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18547,7 +18547,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18614,7 +18614,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
+            encode_path(&subnet_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18728,7 +18728,7 @@ impl Client {
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
+        let url = format!("{}/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -18770,7 +18770,7 @@ impl Client {
         &'a self,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
+        let url = format!("{}/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -18819,7 +18819,7 @@ impl Client {
         limit: Option<::std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
-        let url = format!("{}/roles", self.baseurl,);
+        let url = format!("{}/roles", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -18909,7 +18909,7 @@ impl Client {
         let url = format!(
             "{}/roles/{}",
             self.baseurl,
-            encode_path(&role_name.to_string()),
+            encode_path(&role_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -18951,7 +18951,7 @@ impl Client {
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let url = format!("{}/session/me", self.baseurl,);
+        let url = format!("{}/session/me", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19001,7 +19001,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let url = format!("{}/session/me/groups", self.baseurl,);
+        let url = format!("{}/session/me/groups", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19098,7 +19098,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let url = format!("{}/session/me/sshkeys", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19189,7 +19189,7 @@ impl Client {
         &'a self,
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let url = format!("{}/session/me/sshkeys", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19238,7 +19238,7 @@ impl Client {
         let url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
-            encode_path(&ssh_key_name.to_string()),
+            encode_path(&ssh_key_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19287,7 +19287,7 @@ impl Client {
         let url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
-            encode_path(&ssh_key_name.to_string()),
+            encode_path(&ssh_key_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19333,7 +19333,7 @@ impl Client {
         let url = format!(
             "{}/system/by-id/images/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19379,7 +19379,7 @@ impl Client {
         let url = format!(
             "{}/system/by-id/ip-pools/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19425,7 +19425,7 @@ impl Client {
         let url = format!(
             "{}/system/by-id/silos/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19480,7 +19480,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/certificates", self.baseurl,);
+        let url = format!("{}/system/certificates", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19575,7 +19575,7 @@ impl Client {
         &'a self,
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let url = format!("{}/system/certificates", self.baseurl,);
+        let url = format!("{}/system/certificates", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19623,7 +19623,7 @@ impl Client {
         let url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
-            encode_path(&certificate.to_string()),
+            encode_path(&certificate.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19671,7 +19671,7 @@ impl Client {
         let url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
-            encode_path(&certificate.to_string()),
+            encode_path(&certificate.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19722,7 +19722,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/disks", self.baseurl,);
+        let url = format!("{}/system/hardware/disks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19818,7 +19818,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/racks", self.baseurl,);
+        let url = format!("{}/system/hardware/racks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -19911,7 +19911,7 @@ impl Client {
         let url = format!(
             "{}/system/hardware/racks/{}",
             self.baseurl,
-            encode_path(&rack_id.to_string()),
+            encode_path(&rack_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -19962,7 +19962,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/sleds", self.baseurl,);
+        let url = format!("{}/system/hardware/sleds", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20055,7 +20055,7 @@ impl Client {
         let url = format!(
             "{}/system/hardware/sleds/{}",
             self.baseurl,
-            encode_path(&sled_id.to_string()),
+            encode_path(&sled_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20111,7 +20111,7 @@ impl Client {
         let url = format!(
             "{}/system/hardware/sleds/{}/disks",
             self.baseurl,
-            encode_path(&sled_id.to_string()),
+            encode_path(&sled_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20215,7 +20215,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/images", self.baseurl,);
+        let url = format!("{}/system/images", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20310,7 +20310,7 @@ impl Client {
         &'a self,
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!("{}/system/images", self.baseurl,);
+        let url = format!("{}/system/images", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20358,7 +20358,7 @@ impl Client {
         let url = format!(
             "{}/system/images/{}",
             self.baseurl,
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20408,7 +20408,7 @@ impl Client {
         let url = format!(
             "{}/system/images/{}",
             self.baseurl,
-            encode_path(&image_name.to_string()),
+            encode_path(&image_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20459,7 +20459,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools", self.baseurl,);
+        let url = format!("{}/system/ip-pools", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20546,7 +20546,7 @@ impl Client {
         &'a self,
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools", self.baseurl,);
+        let url = format!("{}/system/ip-pools", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20592,7 +20592,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20639,7 +20639,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20686,7 +20686,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20742,7 +20742,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}/ranges",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20836,7 +20836,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}/ranges/add",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20884,7 +20884,7 @@ impl Client {
         let url = format!(
             "{}/system/ip-pools/{}/ranges/remove",
             self.baseurl,
-            encode_path(&pool_name.to_string()),
+            encode_path(&pool_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -20927,7 +20927,7 @@ impl Client {
     pub async fn ip_pool_service_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -20977,7 +20977,7 @@ impl Client {
         limit: Option<::std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service/ranges", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21064,7 +21064,7 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21107,7 +21107,7 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
+        let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21167,7 +21167,7 @@ impl Client {
         let url = format!(
             "{}/system/metrics/{}",
             self.baseurl,
-            encode_path(&metric_name.to_string()),
+            encode_path(&metric_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21220,7 +21220,7 @@ impl Client {
     pub async fn system_policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/system/policy", self.baseurl,);
+        let url = format!("{}/system/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21262,7 +21262,7 @@ impl Client {
         &'a self,
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/system/policy", self.baseurl,);
+        let url = format!("{}/system/policy", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21313,7 +21313,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/sagas", self.baseurl,);
+        let url = format!("{}/system/sagas", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21403,7 +21403,7 @@ impl Client {
         let url = format!(
             "{}/system/sagas/{}",
             self.baseurl,
-            encode_path(&saga_id.to_string()),
+            encode_path(&saga_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21456,7 +21456,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/silos", self.baseurl,);
+        let url = format!("{}/system/silos", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21545,7 +21545,7 @@ impl Client {
         &'a self,
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let url = format!("{}/system/silos", self.baseurl,);
+        let url = format!("{}/system/silos", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -21596,7 +21596,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21647,7 +21647,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21703,7 +21703,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/identity-providers",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21808,7 +21808,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/identity-providers/local/users",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21862,7 +21862,7 @@ impl Client {
             "{}/system/silos/{}/identity-providers/local/users/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&user_id.to_string()),
+            encode_path(&user_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21921,7 +21921,7 @@ impl Client {
             "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&user_id.to_string()),
+            encode_path(&user_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -21974,7 +21974,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/identity-providers/saml",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22028,7 +22028,7 @@ impl Client {
             "{}/system/silos/{}/identity-providers/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
+            encode_path(&provider_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22077,7 +22077,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22128,7 +22128,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22185,7 +22185,7 @@ impl Client {
         let url = format!(
             "{}/system/silos/{}/users/all",
             self.baseurl,
-            encode_path(&silo_name.to_string()),
+            encode_path(&silo_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22284,7 +22284,7 @@ impl Client {
             "{}/system/silos/{}/users/id/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
-            encode_path(&user_id.to_string()),
+            encode_path(&user_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22335,7 +22335,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/user", self.baseurl,);
+        let url = format!("{}/system/user", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22429,7 +22429,7 @@ impl Client {
         let url = format!(
             "{}/system/user/{}",
             self.baseurl,
-            encode_path(&user_name.to_string()),
+            encode_path(&user_name.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22478,7 +22478,7 @@ impl Client {
         limit: Option<::std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/timeseries/schema", self.baseurl,);
+        let url = format!("{}/timeseries/schema", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22571,7 +22571,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let url = format!("{}/users", self.baseurl,);
+        let url = format!("{}/users", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22670,7 +22670,7 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/disks", self.baseurl,);
+        let url = format!("{}/v1/disks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22768,7 +22768,7 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!("{}/v1/disks", self.baseurl,);
+        let url = format!("{}/v1/disks", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -22821,7 +22821,7 @@ impl Client {
         let url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
-            encode_path(&disk.to_string()),
+            encode_path(&disk.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22874,7 +22874,7 @@ impl Client {
         let url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
-            encode_path(&disk.to_string()),
+            encode_path(&disk.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -22934,7 +22934,7 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/instances", self.baseurl,);
+        let url = format!("{}/v1/instances", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23033,7 +23033,7 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!("{}/v1/instances", self.baseurl,);
+        let url = format!("{}/v1/instances", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23086,7 +23086,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23139,7 +23139,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23204,7 +23204,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/disks",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23316,7 +23316,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/disks/attach",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23371,7 +23371,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/disks/detach",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23426,7 +23426,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/migrate",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23480,7 +23480,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/reboot",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23552,7 +23552,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/serial-console",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23615,7 +23615,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/serial-console/stream",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23674,7 +23674,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/start",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23727,7 +23727,7 @@ impl Client {
         let url = format!(
             "{}/v1/instances/{}/stop",
             self.baseurl,
-            encode_path(&instance.to_string()),
+            encode_path(&instance.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23783,7 +23783,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/organizations", self.baseurl,);
+        let url = format!("{}/v1/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23871,7 +23871,7 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!("{}/v1/organizations", self.baseurl,);
+        let url = format!("{}/v1/organizations", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -23917,7 +23917,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -23964,7 +23964,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24011,7 +24011,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24057,7 +24057,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24104,7 +24104,7 @@ impl Client {
         let url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
-            encode_path(&organization.to_string()),
+            encode_path(&organization.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24158,7 +24158,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/projects", self.baseurl,);
+        let url = format!("{}/v1/projects", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24252,7 +24252,7 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!("{}/v1/projects", self.baseurl,);
+        let url = format!("{}/v1/projects", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24303,7 +24303,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24355,7 +24355,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24407,7 +24407,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24458,7 +24458,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24510,7 +24510,7 @@ impl Client {
         let url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
-            encode_path(&project.to_string()),
+            encode_path(&project.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24566,7 +24566,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/components", self.baseurl,);
+        let url = format!("{}/v1/system/update/components", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24662,7 +24662,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/deployments", self.baseurl,);
+        let url = format!("{}/v1/system/update/deployments", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24753,7 +24753,7 @@ impl Client {
         let url = format!(
             "{}/v1/system/update/deployments/{}",
             self.baseurl,
-            encode_path(&id.to_string()),
+            encode_path(&id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -24795,7 +24795,7 @@ impl Client {
     pub async fn system_update_refresh<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/refresh", self.baseurl,);
+        let url = format!("{}/v1/system/update/refresh", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24837,7 +24837,7 @@ impl Client {
         &'a self,
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/start", self.baseurl,);
+        let url = format!("{}/v1/system/update/start", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24881,7 +24881,7 @@ impl Client {
     pub async fn system_update_stop<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/stop", self.baseurl,);
+        let url = format!("{}/v1/system/update/stop", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -24931,7 +24931,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/updates", self.baseurl,);
+        let url = format!("{}/v1/system/update/updates", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -25022,7 +25022,7 @@ impl Client {
         let url = format!(
             "{}/v1/system/update/updates/{}",
             self.baseurl,
-            encode_path(&version.to_string()),
+            encode_path(&version.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -25069,7 +25069,7 @@ impl Client {
         let url = format!(
             "{}/v1/system/update/updates/{}/components",
             self.baseurl,
-            encode_path(&version.to_string()),
+            encode_path(&version.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -25111,7 +25111,7 @@ impl Client {
     pub async fn system_version<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/version", self.baseurl,);
+        let url = format!("{}/v1/system/update/version", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12929,6 +12929,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Fetch a disk by id
     ///

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -13530,7 +13530,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -13702,7 +13702,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -13876,7 +13876,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -14177,7 +14177,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -14612,7 +14612,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -14894,7 +14894,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -15332,7 +15332,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -15613,7 +15613,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -16321,7 +16321,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -17069,7 +17069,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -17399,7 +17399,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -17854,7 +17854,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -18223,7 +18223,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -18572,7 +18572,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -19312,7 +19312,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -19696,7 +19696,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -20433,7 +20433,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -20711,7 +20711,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -20910,7 +20910,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21132,7 +21132,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21672,7 +21672,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21887,7 +21887,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -21947,7 +21947,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -22904,7 +22904,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -23169,7 +23169,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24036,7 +24036,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24436,7 +24436,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24819,7 +24819,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),
@@ -24905,7 +24905,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12886,6 +12886,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12935,6 +12935,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Fetch a disk by id
     ///

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12882,6 +12882,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -12901,6 +12902,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/nexus_with_timeout.rs
+++ b/progenitor-impl/tests/output/src/nexus_with_timeout.rs
@@ -12944,6 +12944,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -283,7 +283,7 @@ pub mod builder {
             _client.post(&_result, &info).await?;
             let _response = _result?;
             match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
+                200u16 => Ok(ResponseValue::empty(&_response)),
                 _ => Err(Error::UnexpectedResponse(_response)),
             }
         }

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -129,6 +129,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -178,6 +178,10 @@ pub mod builder {
     }
 
     impl<'a> KeyGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 _client: client,

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -257,7 +257,7 @@ pub mod builder {
             let _url = format!(
                 "{}/key/{}",
                 _client.baseurl,
-                encode_path(&query.to_string()),
+                encode_path(&query.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -53,6 +53,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -72,6 +73,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -57,6 +57,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -152,6 +152,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -135,6 +135,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -37,7 +37,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Parameter name collision test
+///Client for `Parameter name collision test`
 ///
 ///Minimal API for testing collision between parameter names and generated code
 ///

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -117,7 +117,12 @@ impl Client {
     /// - `response`: Parameter name that was previously colliding
     /// - `result`: Parameter name that was previously colliding
     /// - `url`: Parameter name that was previously colliding
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.key_get()
     ///    .query(query)
     ///    .client(client)
@@ -238,6 +243,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/key/{query}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 _client,

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -283,7 +283,7 @@ pub mod builder {
             _client.post(&_result, &info).await?;
             let _response = _result?;
             match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
+                200u16 => Ok(ResponseValue::empty(&_response)),
                 _ => Err(Error::UnexpectedResponse(_response)),
             }
         }

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -129,6 +129,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -178,6 +178,10 @@ pub mod builder {
     }
 
     impl<'a> KeyGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 _client: client,

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -257,7 +257,7 @@ pub mod builder {
             let _url = format!(
                 "{}/key/{}",
                 _client.baseurl,
-                encode_path(&query.to_string()),
+                encode_path(&query.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -53,6 +53,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -72,6 +73,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -57,6 +57,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -152,6 +152,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -135,6 +135,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -37,7 +37,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Parameter name collision test
+///Client for `Parameter name collision test`
 ///
 ///Minimal API for testing collision between parameter names and generated code
 ///

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -117,7 +117,12 @@ impl Client {
     /// - `response`: Parameter name that was previously colliding
     /// - `result`: Parameter name that was previously colliding
     /// - `url`: Parameter name that was previously colliding
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.key_get()
     ///    .query(query)
     ///    .client(client)
@@ -238,6 +243,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/key/{query}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 _client,

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -126,6 +126,11 @@ impl Client {
     /// - `response`: Parameter name that was previously colliding
     /// - `result`: Parameter name that was previously colliding
     /// - `url`: Parameter name that was previously colliding
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn key_get<'a>(
         &'a self,
         query: bool,

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -135,7 +135,7 @@ impl Client {
         result: bool,
         url: bool,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!("{}/key/{}", self.baseurl, encode_path(&query.to_string()),);
+        let _url = format!("{}/key/{}", self.baseurl, encode_path(&query.to_string()));
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -160,7 +160,7 @@ impl Client {
         self.post(&_result, &info).await?;
         let _response = _result?;
         match _response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(_response)),
+            200u16 => Ok(ResponseValue::empty(&_response)),
             _ => Err(Error::UnexpectedResponse(_response)),
         }
     }

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -106,6 +106,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Gets a key
     ///

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -53,6 +53,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -72,6 +73,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -100,6 +100,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Gets a key
     ///

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -57,6 +57,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -37,7 +37,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Parameter name collision test
+///Client for `Parameter name collision test`
 ///
 ///Minimal API for testing collision between parameter names and generated code
 ///

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -122,6 +122,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -115,6 +115,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -115,7 +115,12 @@ impl Client {
     ///   parameter
     /// - `unique_key`: A key parameter that will not be overridden by the path
     ///   spec
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.key_get()
     ///    .key(key)
     ///    .unique_key(unique_key)
@@ -185,6 +190,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/key`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -146,6 +146,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -218,7 +218,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -53,6 +53,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -72,6 +73,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -123,6 +123,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -57,6 +57,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -37,7 +37,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Parameter override test
+///Client for `Parameter override test`
 ///
 ///Minimal API for testing parameter overrides
 ///

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -174,7 +174,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -129,6 +129,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -168,6 +168,10 @@ pub mod builder {
     }
 
     impl<'a> KeyGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -193,7 +193,7 @@ pub mod builder {
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/key", client.baseurl,);
+            let url = format!("{}/key", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -115,7 +115,12 @@ impl Client {
     ///   parameter
     /// - `unique_key`: A key parameter that will not be overridden by the path
     ///   spec
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.key_get()
     ///    .key(key)
     ///    .unique_key(unique_key)
@@ -185,6 +190,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/key`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
                 client,

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -146,6 +146,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -218,7 +218,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
+                200u16 => Ok(ResponseValue::empty(&response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -53,6 +53,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -72,6 +73,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -123,6 +123,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -57,6 +57,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -37,7 +37,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Parameter override test
+///Client for `Parameter override test`
 ///
 ///Minimal API for testing parameter overrides
 ///

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -174,7 +174,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -129,6 +129,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -168,6 +168,10 @@ pub mod builder {
     }
 
     impl<'a> KeyGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -193,7 +193,7 @@ pub mod builder {
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/key", client.baseurl,);
+            let url = format!("{}/key", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -124,6 +124,11 @@ impl Client {
     ///   parameter
     /// - `unique_key`: A key parameter that will not be overridden by the path
     ///   spec
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn key_get<'a>(
         &'a self,
         key: Option<bool>,

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -129,7 +129,7 @@ impl Client {
         key: Option<bool>,
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/key", self.baseurl,);
+        let url = format!("{}/key", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -154,7 +154,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
+            200u16 => Ok(ResponseValue::empty(&response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -106,6 +106,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Gets a key
     ///

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -53,6 +53,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -72,6 +73,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -100,6 +100,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Gets a key
     ///

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -57,6 +57,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -37,7 +37,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Parameter override test
+///Client for `Parameter override test`
 ///
 ///Minimal API for testing parameter overrides
 ///

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -122,6 +122,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -115,6 +115,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -2898,7 +2898,12 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/instance`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_get()
     ///    .send()
     ///    .await;
@@ -2909,7 +2914,12 @@ impl Client {
 
     ///Sends a `PUT` request to `/instance`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_ensure()
     ///    .body(body)
     ///    .send()
@@ -2923,7 +2933,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/instance/disk/{id}/snapshot/{snapshot_id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_issue_crucible_snapshot_request()
     ///    .id(id)
     ///    .snapshot_id(snapshot_id)
@@ -2938,7 +2953,12 @@ impl Client {
 
     ///Sends a `GET` request to `/instance/migrate/status`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_migrate_status()
     ///    .body(body)
     ///    .send()
@@ -2950,7 +2970,12 @@ impl Client {
 
     ///Sends a `GET` request to `/instance/serial`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial()
     ///    .send()
     ///    .await;
@@ -2961,7 +2986,12 @@ impl Client {
 
     ///Sends a `PUT` request to `/instance/state`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_state_put()
     ///    .body(body)
     ///    .send()
@@ -2973,7 +3003,12 @@ impl Client {
 
     ///Sends a `GET` request to `/instance/state-monitor`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_state_monitor()
     ///    .body(body)
     ///    .send()
@@ -3015,6 +3050,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
@@ -3097,6 +3137,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/instance`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
@@ -3182,6 +3227,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -3274,6 +3324,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance/migrate/status`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
@@ -3335,6 +3390,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance/serial`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl);
@@ -3407,6 +3467,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/instance/state`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -3490,6 +3555,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance/state-monitor`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3033,6 +3033,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -2827,7 +2827,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Oxide Propolis Server API
+///Client for `Oxide Propolis Server API`
 ///
 ///API for interacting with the Propolis hypervisor frontend.
 ///

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -2980,6 +2980,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -2986,6 +2986,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3058,7 +3058,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/instance`
@@ -3123,7 +3123,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3219,7 +3219,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -3317,7 +3317,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3414,7 +3414,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/instance/serial`
@@ -3483,7 +3483,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -3560,7 +3560,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -2843,6 +2843,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -2862,6 +2863,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3435,7 +3435,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3019,7 +3019,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance", client.baseurl,);
+            let url = format!("{}/instance", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3104,7 +3104,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance", client.baseurl,);
+            let url = format!("{}/instance", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3194,7 +3194,7 @@ pub mod builder {
                 "{}/instance/disk/{}/snapshot/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
-                encode_path(&snapshot_id.to_string()),
+                encode_path(&snapshot_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3284,7 +3284,7 @@ pub mod builder {
                     types::InstanceMigrateStatusRequest::try_from(v).map_err(|e| e.to_string())
                 })
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/migrate/status", client.baseurl,);
+            let url = format!("{}/instance/migrate/status", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3337,7 +3337,7 @@ pub mod builder {
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance/serial", client.baseurl,);
+            let url = format!("{}/instance/serial", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3410,7 +3410,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state", client.baseurl,);
+            let url = format!("{}/instance/state", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3500,7 +3500,7 @@ pub mod builder {
                     types::InstanceStateMonitorRequest::try_from(v).map_err(|e| e.to_string())
                 })
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state-monitor", client.baseurl,);
+            let url = format!("{}/instance/state-monitor", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -2847,6 +2847,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3053,6 +3053,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3113,6 +3117,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceEnsure<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3205,6 +3213,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3299,6 +3311,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3393,6 +3409,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerial<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3457,6 +3477,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStatePut<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3530,6 +3554,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStateMonitor<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2853,7 +2853,12 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `GET` request to `/instance`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_get()
     ///    .send()
     ///    .await;
@@ -2864,7 +2869,12 @@ impl Client {
 
     ///Sends a `PUT` request to `/instance`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_ensure()
     ///    .body(body)
     ///    .send()
@@ -2878,7 +2888,12 @@ impl Client {
     ///
     ///Sends a `POST` request to `/instance/disk/{id}/snapshot/{snapshot_id}`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_issue_crucible_snapshot_request()
     ///    .id(id)
     ///    .snapshot_id(snapshot_id)
@@ -2893,7 +2908,12 @@ impl Client {
 
     ///Sends a `GET` request to `/instance/migrate/status`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_migrate_status()
     ///    .body(body)
     ///    .send()
@@ -2905,7 +2925,12 @@ impl Client {
 
     ///Sends a `GET` request to `/instance/serial`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_serial()
     ///    .send()
     ///    .await;
@@ -2916,7 +2941,12 @@ impl Client {
 
     ///Sends a `PUT` request to `/instance/state`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_state_put()
     ///    .body(body)
     ///    .send()
@@ -2928,7 +2958,12 @@ impl Client {
 
     ///Sends a `GET` request to `/instance/state-monitor`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.instance_state_monitor()
     ///    .body(body)
     ///    .send()
@@ -2970,6 +3005,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
@@ -3052,6 +3092,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/instance`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
@@ -3137,6 +3182,11 @@ pub mod builder {
 
         ///Sends a `POST` request to
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
                 client,
@@ -3229,6 +3279,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance/migrate/status`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
@@ -3290,6 +3345,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance/serial`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl);
@@ -3362,6 +3422,11 @@ pub mod builder {
         }
 
         ///Sends a `PUT` request to `/instance/state`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
@@ -3445,6 +3510,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/instance/state-monitor`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -3390,7 +3390,7 @@ pub mod builder {
             client.post(&result, &info).await?;
             let response = result?;
             match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+                204u16 => Ok(ResponseValue::empty(&response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
                     ResponseValue::from_response(response).await?,
                 )),

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2935,6 +2935,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2941,6 +2941,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2974,7 +2974,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance", client.baseurl,);
+            let url = format!("{}/instance", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3059,7 +3059,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance", client.baseurl,);
+            let url = format!("{}/instance", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3149,7 +3149,7 @@ pub mod builder {
                 "{}/instance/disk/{}/snapshot/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
-                encode_path(&snapshot_id.to_string()),
+                encode_path(&snapshot_id.to_string())
             );
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
@@ -3239,7 +3239,7 @@ pub mod builder {
                     types::InstanceMigrateStatusRequest::try_from(v).map_err(|e| e.to_string())
                 })
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/migrate/status", client.baseurl,);
+            let url = format!("{}/instance/migrate/status", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3292,7 +3292,7 @@ pub mod builder {
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(self) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance/serial", client.baseurl,);
+            let url = format!("{}/instance/serial", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3365,7 +3365,7 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state", client.baseurl,);
+            let url = format!("{}/instance/state", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
@@ -3455,7 +3455,7 @@ pub mod builder {
                     types::InstanceStateMonitorRequest::try_from(v).map_err(|e| e.to_string())
                 })
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state-monitor", client.baseurl,);
+            let url = format!("{}/instance/state-monitor", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2988,6 +2988,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -3013,7 +3013,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/instance`
@@ -3078,7 +3078,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3174,7 +3174,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -3272,7 +3272,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -3369,7 +3369,7 @@ pub mod builder {
             reason = "operation parameter defaults may require non-const initialization"
         )]
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self { client }
         }
 
         ///Sends a `GET` request to `/instance/serial`
@@ -3438,7 +3438,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -3515,7 +3515,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2798,6 +2798,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -2817,6 +2818,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2782,7 +2782,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Oxide Propolis Server API
+///Client for `Oxide Propolis Server API`
 ///
 ///API for interacting with the Propolis hypervisor frontend.
 ///

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2802,6 +2802,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -3008,6 +3008,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceGet<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3068,6 +3072,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceEnsure<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3160,6 +3168,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3254,6 +3266,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3348,6 +3364,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceSerial<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self { client: client }
         }
@@ -3412,6 +3432,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStatePut<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
@@ -3485,6 +3509,10 @@ pub mod builder {
     }
 
     impl<'a> InstanceStateMonitor<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1435,6 +1435,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1350,7 +1350,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for Oxide Propolis Server API
+///Client for `Oxide Propolis Server API`
 ///
 ///API for interacting with the Propolis hypervisor frontend.
 ///

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1366,6 +1366,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -1385,6 +1386,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1429,6 +1429,12 @@ impl ClientHooks<()> for &Client {}
 )]
 impl Client {
     ///Sends a `GET` request to `/instance`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
@@ -1468,6 +1474,12 @@ impl Client {
     }
 
     ///Sends a `PUT` request to `/instance`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_ensure<'a>(
         &'a self,
         body: &'a types::InstanceEnsureRequest,
@@ -1511,6 +1523,12 @@ impl Client {
     ///Issue a snapshot request to a crucible backend
     ///
     ///Sends a `POST` request to `/instance/disk/{id}/snapshot/{snapshot_id}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_issue_crucible_snapshot_request<'a>(
         &'a self,
         id: &'a ::uuid::Uuid,
@@ -1557,6 +1575,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/instance/migrate/status`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_migrate_status<'a>(
         &'a self,
         body: &'a types::InstanceMigrateStatusRequest,
@@ -1598,6 +1622,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/instance/serial`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_serial<'a>(
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
@@ -1643,6 +1673,12 @@ impl Client {
     }
 
     ///Sends a `PUT` request to `/instance/state`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_state_put<'a>(
         &'a self,
         body: types::InstanceStateRequested,
@@ -1684,6 +1720,12 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/instance/state-monitor`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn instance_state_monitor<'a>(
         &'a self,
         body: &'a types::InstanceStateMonitorRequest,

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1672,7 +1672,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1419,6 +1419,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `GET` request to `/instance`
     pub async fn instance_get<'a>(

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1413,6 +1413,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `GET` request to `/instance`
     pub async fn instance_get<'a>(

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1432,7 +1432,7 @@ impl Client {
     pub async fn instance_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-        let url = format!("{}/instance", self.baseurl,);
+        let url = format!("{}/instance", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1472,7 +1472,7 @@ impl Client {
         &'a self,
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-        let url = format!("{}/instance", self.baseurl,);
+        let url = format!("{}/instance", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1520,7 +1520,7 @@ impl Client {
             "{}/instance/disk/{}/snapshot/{}",
             self.baseurl,
             encode_path(&id.to_string()),
-            encode_path(&snapshot_id.to_string()),
+            encode_path(&snapshot_id.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
@@ -1561,7 +1561,7 @@ impl Client {
         &'a self,
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
-        let url = format!("{}/instance/migrate/status", self.baseurl,);
+        let url = format!("{}/instance/migrate/status", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1601,7 +1601,7 @@ impl Client {
     pub async fn instance_serial<'a>(
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<types::Error>> {
-        let url = format!("{}/instance/serial", self.baseurl,);
+        let url = format!("{}/instance/serial", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1647,7 +1647,7 @@ impl Client {
         &'a self,
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/instance/state", self.baseurl,);
+        let url = format!("{}/instance/state", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),
@@ -1688,7 +1688,7 @@ impl Client {
         &'a self,
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
-        let url = format!("{}/instance/state-monitor", self.baseurl,);
+        let url = format!("{}/instance/state-monitor", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1428,6 +1428,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1370,6 +1370,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -314,6 +314,10 @@ pub mod builder {
     }
 
     impl<'a> DefaultParams<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -208,6 +208,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -227,6 +228,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -263,7 +263,12 @@ impl ClientHooks<()> for &Client {}
 impl Client {
     ///Sends a `POST` request to `/`
     ///
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.default_params()
     ///    .body(body)
     ///    .send()
@@ -331,6 +336,11 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -320,7 +320,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 body: Ok(::std::default::Default::default()),
             }
         }

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -293,6 +293,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -212,6 +212,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -336,7 +336,7 @@ pub mod builder {
             let body = body
                 .and_then(|v| types::BodyWithDefaults::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/", client.baseurl,);
+            let url = format!("{}/", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -194,7 +194,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for pagination-demo
+///Client for `pagination-demo`
 ///
 ///Version: 9000.0.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -270,6 +270,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -276,6 +276,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -165,6 +165,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `POST` request to `/`
     pub async fn default_params<'a>(

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -112,6 +112,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -131,6 +132,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -159,6 +159,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `POST` request to `/`
     pub async fn default_params<'a>(

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -116,6 +116,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -181,6 +181,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -174,6 +174,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -175,6 +175,12 @@ impl ClientHooks<()> for &Client {}
 )]
 impl Client {
     ///Sends a `POST` request to `/`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn default_params<'a>(
         &'a self,
         body: &'a types::BodyWithDefaults,

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -98,7 +98,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for pagination-demo
+///Client for `pagination-demo`
 ///
 ///Version: 9000.0.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -179,7 +179,7 @@ impl Client {
         &'a self,
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/", self.baseurl,);
+        let url = format!("{}/", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -55,6 +55,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -37,7 +37,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for pagination-demo
+///Client for `pagination-demo`
 ///
 ///Version: 9000.0.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -104,6 +104,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `GET` request to `/`
     pub async fn freeform_response<'a>(

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -114,6 +114,12 @@ impl ClientHooks<()> for &Client {}
 )]
 impl Client {
     ///Sends a `GET` request to `/`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn freeform_response<'a>(
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -120,6 +120,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -51,6 +51,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -70,6 +71,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -98,6 +98,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `GET` request to `/`
     pub async fn freeform_response<'a>(

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -113,6 +113,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -117,7 +117,7 @@ impl Client {
     pub async fn freeform_response<'a>(
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/", self.baseurl,);
+        let url = format!("{}/", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -138,6 +138,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `GET` request to `/{ref}/{type}/{trait}`
     pub async fn renamed_parameters<'a>(

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -89,6 +89,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -71,7 +71,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for pagination-demo
+///Client for `pagination-demo`
 ///
 ///Version: 9000.0.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -147,6 +147,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -85,6 +85,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -104,6 +105,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -132,6 +132,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `GET` request to `/{ref}/{type}/{trait}`
     pub async fn renamed_parameters<'a>(

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -148,6 +148,12 @@ impl ClientHooks<()> for &Client {}
 )]
 impl Client {
     ///Sends a `GET` request to `/{ref}/{type}/{trait}`
+    ///
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn renamed_parameters<'a>(
         &'a self,
         ref_: &'a str,

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -154,6 +154,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -190,7 +190,7 @@ impl Client {
         self.post(&result, &info).await?;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+            204u16 => Ok(ResponseValue::empty(&response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
                 ResponseValue::from_response(response).await?,
             )),

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -162,7 +162,7 @@ impl Client {
             self.baseurl,
             encode_path(&ref_.to_string()),
             encode_path(&type_.to_string()),
-            encode_path(&trait_.to_string()),
+            encode_path(&trait_.to_string())
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -370,6 +370,13 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -339,7 +339,12 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
-    ///```ignore
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails. 
+    /// ```ignore
     /// let response = client.paginated_u32s()
     ///    .limit(limit)
     ///    .page_token(page_token)
@@ -408,6 +413,11 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/`
+        ///
+        ///# Errors
+        ///
+        ///Returns an error if request construction, transport, or response
+        /// decoding fails.
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::Uint32ResultsPage>, Error<types::Error>> {

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -398,7 +398,7 @@ pub mod builder {
         )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client: client,
+                client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -266,7 +266,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for test_stream_pagination
+///Client for `test_stream_pagination`
 ///
 ///Version: 1.0.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -280,6 +280,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -299,6 +300,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -392,6 +392,10 @@ pub mod builder {
     }
 
     impl<'a> PaginatedU32s<'a> {
+        #[allow(
+            clippy::missing_const_for_fn,
+            reason = "operation parameter defaults may require non-const initialization"
+        )]
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -347,6 +347,10 @@ impl Client {
 
 /// Types for composing operation parameters.
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -284,6 +284,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -353,6 +353,10 @@ impl Client {
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -418,7 +418,7 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/", client.baseurl,);
+            let url = format!("{}/", client.baseurl);
             let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -131,6 +131,10 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built.
     #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -195,6 +195,11 @@ impl Client {
     /// - `limit`: Maximum number of items returned by a single call
     /// - `page_token`: Token returned by previous call to retrieve the
     ///   subsequent page
+    ///
+    ///# Errors
+    ///
+    ///Returns an error if request construction, transport, or response
+    /// decoding fails.
     pub async fn paginated_u32s<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -253,6 +253,10 @@ impl Client {
     ///
     ///Arguments:
     /// - `limit`: Maximum number of items returned by a single call
+    #[allow(
+        clippy::elidable_lifetime_names,
+        reason = "the lifetime also binds borrowed stream parameters"
+    )]
     pub fn paginated_u32s_stream<'a>(
         &'a self,
         limit: Option<::std::num::NonZeroU32>,

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -200,7 +200,7 @@ impl Client {
         limit: Option<::std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::Uint32ResultsPage>, Error<types::Error>> {
-        let url = format!("{}/", self.baseurl,);
+        let url = format!("{}/", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map.append(
             ::reqwest::header::HeaderName::from_static("api-version"),

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -180,6 +180,10 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[allow(
+    clippy::match_same_arms,
+    reason = "generated status ranges remain explicit"
+)]
 impl Client {
     ///Sends a `GET` request to `/`
     ///

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -4,6 +4,10 @@ use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderE
 pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
+#[allow(
+    clippy::default_trait_access,
+    reason = "default expressions are emitted by typify"
+)]
 pub mod types {
     /// Error types.
     pub mod error {

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -174,6 +174,10 @@ impl ClientInfo<()> for Client {
 
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
+#[allow(
+    clippy::result_large_err,
+    reason = "generated methods preserve the public Error representation"
+)]
 impl Client {
     ///Sends a `GET` request to `/`
     ///

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -113,7 +113,7 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
-///Client for test_stream_pagination
+///Client for `test_stream_pagination`
 ///
 ///Version: 1.0.0
 pub struct Client {

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -189,6 +189,10 @@ impl ClientInfo<()> for Client {
 impl ClientHooks<()> for &Client {}
 #[allow(clippy::all)]
 #[allow(
+    clippy::too_many_arguments,
+    reason = "generated parameters mirror the OpenAPI operation"
+)]
+#[allow(
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -5,6 +5,10 @@ pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
 /// Types used as operation parameters and responses.
 #[allow(clippy::all)]
 #[allow(
+    clippy::struct_field_names,
+    reason = "type definitions are emitted by typify"
+)]
+#[allow(
     clippy::default_trait_access,
     reason = "default expressions are emitted by typify"
 )]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -196,6 +196,13 @@ impl ClientHooks<()> for &Client {}
     clippy::result_large_err,
     reason = "generated methods preserve the public Error representation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        clippy::future_not_send,
+        reason = "reqwest futures use browser-local state on wasm"
+    )
+)]
 #[allow(
     clippy::match_same_arms,
     reason = "generated status ranges remain explicit"

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -127,6 +127,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new(baseurl: &str) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
@@ -146,6 +147,7 @@ impl Client {
     /// `baseurl` is the base URL provided to the internal
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
+    #[must_use]
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -53,7 +53,7 @@ fn verify_apis(openapi_file: &str) {
     let mut generator = Generator::default();
     let output = generate_formatted(&mut generator, &spec);
     expectorate::assert_contents(
-        format!("tests/output/src/{}_positional.rs", openapi_stem),
+        format!("tests/output/src/{openapi_stem}_positional.rs"),
         &output,
     );
 
@@ -76,7 +76,7 @@ fn verify_apis(openapi_file: &str) {
     );
     let output = generate_formatted(&mut generator, &spec);
     expectorate::assert_contents(
-        format!("tests/output/src/{}_builder.rs", openapi_stem),
+        format!("tests/output/src/{openapi_stem}_builder.rs"),
         &output,
     );
 
@@ -89,7 +89,7 @@ fn verify_apis(openapi_file: &str) {
     );
     let output = generate_formatted(&mut generator, &spec);
     expectorate::assert_contents(
-        format!("tests/output/src/{}_builder_tagged.rs", openapi_stem),
+        format!("tests/output/src/{openapi_stem}_builder_tagged.rs"),
         &output,
     );
 
@@ -99,7 +99,7 @@ fn verify_apis(openapi_file: &str) {
         .unwrap();
     let output = reformat_code(tokens);
 
-    expectorate::assert_contents(format!("tests/output/src/{}_cli.rs", openapi_stem), &output);
+    expectorate::assert_contents(format!("tests/output/src/{openapi_stem}_cli.rs"), &output);
 
     // httpmock generation.
     let code = generator
@@ -118,7 +118,7 @@ fn verify_apis(openapi_file: &str) {
 
     let output = progenitor_impl::space_out_items(output).unwrap();
     expectorate::assert_contents(
-        format!("tests/output/src/{}_httpmock.rs", openapi_stem),
+        format!("tests/output/src/{openapi_stem}_httpmock.rs"),
         &output,
     );
 }
@@ -176,7 +176,7 @@ fn test_nexus_with_different_timeout() {
     let mut generator = Generator::new(GenerationSettings::default().with_timeout(75));
     let output = generate_formatted(&mut generator, &spec);
     expectorate::assert_contents(
-        format!("tests/output/src/{}_with_timeout.rs", openapi_stem),
+        format!("tests/output/src/{openapi_stem}_with_timeout.rs"),
         &output,
     );
 }

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -68,7 +68,7 @@ fn verify_apis(openapi_file: &str) {
                     ..Default::default()
                 },
                 "usize",
-                [TypeImpl::Display].into_iter(),
+                std::iter::once(TypeImpl::Display),
             ),
     );
     let output = generate_formatted(&mut generator, &spec);

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -16,13 +16,11 @@ fn load_api<P>(p: P) -> OpenAPI
 where
     P: AsRef<Path> + std::clone::Clone + std::fmt::Debug,
 {
-    let mut f = File::open(p.clone()).unwrap();
-    if let Ok(json_value) = serde_json::from_reader(f) {
-        json_value
-    } else {
-        f = File::open(p).unwrap();
+    let f = File::open(p.clone()).unwrap();
+    serde_json::from_reader(f).unwrap_or_else(|_| {
+        let f = File::open(p).unwrap();
         serde_yaml::from_reader(f).unwrap()
-    }
+    })
 }
 
 fn generate_formatted(generator: &mut Generator, spec: &OpenAPI) -> String {

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -17,12 +17,11 @@ where
     P: AsRef<Path> + std::clone::Clone + std::fmt::Debug,
 {
     let mut f = File::open(p.clone()).unwrap();
-    match serde_json::from_reader(f) {
-        Ok(json_value) => json_value,
-        _ => {
-            f = File::open(p).unwrap();
-            serde_yaml::from_reader(f).unwrap()
-        }
+    if let Ok(json_value) = serde_json::from_reader(f) {
+        json_value
+    } else {
+        f = File::open(p).unwrap();
+        serde_yaml::from_reader(f).unwrap()
     }
 }
 

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -27,7 +27,7 @@ where
 }
 
 fn generate_formatted(generator: &mut Generator, spec: &OpenAPI) -> String {
-    let content = generator.generate_tokens(&spec).unwrap();
+    let content = generator.generate_tokens(spec).unwrap();
     reformat_code(content)
 }
 

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -183,7 +183,7 @@ fn test_nexus_with_different_timeout() {
 // TODO this file is full of inconsistencies and incorrectly specified types.
 // It's an interesting test to consider whether we try to do our best to
 // interpret the intent or just fail.
-#[ignore]
+#[ignore = "sample contains inconsistent and invalid types"]
 #[test]
 fn test_github() {
     verify_apis("api.github.com.json");

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -165,7 +165,7 @@ fn test_cli_gen() {
 
 #[test]
 fn test_nexus_with_different_timeout() {
-    const OPENAPI_FILE: &'static str = "nexus.json";
+    const OPENAPI_FILE: &str = "nexus.json";
 
     let mut in_path = PathBuf::from("../sample_openapi");
     in_path.push(OPENAPI_FILE);

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -38,7 +38,7 @@ fn reformat_code(content: TokenStream) -> String {
         wrap_comments: Some(true),
         ..Default::default()
     };
-    space_out_items(rustfmt_wrapper::rustfmt_config(rustfmt_config, content).unwrap()).unwrap()
+    space_out_items(&rustfmt_wrapper::rustfmt_config(rustfmt_config, content).unwrap()).unwrap()
 }
 
 #[track_caller]
@@ -116,7 +116,7 @@ fn verify_apis(openapi_file: &str) {
     )
     .unwrap();
 
-    let output = progenitor_impl::space_out_items(output).unwrap();
+    let output = progenitor_impl::space_out_items(&output).unwrap();
     expectorate::assert_contents(
         format!("tests/output/src/{openapi_stem}_httpmock.rs"),
         &output,

--- a/progenitor-impl/tests/test_specific.rs
+++ b/progenitor-impl/tests/test_specific.rs
@@ -24,7 +24,7 @@ fn generate_formatted(generator: &mut Generator, spec: &OpenAPI) -> String {
         wrap_comments: Some(true),
         ..Default::default()
     };
-    space_out_items(rustfmt_wrapper::rustfmt_config(rustfmt_config, content).unwrap()).unwrap()
+    space_out_items(&rustfmt_wrapper::rustfmt_config(rustfmt_config, content).unwrap()).unwrap()
 }
 
 #[allow(dead_code)]

--- a/progenitor-impl/tests/test_specific.rs
+++ b/progenitor-impl/tests/test_specific.rs
@@ -83,7 +83,7 @@ fn test_renamed_parameters() {
     expectorate::assert_contents(
         format!("tests/output/src/{}.rs", "test_renamed_parameters"),
         &output,
-    )
+    );
 }
 
 #[endpoint {
@@ -114,7 +114,7 @@ fn test_freeform_response() {
     expectorate::assert_contents(
         format!("tests/output/src/{}.rs", "test_freeform_response"),
         &output,
-    )
+    );
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/progenitor-impl/tests/test_specific.rs
+++ b/progenitor-impl/tests/test_specific.rs
@@ -133,6 +133,10 @@ fn forty_two() -> u32 {
     42
 }
 
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default must match the Option field type"
+)]
 fn yes_yes() -> Option<bool> {
     Some(true)
 }

--- a/progenitor-impl/tests/test_specific.rs
+++ b/progenitor-impl/tests/test_specific.rs
@@ -129,7 +129,7 @@ struct BodyWithDefaults {
     something: Option<bool>,
 }
 
-fn forty_two() -> u32 {
+const fn forty_two() -> u32 {
     42
 }
 
@@ -137,7 +137,7 @@ fn forty_two() -> u32 {
     clippy::unnecessary_wraps,
     reason = "serde default must match the Option field type"
 )]
-fn yes_yes() -> Option<bool> {
+const fn yes_yes() -> Option<bool> {
     Some(true)
 }
 

--- a/progenitor-impl/tests/test_specific.rs
+++ b/progenitor-impl/tests/test_specific.rs
@@ -272,6 +272,10 @@ async fn test_stream_pagination() {
 
     // Test the positional client.
     #[allow(dead_code)]
+    #[allow(
+        clippy::items_after_statements,
+        reason = "keeps the included snapshot next to its test phase"
+    )]
     mod gen_client_positional {
         // This is weird: we're now `include!`ing the file we just used to
         // confirm the generated code is what we expect. If changes are made to
@@ -317,6 +321,10 @@ async fn test_stream_pagination() {
     server_ctx.page_pairs.lock().unwrap().clear();
 
     #[allow(dead_code, unused_imports)]
+    #[allow(
+        clippy::items_after_statements,
+        reason = "keeps the included snapshot next to its test phase"
+    )]
     mod gen_client_builder {
         // This is weird: we're now `include!`ing the file we just used to
         // confirm the generated code is what we expect. If changes are made to

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -430,14 +430,13 @@ fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
     let path_str = path.to_string_lossy();
 
     let mut f = open_file(&path, spec_path.span())?;
-    let oapi: OpenAPI = match serde_json::from_reader(f) {
-        Ok(json_value) => json_value,
-        _ => {
-            f = open_file(&path, spec_path.span())?;
-            serde_yaml::from_reader(f).map_err(|e| {
-                syn::Error::new(spec_path.span(), format!("failed to parse {path_str}: {e}"))
-            })?
-        }
+    let oapi: OpenAPI = if let Ok(json_value) = serde_json::from_reader(f) {
+        json_value
+    } else {
+        f = open_file(&path, spec_path.span())?;
+        serde_yaml::from_reader(f).map_err(|e| {
+            syn::Error::new(spec_path.span(), format!("failed to parse {path_str}: {e}"))
+        })?
     };
 
     let mut builder = Generator::new(&settings);

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -325,7 +325,7 @@ fn is_crate(s: &str) -> bool {
 fn open_file(path: PathBuf, span: proc_macro2::Span) -> Result<File, syn::Error> {
     File::open(path.clone()).map_err(|e| {
         let path_str = path.to_string_lossy();
-        syn::Error::new(span, format!("couldn't read file {}: {}", path_str, e))
+        syn::Error::new(span, format!("couldn't read file {path_str}: {e}"))
     })
 }
 
@@ -427,10 +427,7 @@ fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
         _ => {
             f = open_file(path.clone(), spec_path.span())?;
             serde_yaml::from_reader(f).map_err(|e| {
-                syn::Error::new(
-                    spec_path.span(),
-                    format!("failed to parse {}: {}", path_str, e),
-                )
+                syn::Error::new(spec_path.span(), format!("failed to parse {path_str}: {e}"))
             })?
         }
     };

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -379,31 +379,29 @@ fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
         map_type.map(|map_type| settings.with_map_type(map_type.to_token_stream()));
 
         settings.with_unknown_crates(unknown_crates);
-        crates.into_iter().for_each(
-            |(CrateName(crate_name), MacroCrateSpec { original, version })| {
-                if let Some(original_crate) = original {
-                    settings.with_crate(original_crate, version, Some(&crate_name));
-                } else {
-                    settings.with_crate(crate_name, version, None);
-                }
-            },
-        );
+        for (CrateName(crate_name), MacroCrateSpec { original, version }) in crates {
+            if let Some(original_crate) = original {
+                settings.with_crate(original_crate, version, Some(&crate_name));
+            } else {
+                settings.with_crate(crate_name, version, None);
+            }
+        }
 
-        derives.into_iter().for_each(|derive| {
+        for derive in derives {
             settings.with_derive(derive.to_token_stream());
-        });
-        patch.into_iter().for_each(|(type_name, patch)| {
+        }
+        for (type_name, patch) in patch {
             settings.with_patch(type_name.to_token_stream().to_string(), &patch.into());
-        });
-        replace.into_iter().for_each(|(type_name, type_and_impls)| {
+        }
+        for (type_name, type_and_impls) in replace {
             let type_name = type_name.to_token_stream();
             let (replace_name, impls) = type_and_impls.into_inner().into_name_and_impls();
             settings.with_replacement(type_name, replace_name, impls);
-        });
-        convert.into_iter().for_each(|(schema, type_and_impls)| {
+        }
+        for (schema, type_and_impls) in convert {
             let (type_name, impls) = type_and_impls.into_inner().into_name_and_impls();
             settings.with_conversion(schema, type_name, impls);
-        });
+        }
         if let Some(timeout) = timeout {
             settings.with_timeout(timeout);
         }

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -55,7 +55,7 @@ impl syn::parse::Parse for SpecSource {
         if lookahead.peek(LitStr) {
             // spec = "path/to/spec.json"
             let path: LitStr = input.parse()?;
-            Ok(SpecSource {
+            Ok(Self {
                 path,
                 relative_to: RelativeTo::ManifestDir,
             })
@@ -66,7 +66,7 @@ impl syn::parse::Parse for SpecSource {
             let stream: proc_macro2::TokenStream = content.parse()?;
             let helper: SpecSourceStruct =
                 serde_tokenstream::from_tokenstream_spanned(&brace_token.span, &stream)?;
-            Ok(SpecSource {
+            Ok(Self {
                 path: helper.path.into_inner(),
                 relative_to: helper.relative_to,
             })

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -4,7 +4,11 @@
 
 #![deny(missing_docs)]
 
-use std::{collections::HashMap, fs::File, path::PathBuf};
+use std::{
+    collections::HashMap,
+    fs::File,
+    path::{Path, PathBuf},
+};
 
 use openapiv3::OpenAPI;
 use proc_macro::TokenStream;
@@ -322,8 +326,8 @@ fn is_crate(s: &str) -> bool {
     !s.contains(|cc: char| !cc.is_alphanumeric() && cc != '_' && cc != '-')
 }
 
-fn open_file(path: PathBuf, span: proc_macro2::Span) -> Result<File, syn::Error> {
-    File::open(path.clone()).map_err(|e| {
+fn open_file(path: &Path, span: proc_macro2::Span) -> Result<File, syn::Error> {
+    File::open(path).map_err(|e| {
         let path_str = path.to_string_lossy();
         syn::Error::new(span, format!("couldn't read file {path_str}: {e}"))
     })
@@ -421,11 +425,11 @@ fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
     let path = base_dir.join(spec_path.value());
     let path_str = path.to_string_lossy();
 
-    let mut f = open_file(path.clone(), spec_path.span())?;
+    let mut f = open_file(&path, spec_path.span())?;
     let oapi: OpenAPI = match serde_json::from_reader(f) {
         Ok(json_value) => json_value,
         _ => {
-            f = open_file(path.clone(), spec_path.span())?;
+            f = open_file(&path, spec_path.span())?;
             serde_yaml::from_reader(f).map_err(|e| {
                 syn::Error::new(spec_path.span(), format!("failed to parse {path_str}: {e}"))
             })?

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -333,6 +333,10 @@ fn open_file(path: &Path, span: proc_macro2::Span) -> Result<File, syn::Error> {
     })
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "keeps macro expansion stages together"
+)]
 fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
     let (spec_source, settings) = if let Ok(spec) = syn::parse::<LitStr>(item.clone()) {
         let spec_source = SpecSource {

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 Oxide Computer Company
 
-//! Macros for the progenitor OpenAPI client generator.
+//! Macros for the progenitor `OpenAPI` client generator.
 
 #![deny(missing_docs)]
 
@@ -23,13 +23,13 @@ mod token_utils;
 /// Where to resolve the spec path relative to.
 #[derive(Debug, Clone, Copy, Deserialize)]
 enum RelativeTo {
-    /// Resolve relative to CARGO_MANIFEST_DIR (the default).
+    /// Resolve relative to `CARGO_MANIFEST_DIR` (the default).
     ManifestDir,
-    /// Resolve relative to OUT_DIR.
+    /// Resolve relative to `OUT_DIR`.
     OutDir,
 }
 
-/// Specification of where to find the OpenAPI document.
+/// Specification of where to find the `OpenAPI` document.
 #[derive(Debug)]
 struct SpecSource {
     /// The path to the spec file.
@@ -40,7 +40,7 @@ struct SpecSource {
 
 impl syn::parse::Parse for SpecSource {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        /// Helper struct for deserializing the struct form of SpecSource.
+        /// Helper struct for deserializing the struct form of `SpecSource`.
         #[derive(Deserialize)]
         struct SpecSourceStruct {
             path: ParseWrapper<LitStr>,
@@ -72,10 +72,10 @@ impl syn::parse::Parse for SpecSource {
     }
 }
 
-/// Generates a client from the given OpenAPI document
+/// Generates a client from the given `OpenAPI` document
 ///
 /// `generate_api!` can be invoked in two ways. The simple form, takes a path
-/// to the OpenAPI document:
+/// to the `OpenAPI` document:
 /// ```ignore
 /// generate_api!("path/to/spec.json");
 /// ```
@@ -106,7 +106,7 @@ impl syn::parse::Parse for SpecSource {
 /// );
 /// ```
 ///
-/// The `spec` key is required; it is the OpenAPI document (JSON or YAML) from
+/// The `spec` key is required; it is the `OpenAPI` document (JSON or YAML) from
 /// which the client is derived. It can be specified as a simple string path, or
 /// as a struct with `path` and `relative_to` fields. The `relative_to`
 /// field controls where the path is resolved from:

--- a/progenitor/src/lib.rs
+++ b/progenitor/src/lib.rs
@@ -1,11 +1,11 @@
 // Copyright 2024 Oxide Computer Company
 
 //! Progenitor is a Rust crate for generating opinionated clients from API
-//! descriptions specified in the OpenAPI 3.0.x format. It makes use of Rust
+//! descriptions specified in the `OpenAPI` 3.0.x format. It makes use of Rust
 //! futures for async API calls and `Streams` for paginated interfaces.
 //!
 //! It generates a type called `Client` with methods that correspond to the
-//! operations specified in the OpenAPI document.
+//! operations specified in the `OpenAPI` document.
 //!
 //! For details see the [repo
 //! README](https://github.com/oxidecomputer/progenitor/blob/main/README.md)

--- a/progenitor/tests/build_buildomat.rs
+++ b/progenitor/tests/build_buildomat.rs
@@ -4,7 +4,8 @@ mod positional {
     progenitor::generate_api!("../sample_openapi/buildomat.json");
 
     fn _ignore() {
-        let _ = Client::new("").worker_task_upload_chunk("task", vec![0]);
+        let client = Client::new("");
+        let _future = client.worker_task_upload_chunk("task", vec![0]);
     }
 }
 
@@ -16,7 +17,8 @@ mod builder_untagged {
     );
 
     fn _ignore() {
-        let _ = Client::new("")
+        let client = Client::new("");
+        let _future = client
             .worker_task_upload_chunk()
             .task("task")
             .body(vec![0])
@@ -32,7 +34,8 @@ mod builder_tagged {
     );
 
     fn _ignore() {
-        let _ = Client::new("")
+        let client = Client::new("");
+        let _future = client
             .worker_task_upload_chunk()
             .task("task")
             .body(vec![0])

--- a/progenitor/tests/build_keeper.rs
+++ b/progenitor/tests/build_keeper.rs
@@ -4,13 +4,12 @@ mod positional {
     progenitor::generate_api!("../sample_openapi/keeper.json");
 
     fn _ignore() {
-        let _ = Client::new("").enrol(
-            "auth token",
-            &types::EnrolBody {
-                host: "".to_string(),
-                key: "".to_string(),
-            },
-        );
+        let body = types::EnrolBody {
+            host: "".to_string(),
+            key: "".to_string(),
+        };
+        let client = Client::new("");
+        let _future = client.enrol("auth token", &body);
     }
 }
 
@@ -22,7 +21,8 @@ mod builder_untagged {
     );
 
     fn _ignore() {
-        let _ = Client::new("")
+        let client = Client::new("");
+        let _future = client
             .enrol()
             .authorization("")
             .body(types::EnrolBody {
@@ -41,7 +41,8 @@ mod builder_tagged {
     );
 
     fn _ignore() {
-        let _ = Client::new("")
+        let client = Client::new("");
+        let _future = client
             .enrol()
             .authorization("")
             .body(types::EnrolBody {

--- a/progenitor/tests/build_keeper.rs
+++ b/progenitor/tests/build_keeper.rs
@@ -5,8 +5,8 @@ mod positional {
 
     fn _ignore() {
         let body = types::EnrolBody {
-            host: "".to_string(),
-            key: "".to_string(),
+            host: String::new(),
+            key: String::new(),
         };
         let client = Client::new("");
         let _future = client.enrol("auth token", &body);
@@ -26,8 +26,8 @@ mod builder_untagged {
             .enrol()
             .authorization("")
             .body(types::EnrolBody {
-                host: "".to_string(),
-                key: "".to_string(),
+                host: String::new(),
+                key: String::new(),
             })
             .send();
     }
@@ -46,8 +46,8 @@ mod builder_tagged {
             .enrol()
             .authorization("")
             .body(types::EnrolBody {
-                host: "".to_string(),
-                key: "".to_string(),
+                host: String::new(),
+                key: String::new(),
             })
             .send();
     }

--- a/progenitor/tests/build_nexus.rs
+++ b/progenitor/tests/build_nexus.rs
@@ -10,7 +10,7 @@ mod positional {
     use nexus_client::{Client, types};
 
     fn _ignore() {
-        let _future = async {
+        let future = async {
             let client = Client::new("");
             let org = types::Name::try_from("org").unwrap();
             let project = types::Name::try_from("project").unwrap();
@@ -18,6 +18,7 @@ mod positional {
             let stream = client.instance_disk_list_stream(&org, &project, &instance, None, None);
             let _collect_future = stream.collect::<Vec<_>>();
         };
+        std::mem::drop(future);
     }
 }
 

--- a/progenitor/tests/build_nexus.rs
+++ b/progenitor/tests/build_nexus.rs
@@ -10,13 +10,13 @@ mod positional {
     use nexus_client::{Client, types};
 
     fn _ignore() {
-        let _ = async {
+        let _future = async {
             let client = Client::new("");
             let org = types::Name::try_from("org").unwrap();
             let project = types::Name::try_from("project").unwrap();
             let instance = types::Name::try_from("instance").unwrap();
             let stream = client.instance_disk_list_stream(&org, &project, &instance, None, None);
-            let _ = stream.collect::<Vec<_>>();
+            let _collect_future = stream.collect::<Vec<_>>();
         };
     }
 }
@@ -68,7 +68,7 @@ mod builder_untagged {
             .project_name("project")
             .instance_name("instance")
             .stream();
-        let _ = stream.collect::<Vec<_>>();
+        let _future = stream.collect::<Vec<_>>();
     }
 }
 
@@ -95,7 +95,7 @@ mod builder_tagged {
             .project_name("project")
             .instance_name("instance")
             .stream();
-        let _ = stream.collect::<Vec<_>>();
+        let _future = stream.collect::<Vec<_>>();
 
         let _ = client
             .instance_create()

--- a/progenitor/tests/build_propolis.rs
+++ b/progenitor/tests/build_propolis.rs
@@ -11,7 +11,7 @@ mod propolis_client {
 
 use propolis_client::Client;
 
-pub fn _ignore() {
+fn _ignore() {
     let _future = async {
         let _upgraded: reqwest::Upgraded = Client::new("")
             .instance_serial()

--- a/progenitor/tests/build_propolis.rs
+++ b/progenitor/tests/build_propolis.rs
@@ -12,7 +12,7 @@ mod propolis_client {
 use propolis_client::Client;
 
 fn _ignore() {
-    let _future = async {
+    let future = async {
         let _upgraded: reqwest::Upgraded = Client::new("")
             .instance_serial()
             .send()
@@ -20,4 +20,5 @@ fn _ignore() {
             .unwrap()
             .into_inner();
     };
+    std::mem::drop(future);
 }

--- a/progenitor/tests/build_propolis.rs
+++ b/progenitor/tests/build_propolis.rs
@@ -12,7 +12,7 @@ mod propolis_client {
 use propolis_client::Client;
 
 pub fn _ignore() {
-    let _ = async {
+    let _future = async {
         let _upgraded: reqwest::Upgraded = Client::new("")
             .instance_serial()
             .send()

--- a/progenitor/tests/load_yaml.rs
+++ b/progenitor/tests/load_yaml.rs
@@ -2,6 +2,7 @@ mod load_yaml {
     progenitor::generate_api!("../sample_openapi/param-overrides.yaml");
 
     fn _ignore() {
-        let _ = Client::new("").key_get(None, None);
+        let client = Client::new("");
+        let _future = client.key_get(None, None);
     }
 }


### PR DESCRIPTION
## Summary

Rebased onto current `main` and refreshed the Clippy cleanup with nightly across every workspace crate and Cargo target. Each lint is isolated in one commit, and every commit summary ends with the exact lint name.

The broad `clippy::all` boundary remains on emitted modules so newly introduced lints do not break downstream repositories. During this work the suppressed lint groups were force-enabled; generator-owned findings were fixed or documented with narrow, reasoned allowances.

## Commit index

### Compatibility, contracts, and intentional boundaries

- `fcd5e66` [stable/default] fix(clippy): retain the public error representation (clippy::result_large_err)
- `60ada62` [stable/default] chore(lints): narrow the client hook suppression (unused_variables)
- `5421f90` [pedantic] style(clippy): name concrete default types (clippy::default_trait_access)
- `83dbf78` [pedantic] fix(clippy): reject oversized schema bounds (clippy::cast_possible_truncation)
- `76e1638` [pedantic] docs(clippy): describe generation failures (clippy::missing_errors_doc)
- `0f30bee` [pedantic] docs(clippy): describe generation panic invariants (clippy::missing_panics_doc)
- `3a10bda` [pedantic] chore(clippy): document cohesive generation functions (clippy::too_many_lines)
- `a7c7726` [pedantic] chore(clippy): preserve explicit CLI execution modes (clippy::single_match_else)
- `c64a3ba` [pedantic] chore(clippy): document numeric schema conversion (clippy::cast_precision_loss)
- `6839bf3` [pedantic] chore(clippy): retain stream parameter lifetimes (clippy::elidable_lifetime_names)
- `0b817b6` [pedantic] chore(clippy): isolate typify field naming (clippy::struct_field_names)
- `43450f1` [nursery] chore(clippy): preserve path template placeholders (clippy::literal_string_with_formatting_args)
- `56a515e` [stable/default] chore(clippy): retain schema-shaped method parameters (clippy::too_many_arguments)
- `a123c0a` [pedantic] chore(clippy): allow browser-local response futures on wasm (clippy::future_not_send)

### Changes visible in emitted clients

- `432a87b` [pedantic] docs(clippy): mark code terms in documentation (clippy::doc_markdown)
- `6025da7` [pedantic] docs(clippy): mark returned values as significant (clippy::must_use_candidate)
- `0a1284a` [pedantic] style(clippy): combine identical error match arms (clippy::match_same_arms)
- `0d37ea9` [pedantic] style(clippy): remove trailing format argument commas (clippy::unnecessary_trailing_comma)
- `96818d1` [pedantic] refactor(clippy): borrow generation inputs where possible (clippy::needless_pass_by_value)
- `acf5038` [nursery] refactor(clippy): make immutable helpers const (clippy::missing_const_for_fn)
- `3ffc65c` [stable/default] style(clippy): use shorthand for generated client fields (clippy::redundant_field_names)

### Internal and mechanical cleanup

- `1157204` [stable/default] style(clippy): simplify optional requirement check (clippy::unnecessary_map_or)
- `84c0baf` [stable/default] style(clippy): remove redundant format borrows (clippy::useless_borrows_in_formatting)
- `09b23dc` [stable/default] style(clippy): collapse nested response check (clippy::collapsible_if)
- `4a4ab4f` [stable/default] style(clippy): defer panic message formatting (clippy::expect_fun_call)
- `4b52f71` [stable/default] refactor(clippy): implement Display for path templates (clippy::to_string_trait_impl)
- `eee7a19` [stable/default] style(clippy): insert an identifier character directly (clippy::single_char_add_str)
- `e24fe08` [stable/default] style(clippy): derive default generator styles (clippy::derivable_impls)
- `04bf539` [stable/default] style(clippy): format path templates directly (clippy::to_string_in_format_args)
- `3ad50a1` [stable/default] style(clippy): use arrays for fixed test cases (clippy::useless_vec)
- `9d372d8` [stable/default] style(clippy): elide a constant static lifetime (clippy::redundant_static_lifetimes)
- `ea2abdf` [stable/default] style(clippy): avoid an immediately dereferenced borrow (clippy::needless_borrow)
- `353d816` [stable/default] style(clippy): name intentionally unused futures (clippy::let_underscore_future)
- `56b2a56` [pedantic] style(clippy): inline formatting arguments (clippy::uninlined_format_args)
- `622b568` [pedantic] style(clippy): nest shared response patterns (clippy::unnested_or_patterns)
- `a82c500` [pedantic] style(clippy): remove a redundant response else (clippy::redundant_else)
- `cedd56f` [pedantic] style(clippy): remove unnecessary raw string hashes (clippy::needless_raw_string_hashes)
- `7870791` [pedantic] style(clippy): copy static implementation names (clippy::cloned_instead_of_copied)
- `76cd005` [pedantic] style(clippy): clone owned strings explicitly (clippy::implicit_clone)
- `e583db7` [pedantic] style(clippy): write into documentation buffers directly (clippy::format_push_string)
- `d324dcb` [pedantic] refactor(clippy): pass optional components idiomatically (clippy::ref_option)
- `67d745a` [pedantic] style(clippy): terminate unit-returning statements (clippy::semicolon_if_nothing_returned)
- `fdc4cc6` [pedantic] style(clippy): branch directly on inner client state (clippy::match_bool)
- `f2fe5cf` [pedantic] style(clippy): destructure response details with let-else (clippy::manual_let_else)
- `6439ca2` [pedantic] style(clippy): collect builder parameters directly (clippy::unnecessary_join)
- `67722fe` [pedantic] style(clippy): use loops for builder tag generation (clippy::needless_for_each)
- `1375b3e` [pedantic] style(clippy): iterate over container references (clippy::explicit_iter_loop)
- `b4972b7` [pedantic] style(clippy): remove an unnecessary match semicolon (clippy::unnecessary_semicolon)
- `8cd661b` [pedantic] refactor(clippy): return generation values directly (clippy::unnecessary_wraps)
- `123b4b3` [pedantic] refactor(clippy): make stateless helpers associated (clippy::unused_self)
- `610dc0e` [pedantic] style(clippy): elide response helper lifetimes (clippy::needless_lifetimes)
- `042c637` [pedantic] style(clippy): build parameter examples in place (clippy::format_collect)
- `1630cf9` [pedantic] chore(clippy): keep snapshot modules near test phases (clippy::items_after_statements)
- `8cf53b2` [pedantic] docs(clippy): explain the ignored GitHub fixture (clippy::ignore_without_reason)
- `30d37fd` [pedantic] style(clippy): construct empty strings directly (clippy::manual_string_new)
- `630a467` [nursery] style(clippy): split the client hook overview (clippy::too_long_first_doc_paragraph)
- `79d5ce6` [nursery] style(clippy): align visibility with private modules (clippy::redundant_pub_crate)
- `ae50982` [nursery] style(clippy): refer to error variants through Self (clippy::use_self)
- `b92cce6` [nursery] style(clippy): express optional fallbacks directly (clippy::option_if_let_else)
- `3d20ce4` [nursery] style(clippy): test simple enum variants directly (clippy::equatable_if_let)
- `21cfe32` [nursery] style(clippy): check upgrade responses with any (clippy::search_is_some)
- `abeba68` [nursery] style(clippy): move converted array items directly (clippy::redundant_clone)
- `7c223b0` [nursery] refactor(clippy): borrow helper receivers immutably (clippy::needless_pass_by_ref_mut)
- `5658b15` [nursery] style(clippy): construct the single type implementation iterator (clippy::iter_on_single_items)
- `4514647` [nursery] style(clippy): derive the JSON dependency flag from the branch (clippy::useless_let_if_seq)
- `6dc453e` [nursery] style(clippy): compare the wasm base URL directly (clippy::manual_assert_eq)
- `2e100ed` [nursery] style(clippy): consume the inert compile-check future (clippy::no_effect_underscore_binding)

## Deferred typify follow-up

The forced generated-code audit found two pedantic diagnostics originating in typify output:

- `clippy::struct_field_names`: schema-derived names such as `Error::error_code`, including corresponding typify builder fields.
- `clippy::default_trait_access`: typify emits `Default::default()` where Clippy prefers a concrete type.

These are now isolated with exact, reasoned allowances on the generated `types` module while the existing `clippy::all` downstream compatibility boundary remains. They should be addressed in typify later rather than rewritten in progenitor after generation.

## Existing allowance audit

- Narrowed the client hook's `unused` suppression to `unused_variables`.
- Retained `async_fn_in_trait`, generated `unused_imports` / `unused_mut`, fixture `dead_code`, and missing-doc boundaries where they reflect generated or deliberately compile-only code.
- Added exact rationales for schema-shaped argument counts, explicit response ranges, public error size, conditional builder const eligibility, named stream lifetimes, and browser-local wasm futures.

## Validation

Toolchain:

- `rustc 1.99.0-nightly (af3d95584 2026-07-09)`
- `cargo 1.99.0-nightly (59800466c 2026-07-07)`
- `clippy 0.1.98 (af3d95584d 2026-07-09)`

Passed:

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --workspace --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery -D warnings`
- `cargo +nightly clippy -p example-wasm --target wasm32-unknown-unknown --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery -D warnings`
- forced-warning audits for `clippy::all`, `clippy::pedantic`, and `clippy::nursery`
- `cargo +nightly test -p progenitor-impl --test test_output --test test_specific`
- `cargo +nightly test -p cargo-progenitor --test test_cmd`

The monolithic `cargo +nightly test --workspace --all-targets --all-features` run was also attempted. It found the stale CLI help fixture fixed above; its retry was stopped during linking when the local filesystem reached 100%. The package-scoped affected tests pass, and every workspace target compiles under the Clippy commands above.
