### PR TITLE
update typify to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -3001,9 +3001,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typify"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+checksum = "8cdc2e612ea322c6e232d46a0b34607c8eb28978fd6060ecfb139f2a50db8d5f"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -3011,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+checksum = "691591f49550c0d371bc441d019c30ce241d4116aee7d68df7a9840d6c70bf8f"
 dependencies = [
  "heck",
  "log",
@@ -3031,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+checksum = "d41aea893c49cf95661389207b8af0c6254ff48b2c3ae1e4f3704777dbdfcf03"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde_yaml = "0.9"
 syn = { version = "2.0.117", features = ["parsing"] }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["rt", "net"] }
-typify = { version = "0.6.2" }
+typify = { version = "0.7.0" }
 url = "2.5.8"
 unicode-ident = "1.0.24"
 uuid = { version = "1.23.2", features = ["serde", "v4"] }

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -399,7 +399,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(:: serde :: Serialize, Clone, Debug, schemars :: JsonSchema)]
+    #[derive(:: serde :: Serialize, Clone, Debug)]
     #[serde(transparent)]
     pub struct BlockSize(i64);
     impl ::std::ops::Deref for BlockSize {
@@ -433,6 +433,26 @@ pub mod types {
         {
             Self::try_from(<i64>::deserialize(deserializer)?)
                 .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
+        }
+    }
+
+    impl ::schemars::JsonSchema for BlockSize {
+        fn schema_name() -> ::std::string::String {
+            "BlockSize".to_string()
+        }
+
+        fn json_schema(gen: &mut ::schemars::gen::SchemaGenerator) -> ::schemars::schema::Schema {
+            let mut schema = <i64 as ::schemars::JsonSchema>::json_schema(gen).into_object();
+            schema.enum_values = ::std::option::Option::Some(
+                [
+                    ::serde_json::from_str("512").unwrap(),
+                    ::serde_json::from_str("2048").unwrap(),
+                    ::serde_json::from_str("4096").unwrap(),
+                ]
+                .into_iter()
+                .collect(),
+            );
+            schema.into()
         }
     }
 


### PR DESCRIPTION
This does bring in an assumption of `schemars` 0.8.0 -- we'll see how much this annoys people.