### PR TITLE
Accept `--json-body -` to read body from stdin.

### DIFF
--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -473,7 +473,8 @@ impl Generator {
             CliBodyArg::Optional => Some(false),
         })
         .map(|required| {
-            let help = "Path to a file that contains the full json body.";
+            let help =
+                "Path to a file that contains the full json body, or '-' to read from stdin.";
 
             quote! {
                 .arg(
@@ -511,7 +512,13 @@ impl Generator {
                 if let Some(value) =
                     matches.get_one::<std::path::PathBuf>("json-body")
                 {
-                    let body_txt = std::fs::read_to_string(value).with_context(|| format!("failed to read {}", value.display()))?;
+                    let body_txt = if value.as_os_str() == "-" {
+                        let mut buf = String::new();
+                        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf).context("failed to read from stdin")?;
+                        buf
+                    } else {
+                        std::fs::read_to_string(value).with_context(|| format!("failed to read {}", value.display()))?
+                    };
                     let body_value =
                         serde_json::from_str::<#body_type_ident>(
                             &body_txt,

--- a/progenitor-impl/tests/output/src/buildomat_cli.rs
+++ b/progenitor-impl/tests/output/src/buildomat_cli.rs
@@ -83,7 +83,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -148,7 +151,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -186,7 +192,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -234,7 +243,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -273,7 +285,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -309,7 +324,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -466,8 +484,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::TaskSubmit>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -572,8 +597,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::UserCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -642,8 +674,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::WorkerBootstrap>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -702,8 +741,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::WorkerAppendTask>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -762,8 +808,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::WorkerCompleteTask>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -802,8 +855,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::WorkerAddOutput>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);

--- a/progenitor-impl/tests/output/src/cli_gen_cli.rs
+++ b/progenitor-impl/tests/output/src/cli_gen_cli.rs
@@ -30,7 +30,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -57,8 +60,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::UnoBody>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);

--- a/progenitor-impl/tests/output/src/keeper_cli.rs
+++ b/progenitor-impl/tests/output/src/keeper_cli.rs
@@ -48,7 +48,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -113,7 +116,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -138,7 +144,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -177,7 +186,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -217,8 +229,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::EnrolBody>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -299,8 +318,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ReportFinishBody>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -327,8 +353,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ReportOutputBody>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -365,8 +398,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ReportStartBody>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);

--- a/progenitor-impl/tests/output/src/nexus_cli.rs
+++ b/progenitor-impl/tests/output/src/nexus_cli.rs
@@ -357,7 +357,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -387,7 +390,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -429,7 +435,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -481,7 +490,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -517,7 +529,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -616,7 +631,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -668,7 +686,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -721,7 +742,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -793,7 +817,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -859,7 +886,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -970,7 +1000,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -1167,7 +1200,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -1338,7 +1374,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -1471,7 +1510,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -1515,7 +1557,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -1582,7 +1627,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -1697,7 +1745,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -1797,7 +1848,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2038,7 +2092,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2127,7 +2184,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2274,7 +2334,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2352,7 +2415,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2435,7 +2501,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2525,7 +2594,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2609,7 +2681,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2741,7 +2816,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2837,7 +2915,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -2985,7 +3066,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3069,7 +3153,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3168,7 +3255,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3281,7 +3371,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3412,7 +3505,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3621,7 +3717,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3709,7 +3808,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3757,7 +3859,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3812,7 +3917,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3837,7 +3945,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3873,7 +3984,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3892,7 +4006,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -3972,7 +4089,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4095,7 +4215,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4184,7 +4307,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4241,7 +4367,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4328,7 +4457,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4385,7 +4517,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4591,7 +4726,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4753,7 +4891,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4885,7 +5026,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4928,7 +5072,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -4971,7 +5118,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -5176,7 +5326,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -5224,7 +5377,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -5271,7 +5427,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -5339,7 +5498,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -5399,7 +5561,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -5464,7 +5629,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -5550,7 +5718,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -6150,8 +6321,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DeviceAuthRequest>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6180,8 +6358,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DeviceAuthVerify>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6220,8 +6405,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DeviceAccessTokenRequest>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6282,8 +6474,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SpoofLoginBody>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6318,8 +6517,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::UsernamePasswordCredentials>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6458,8 +6664,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::OrganizationCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6522,8 +6735,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::OrganizationUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6602,8 +6822,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::OrganizationRolePolicy>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6678,8 +6905,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ProjectCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6742,8 +6976,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ProjectUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -6853,8 +7094,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DiskCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7056,8 +7304,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ImageCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7218,8 +7473,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7371,8 +7633,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DiskIdentifier>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7415,8 +7684,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DiskIdentifier>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7491,8 +7767,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceMigrate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7604,8 +7887,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::NetworkInterfaceCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7696,8 +7986,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::NetworkInterfaceUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -7957,8 +8254,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ProjectRolePolicy>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8048,8 +8352,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SnapshotCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8198,8 +8509,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::VpcCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8274,8 +8592,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::VpcUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8373,8 +8698,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::VpcFirewallRuleUpdateParams>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8472,8 +8804,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::VpcRouterCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8559,8 +8898,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::VpcRouterUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8703,8 +9049,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::RouterRouteCreateParams>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8799,8 +9152,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::RouterRouteUpdateParams>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -8946,8 +9306,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::VpcSubnetCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -9033,8 +9400,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::VpcSubnetUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -9167,8 +9541,15 @@ impl<T: CliConfig> Cli<T> {
     pub async fn execute_policy_update(&self, matches: &::clap::ArgMatches) -> anyhow::Result<()> {
         let mut request = self.client.policy_update();
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SiloRolePolicy>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -9351,8 +9732,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SshKeyCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -9550,8 +9938,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::CertificateCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -9868,8 +10263,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::GlobalImageCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -9984,8 +10386,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::IpPoolCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10040,8 +10449,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::IpPoolUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10131,8 +10547,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::IpRange>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10163,8 +10586,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::IpRange>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10247,8 +10677,15 @@ impl<T: CliConfig> Cli<T> {
     ) -> anyhow::Result<()> {
         let mut request = self.client.ip_pool_service_range_add();
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::IpRange>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10275,8 +10712,15 @@ impl<T: CliConfig> Cli<T> {
     ) -> anyhow::Result<()> {
         let mut request = self.client.ip_pool_service_range_remove();
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::IpRange>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10367,8 +10811,15 @@ impl<T: CliConfig> Cli<T> {
     ) -> anyhow::Result<()> {
         let mut request = self.client.system_policy_update();
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::FleetRolePolicy>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10502,8 +10953,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SiloCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10622,8 +11080,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::UserCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10686,8 +11151,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::UserPassword>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10750,8 +11222,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SamlIdentityProviderCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -10834,8 +11313,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SiloRolePolicy>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11124,8 +11610,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DiskCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11290,8 +11783,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11449,8 +11949,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DiskPath>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11493,8 +12000,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::DiskPath>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11537,8 +12051,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceMigrate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11783,8 +12304,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::OrganizationCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11847,8 +12375,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::OrganizationUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -11927,8 +12462,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::OrganizationRolePolicy>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -12009,8 +12551,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ProjectCreate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -12080,8 +12629,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ProjectUpdate>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -12172,8 +12728,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::ProjectRolePolicy>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -12330,8 +12893,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::SystemUpdateStart>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);

--- a/progenitor-impl/tests/output/src/propolis_server_cli.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_cli.rs
@@ -42,7 +42,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -83,7 +86,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -105,7 +111,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(true)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -129,7 +138,10 @@ impl<T: CliConfig> Cli<T> {
                     .value_name("JSON-FILE")
                     .required(false)
                     .value_parser(::clap::value_parser!(std::path::PathBuf))
-                    .help("Path to a file that contains the full json body."),
+                    .help(
+                        "Path to a file that contains the full json body, or '-' to read from \
+                         stdin.",
+                    ),
             )
             .arg(
                 ::clap::Arg::new("json-body-template")
@@ -186,8 +198,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceEnsureRequest>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -245,8 +264,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceMigrateStatusRequest>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -290,8 +316,15 @@ impl<T: CliConfig> Cli<T> {
     ) -> anyhow::Result<()> {
         let mut request = self.client.instance_state_put();
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceStateRequested>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);
@@ -322,8 +355,15 @@ impl<T: CliConfig> Cli<T> {
         }
 
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value)
-                .with_context(|| format!("failed to read {}", value.display()))?;
+            let body_txt = if value.as_os_str() == "-" {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+                    .context("failed to read from stdin")?;
+                buf
+            } else {
+                std::fs::read_to_string(value)
+                    .with_context(|| format!("failed to read {}", value.display()))?
+            };
             let body_value = serde_json::from_str::<types::InstanceStateMonitorRequest>(&body_txt)
                 .with_context(|| format!("failed to parse {}", value.display()))?;
             request = request.body(body_value);


### PR DESCRIPTION
So that we can write something like `echo '{...}' | oxide instance create --json-body -`. Analogous to the existing `oxide api --input -`.