### PR TITLE
Stop activating schemars chrono/uuid1 features in progenitor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ regex = "1.12.3"
 regress = "0.11.1"
 reqwest = { version = "0.13.3", default-features = false, features = ["json", "query", "stream"] }
 rustfmt-wrapper = "0.2.1"
-schemars = { version = "0.8.22", features = ["chrono", "uuid1"] }
+schemars = "0.8.22"
 semver = "1.0.28"
 serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0.149"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ generate_api!(
 Note that the macro will be re-evaluated when the `spec` OpenAPI document
 changes (when its mtime is updated).
 
+If you derive `schemars::JsonSchema` on generated types (see `derives = [ ...
+]` in the macro example above), depend on `schemars` yourself and enable the
+matching feature for each formatted type that appears in your spec, so the
+`JsonSchema` impls for those types are available:
+
+```toml
+[dependencies]
+schemars = { version = "0.8", features = ["chrono", "uuid1"] }
+```
+
 ### `build.rs`
 
 Progenitor includes an interface appropriate for use in a

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ Note that the macro will be re-evaluated when the `spec` OpenAPI document
 changes (when its mtime is updated).
 
 If you derive `schemars::JsonSchema` on generated types (see `derives = [ ...
-]` in the macro example above), depend on `schemars` yourself and enable the
-matching feature for each formatted type that appears in your spec, so the
-`JsonSchema` impls for those types are available:
+]` in the macro example above), add a dependency on `schemars` and enable the
+necessary features for each formatted type that appears in your spec. For example:
 
 ```toml
 [dependencies]

--- a/example-macro/Cargo.toml
+++ b/example-macro/Cargo.toml
@@ -9,6 +9,6 @@ rust-version.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 progenitor = { path = "../progenitor" }
 reqwest = { version = "0.13.3", features = ["json", "query", "stream"] }
-schemars = { version = "0.8.22", features = ["uuid1"] }
+schemars = { version = "0.8.22", features = ["chrono", "uuid1"] }
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1.23", features = ["serde", "v4"] }


### PR DESCRIPTION
These impls are only needed when consumers derive `schemars::JsonSchema` on generated types that contain `date` or `uuid` fields -- a consumer concern, not progenitor's. `example-macro` and the `README` now show the pattern.

Resolves #1362 